### PR TITLE
fix: correct Solana parser entry classification and precision

### DIFF
--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -1,51 +1,81 @@
-use bigdecimal::{BigDecimal, FromPrimitive};
+use bigdecimal::BigDecimal;
 use solana_transaction_status::option_serializer::OptionSerializer;
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionStatusMeta,
 };
 use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
+use std::str::FromStr;
 use uuid::Uuid;
 
 pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry>> {
     let mut entries = Vec::new();
 
-    // 1. Deserialize the raw metadata back to the Solana SDK structure
-    // Note: We are using the structure from `solana_transaction_status` which matches what `get_transaction` returns (EncodedConfirmedTransactionWithStatusMeta)
     let sol_tx: EncodedConfirmedTransactionWithStatusMeta =
         serde_json::from_value(tx.raw_metadata.clone())?;
 
-    // Safety check: Ensure meta exists
     let meta = match &sol_tx.transaction.meta {
         Some(m) => m,
         None => return Ok(vec![]),
     };
 
-    // 2. Extract Native SOL Changes
-    // We need to look at account_keys to find the index of `tx.wallet_address`
+    // Skip failed transactions
+    if meta.err.is_some() {
+        return Ok(vec![]);
+    }
+
     let transaction = &sol_tx.transaction.transaction;
     if let solana_transaction_status::EncodedTransaction::Json(ui_tx) = transaction {
         if let solana_transaction_status::UiMessage::Parsed(message) = &ui_tx.message {
-            // Find index of wallet in account_keys
             if let Some(idx) = message
                 .account_keys
                 .iter()
                 .position(|k| k.pubkey == tx.wallet_address)
             {
-                let sol_change = extract_sol_change(meta, idx);
+                let lamport_change = extract_sol_change_lamports(meta, idx);
+                let fee_lamports = meta.fee;
+                let is_fee_payer = idx == 0;
 
-                if sol_change.abs() > 0.000001 {
+                // If this wallet is the fee payer, separate fee from the net transfer
+                if is_fee_payer && fee_lamports > 0 {
+                    // Fee entry (always negative)
+                    let fee_amount = lamports_to_sol(-(fee_lamports as i64));
                     entries.push(LedgerEntry {
                         id: Uuid::new_v4(),
                         transaction_id: tx.id,
                         user_id: tx.user_id,
                         wallet_address: tx.wallet_address.clone(),
                         asset_symbol: "SOL".to_string(),
-                        amount: BigDecimal::from_f64(sol_change).unwrap_or_default(),
-                        entry_type: if sol_change > 0.0 {
-                            EntryType::Transfer
-                        } else {
-                            EntryType::Transfer
-                        }, // Simplified for now
+                        amount: fee_amount,
+                        entry_type: EntryType::Fee,
+                        fiat_value: None,
+                    });
+
+                    // Net transfer amount = total balance change + fee (since fee is included in the balance change)
+                    let transfer_lamports = lamport_change + fee_lamports as i64;
+                    if transfer_lamports != 0 {
+                        let transfer_amount = lamports_to_sol(transfer_lamports);
+                        entries.push(LedgerEntry {
+                            id: Uuid::new_v4(),
+                            transaction_id: tx.id,
+                            user_id: tx.user_id,
+                            wallet_address: tx.wallet_address.clone(),
+                            asset_symbol: "SOL".to_string(),
+                            amount: transfer_amount,
+                            entry_type: EntryType::Transfer,
+                            fiat_value: None,
+                        });
+                    }
+                } else if lamport_change != 0 {
+                    // Non-fee-payer: entire balance change is a transfer
+                    let amount = lamports_to_sol(lamport_change);
+                    entries.push(LedgerEntry {
+                        id: Uuid::new_v4(),
+                        transaction_id: tx.id,
+                        user_id: tx.user_id,
+                        wallet_address: tx.wallet_address.clone(),
+                        asset_symbol: "SOL".to_string(),
+                        amount,
+                        entry_type: EntryType::Transfer,
                         fiat_value: None,
                     });
                 }
@@ -53,10 +83,9 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
         }
     }
 
-    // 3. Extract SPL Token Changes
+    // Extract SPL Token Changes
     if let OptionSerializer::Some(pre_token_balances) = &meta.pre_token_balances {
         if let OptionSerializer::Some(post_token_balances) = &meta.post_token_balances {
-            // We iterate over post_token_balances where owner == wallet_address
             for post in post_token_balances {
                 let owner_match = match &post.owner {
                     OptionSerializer::Some(owner) => owner == &tx.wallet_address,
@@ -66,25 +95,26 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
 
                 if owner_match {
                     let mint = post.mint.clone();
+                    let decimals = post.ui_token_amount.decimals as u32;
 
-                    // Find corresponding pre-balance for this account index
-                    let pre_amount = pre_token_balances
+                    let pre_raw = pre_token_balances
                         .iter()
                         .find(|p| p.account_index == post.account_index)
-                        .map(|p| p.ui_token_amount.ui_amount.unwrap_or(0.0))
-                        .unwrap_or(0.0); // If not found, it's a new token account (0 balance)
+                        .and_then(|p| p.ui_token_amount.amount.parse::<i128>().ok())
+                        .unwrap_or(0);
 
-                    let post_amount = post.ui_token_amount.ui_amount.unwrap_or(0.0);
-                    let delta = post_amount - pre_amount;
+                    let post_raw = post.ui_token_amount.amount.parse::<i128>().unwrap_or(0);
+                    let delta_raw = post_raw - pre_raw;
 
-                    if delta.abs() > 0.000001 {
+                    if delta_raw != 0 {
+                        let amount = token_raw_to_decimal(delta_raw, decimals);
                         entries.push(LedgerEntry {
                             id: Uuid::new_v4(),
                             transaction_id: tx.id,
                             user_id: tx.user_id,
                             wallet_address: tx.wallet_address.clone(),
                             asset_symbol: mint,
-                            amount: BigDecimal::from_f64(delta).unwrap_or_default(),
+                            amount,
                             entry_type: EntryType::Transfer,
                             fiat_value: None,
                         });
@@ -97,8 +127,23 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
     Ok(entries)
 }
 
-fn extract_sol_change(meta: &UiTransactionStatusMeta, wallet_index: usize) -> f64 {
-    let pre = meta.pre_balances.get(wallet_index).copied().unwrap_or(0) as f64;
-    let post = meta.post_balances.get(wallet_index).copied().unwrap_or(0) as f64;
-    (post - pre) / 1_000_000_000.0 // Lamports to SOL
+/// Extract the raw lamport balance change for a given account index.
+fn extract_sol_change_lamports(meta: &UiTransactionStatusMeta, wallet_index: usize) -> i64 {
+    let pre = meta.pre_balances.get(wallet_index).copied().unwrap_or(0) as i64;
+    let post = meta.post_balances.get(wallet_index).copied().unwrap_or(0) as i64;
+    post - pre
+}
+
+/// Convert lamports (i64) to SOL as BigDecimal without floating-point precision loss.
+fn lamports_to_sol(lamports: i64) -> BigDecimal {
+    let raw = BigDecimal::from_str(&format!("{}", lamports)).unwrap();
+    let divisor = BigDecimal::from_str("1000000000").unwrap();
+    raw / divisor
+}
+
+/// Convert raw token amount to BigDecimal using the token's decimals.
+fn token_raw_to_decimal(raw: i128, decimals: u32) -> BigDecimal {
+    let raw_bd = BigDecimal::from_str(&format!("{}", raw)).unwrap();
+    let divisor = BigDecimal::from_str(&format!("1{}", "0".repeat(decimals as usize))).unwrap();
+    raw_bd / divisor
 }

--- a/adapters/tests/solana_parser_test.rs
+++ b/adapters/tests/solana_parser_test.rs
@@ -1,14 +1,37 @@
-use bigdecimal::{BigDecimal, FromPrimitive};
+use bigdecimal::BigDecimal;
 use serde_json::json;
 use spectraplex_adapters::solana_parser;
-use spectraplex_core::models::{Chain, Transaction};
+use spectraplex_core::models::{Chain, EntryType, Transaction};
+use std::str::FromStr;
 use uuid::Uuid;
 
+/// Helper to build a Transaction from JSON metadata.
+fn make_tx(wallet: &str, raw_metadata: serde_json::Value) -> Transaction {
+    Transaction {
+        id: Uuid::new_v4(),
+        user_id: Uuid::new_v4(),
+        wallet_address: wallet.to_string(),
+        timestamp: 1672531200,
+        tx_hash: "sig123".to_string(),
+        chain: Chain::Solana,
+        raw_metadata,
+    }
+}
+
+fn bd(s: &str) -> BigDecimal {
+    BigDecimal::from_str(s).unwrap()
+}
+
+// -----------------------------------------------------------------------
+// 1. Native SOL transfer (sender / fee payer)
+// -----------------------------------------------------------------------
 #[test]
-fn test_parse_solana_native_transfer() {
+fn test_native_sol_send_with_fee_separation() {
     let wallet = "WalletAddress111111111111111111111111111111";
 
-    let full_tx_json = json!({
+    // Sender sends 0.5 SOL. Fee is 5000 lamports.
+    // pre=10 SOL, post=9.499995 SOL  (balance change = -500_005_000 lamports)
+    let meta = json!({
         "slot": 123456,
         "transaction": {
             "signatures": ["sig123"],
@@ -26,7 +49,7 @@ fn test_parse_solana_native_transfer() {
             "status": { "Ok": null },
             "fee": 5000,
             "preBalances": [10_000_000_000u64, 0],
-            "postBalances": [9_500_000_000u64, 500_000_000],
+            "postBalances": [9_499_995_000u64, 500_000_000u64],
             "innerInstructions": [],
             "logMessages": [],
             "preTokenBalances": [],
@@ -36,28 +59,556 @@ fn test_parse_solana_native_transfer() {
         "blockTime": 1672531200
     });
 
-    let tx = Transaction {
-        id: Uuid::new_v4(),
-        user_id: Uuid::new_v4(),
-        wallet_address: wallet.to_string(),
-        timestamp: 1672531200,
-        tx_hash: "sig123".to_string(),
-        chain: Chain::Solana,
-        raw_metadata: full_tx_json,
-    };
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
 
+    assert_eq!(entries.len(), 2, "Should produce fee + transfer entries");
+
+    // First entry should be the fee
+    let fee_entry = &entries[0];
+    assert_eq!(fee_entry.asset_symbol, "SOL");
+    assert!(matches!(fee_entry.entry_type, EntryType::Fee));
+    assert_eq!(fee_entry.amount, bd("-0.000005"));
+
+    // Second entry should be the transfer
+    let transfer_entry = &entries[1];
+    assert_eq!(transfer_entry.asset_symbol, "SOL");
+    assert!(matches!(transfer_entry.entry_type, EntryType::Transfer));
+    assert_eq!(transfer_entry.amount, bd("-0.5"));
+}
+
+// -----------------------------------------------------------------------
+// 2. Native SOL receive (non-fee-payer)
+// -----------------------------------------------------------------------
+#[test]
+fn test_native_sol_receive() {
+    let receiver = "Receiver11111111111111111111111111111111";
+
+    let meta = json!({
+        "slot": 123456,
+        "transaction": {
+            "signatures": ["sig456"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": "SenderXX111111111111111111111111111111111", "signer": true, "writable": true },
+                    { "pubkey": receiver, "signer": false, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [10_000_000_000u64, 1_000_000_000u64],
+            "postBalances": [8_999_995_000u64, 2_000_000_000u64],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(receiver, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    assert_eq!(entries.len(), 1, "Receiver gets one transfer entry, no fee");
+    let entry = &entries[0];
+    assert_eq!(entry.asset_symbol, "SOL");
+    assert!(matches!(entry.entry_type, EntryType::Transfer));
+    assert_eq!(entry.amount, bd("1"));
+}
+
+// -----------------------------------------------------------------------
+// 3. Fee-only transaction (e.g. a failed vote or no-op where only fee is deducted)
+// -----------------------------------------------------------------------
+#[test]
+fn test_fee_only_transaction() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+
+    // Balance changes by exactly -5000 lamports (the fee), no transfer component.
+    let meta = json!({
+        "slot": 200000,
+        "transaction": {
+            "signatures": ["sigFeeOnly"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": wallet, "signer": true, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [1_000_000_000u64],
+            "postBalances": [999_995_000u64],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    // Only a fee entry, no transfer (transfer_lamports = -5000 + 5000 = 0)
+    assert_eq!(entries.len(), 1, "Fee-only tx should produce one Fee entry");
+    assert!(matches!(entries[0].entry_type, EntryType::Fee));
+    assert_eq!(entries[0].amount, bd("-0.000005"));
+}
+
+// -----------------------------------------------------------------------
+// 4. Failed transaction (should be skipped)
+// -----------------------------------------------------------------------
+#[test]
+fn test_failed_transaction_skipped() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+
+    let meta = json!({
+        "slot": 300000,
+        "transaction": {
+            "signatures": ["sigFailed"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": wallet, "signer": true, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": { "InstructionError": [0, "InvalidAccountData"] },
+            "status": { "Err": { "InstructionError": [0, "InvalidAccountData"] } },
+            "fee": 5000,
+            "preBalances": [1_000_000_000u64],
+            "postBalances": [999_995_000u64],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
     let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
 
     assert_eq!(
         entries.len(),
-        1,
-        "Should produce 1 entry for native SOL change"
+        0,
+        "Failed transactions should produce no entries"
     );
+}
 
-    let entry = &entries[0];
-    assert_eq!(entry.wallet_address, wallet);
-    assert_eq!(entry.asset_symbol, "SOL");
+// -----------------------------------------------------------------------
+// 5. SPL Token transfer
+// -----------------------------------------------------------------------
+#[test]
+fn test_spl_token_transfer() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+    let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"; // USDC
 
-    let expected_amount = BigDecimal::from_f64(-0.5).unwrap();
-    assert_eq!(entry.amount, expected_amount);
+    let meta = json!({
+        "slot": 400000,
+        "transaction": {
+            "signatures": ["sigSPL"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": "OtherWallet1111111111111111111111111111111", "signer": true, "writable": true },
+                    { "pubkey": wallet, "signer": false, "writable": true },
+                    { "pubkey": "TokenProgram111111111111111111111111111111", "signer": false, "writable": false }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [1_000_000_000u64, 0, 0],
+            "postBalances": [999_995_000u64, 0, 0],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [
+                {
+                    "accountIndex": 1,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 100.0,
+                        "decimals": 6,
+                        "amount": "100000000",
+                        "uiAmountString": "100.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "postTokenBalances": [
+                {
+                    "accountIndex": 1,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 150.5,
+                        "decimals": 6,
+                        "amount": "150500000",
+                        "uiAmountString": "150.5"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    // Wallet is not fee payer (index 1), no SOL change for wallet, but has SPL token change
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+    assert_eq!(token_entries.len(), 1, "Should have one SPL token entry");
+    assert_eq!(token_entries[0].amount, bd("50.5"));
+    assert!(matches!(token_entries[0].entry_type, EntryType::Transfer));
+}
+
+// -----------------------------------------------------------------------
+// 6. SPL Token send (negative delta)
+// -----------------------------------------------------------------------
+#[test]
+fn test_spl_token_send() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+    let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    let meta = json!({
+        "slot": 400001,
+        "transaction": {
+            "signatures": ["sigSPLsend"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": wallet, "signer": true, "writable": true },
+                    { "pubkey": "Receiver11111111111111111111111111111111", "signer": false, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [1_000_000_000u64, 0],
+            "postBalances": [999_995_000u64, 0],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [
+                {
+                    "accountIndex": 0,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 200.0,
+                        "decimals": 6,
+                        "amount": "200000000",
+                        "uiAmountString": "200.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "postTokenBalances": [
+                {
+                    "accountIndex": 0,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 125.0,
+                        "decimals": 6,
+                        "amount": "125000000",
+                        "uiAmountString": "125.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+    assert_eq!(token_entries.len(), 1);
+    assert_eq!(token_entries[0].amount, bd("-75"));
+}
+
+// -----------------------------------------------------------------------
+// 7. Multi-instruction tx: SOL + SPL changes together
+// -----------------------------------------------------------------------
+#[test]
+fn test_multi_asset_transaction() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+    let mint = "So11111111111111111111111111111111111111112"; // wrapped SOL mint (example)
+
+    let meta = json!({
+        "slot": 500000,
+        "transaction": {
+            "signatures": ["sigMulti"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": wallet, "signer": true, "writable": true },
+                    { "pubkey": "DEX111111111111111111111111111111111111111", "signer": false, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 10000,
+            "preBalances": [5_000_000_000u64, 0],
+            "postBalances": [4_899_990_000u64, 0],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [
+                {
+                    "accountIndex": 0,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 0.0,
+                        "decimals": 9,
+                        "amount": "0",
+                        "uiAmountString": "0.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "postTokenBalances": [
+                {
+                    "accountIndex": 0,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 1.0,
+                        "decimals": 9,
+                        "amount": "1000000000",
+                        "uiAmountString": "1.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    // Should have: 1 Fee entry, 1 SOL Transfer entry, 1 SPL token entry
+    let fee_entries: Vec<_> = entries
+        .iter()
+        .filter(|e| matches!(e.entry_type, EntryType::Fee))
+        .collect();
+    let sol_transfers: Vec<_> = entries
+        .iter()
+        .filter(|e| e.asset_symbol == "SOL" && matches!(e.entry_type, EntryType::Transfer))
+        .collect();
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+
+    assert_eq!(fee_entries.len(), 1, "One fee entry");
+    assert_eq!(fee_entries[0].amount, bd("-0.00001"));
+
+    // SOL transfer: total change = 4_899_990_000 - 5_000_000_000 = -100_010_000
+    // Fee = 10_000 lamports. Transfer = -100_010_000 + 10_000 = -100_000_000 = -0.1 SOL
+    assert_eq!(sol_transfers.len(), 1, "One SOL transfer entry");
+    assert_eq!(sol_transfers[0].amount, bd("-0.1"));
+
+    assert_eq!(token_entries.len(), 1, "One SPL token entry");
+    assert_eq!(token_entries[0].amount, bd("1"));
+}
+
+// -----------------------------------------------------------------------
+// 8. Zero balance change (wallet not involved)
+// -----------------------------------------------------------------------
+#[test]
+fn test_zero_balance_change_no_entries() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+
+    let meta = json!({
+        "slot": 600000,
+        "transaction": {
+            "signatures": ["sigZero"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": "OtherSigner1111111111111111111111111111111", "signer": true, "writable": true },
+                    { "pubkey": wallet, "signer": false, "writable": false }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [1_000_000_000u64, 2_000_000_000u64],
+            "postBalances": [999_995_000u64, 2_000_000_000u64],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    assert_eq!(
+        entries.len(),
+        0,
+        "No entries when wallet balance doesn't change"
+    );
+}
+
+// -----------------------------------------------------------------------
+// 9. No meta (should return empty)
+// -----------------------------------------------------------------------
+#[test]
+fn test_no_meta_returns_empty() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+
+    let meta = json!({
+        "slot": 700000,
+        "transaction": {
+            "signatures": ["sigNoMeta"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": wallet, "signer": true, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": null,
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+    assert_eq!(entries.len(), 0, "No meta should produce no entries");
+}
+
+// -----------------------------------------------------------------------
+// 10. Precision: verify no floating-point drift
+// -----------------------------------------------------------------------
+#[test]
+fn test_precision_no_floating_point_drift() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+
+    // Use values that are problematic in f64: 0.1 + 0.2 != 0.3
+    // 123456789 lamports = 0.123456789 SOL (exact in base-10)
+    let meta = json!({
+        "slot": 800000,
+        "transaction": {
+            "signatures": ["sigPrecision"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": "OtherSigner1111111111111111111111111111111", "signer": true, "writable": true },
+                    { "pubkey": wallet, "signer": false, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [10_000_000_000u64, 1_000_000_000u64],
+            "postBalances": [9_876_538_211u64, 1_123_456_789u64],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    assert_eq!(entries.len(), 1);
+    // 1_123_456_789 - 1_000_000_000 = 123_456_789 lamports = 0.123456789 SOL
+    assert_eq!(entries[0].amount, bd("0.123456789"));
+}
+
+// -----------------------------------------------------------------------
+// 11. New token account (no pre-balance entry for the account)
+// -----------------------------------------------------------------------
+#[test]
+fn test_spl_new_token_account() {
+    let wallet = "WalletAddress111111111111111111111111111111";
+    let mint = "TokenMint111111111111111111111111111111111";
+
+    let meta = json!({
+        "slot": 900000,
+        "transaction": {
+            "signatures": ["sigNewAccount"],
+            "message": {
+                "accountKeys": [
+                    { "pubkey": "OtherSigner1111111111111111111111111111111", "signer": true, "writable": true },
+                    { "pubkey": wallet, "signer": false, "writable": true }
+                ],
+                "instructions": [],
+                "recentBlockhash": "11111111111111111111111111111111"
+            }
+        },
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000,
+            "preBalances": [10_000_000_000u64, 0],
+            "postBalances": [9_999_995_000u64, 0],
+            "innerInstructions": [],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [
+                {
+                    "accountIndex": 1,
+                    "mint": mint,
+                    "uiTokenAmount": {
+                        "uiAmount": 1000.0,
+                        "decimals": 9,
+                        "amount": "1000000000000",
+                        "uiAmountString": "1000.0"
+                    },
+                    "owner": wallet
+                }
+            ],
+            "rewards": []
+        },
+        "blockTime": 1672531200
+    });
+
+    let tx = make_tx(wallet, meta);
+    let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
+
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+    assert_eq!(
+        token_entries.len(),
+        1,
+        "New token account should produce one entry"
+    );
+    assert_eq!(token_entries[0].amount, bd("1000"));
 }


### PR DESCRIPTION
## Summary
- **Fix entry type classification bug**: Fee payer (index 0) now gets a separate `Fee` entry for the transaction fee, with the remaining balance change as a `Transfer` entry. Previously both if/else branches returned `EntryType::Transfer`.
- **Fix precision loss**: Replaced `BigDecimal::from_f64()` with lamport-based integer arithmetic using `BigDecimal::from_str()`. SPL token amounts now use the raw `amount` string field instead of `ui_amount` (f64).
- **Skip failed transactions**: Parser now checks `meta.err` and returns empty entries for failed transactions.
- **11 comprehensive tests**: Native SOL send/receive, fee-only, failed tx, SPL token send/receive, multi-asset, zero balance change, null meta, precision verification, new token account.

## Test plan
- [x] `cargo test --workspace` passes (11/11 parser tests green)
- [x] Verified precision with lamport values that cause f64 drift (e.g., 0.123456789 SOL)
- [x] Verified fee separation: fee-only tx produces 1 Fee entry, send tx produces Fee + Transfer
- [x] Verified failed transactions produce 0 entries
- [x] Verified SPL token amounts use raw integer arithmetic (no f64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)