### PR TITLE
style: fix cargo fmt formatting across workspace

### DIFF
--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod repo;
 pub mod solana;
 pub mod solana_grpc;
 pub mod solana_parser;
-pub mod repo;

--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -1,4 +1,4 @@
-use spectraplex_core::models::{Transaction, LedgerEntry};
+use spectraplex_core::models::{LedgerEntry, Transaction};
 use sqlx::{postgres::PgPool, Row};
 
 pub struct Repository {
@@ -48,7 +48,7 @@ impl Repository {
                 spectraplex_core::models::EntryType::Staking => "staking",
                 spectraplex_core::models::EntryType::Income => "income",
             };
-            
+
             sqlx::query(
                 r#"
                 INSERT INTO ledger_entries (id, transaction_id, user_id, wallet_address, asset_symbol, amount, entry_type, fiat_value)
@@ -69,15 +69,18 @@ impl Repository {
         }
         Ok(())
     }
-    
-    pub async fn get_transactions_by_wallet(&self, wallet: &str) -> anyhow::Result<Vec<Transaction>> {
+
+    pub async fn get_transactions_by_wallet(
+        &self,
+        wallet: &str,
+    ) -> anyhow::Result<Vec<Transaction>> {
         let rows = sqlx::query(
             r#"
             SELECT id, user_id, wallet_address, timestamp, tx_hash, chain::text, raw_metadata
             FROM transactions
             WHERE wallet_address = $1
             ORDER BY timestamp ASC
-            "#
+            "#,
         )
         .bind(wallet)
         .fetch_all(&self.pool)
@@ -92,7 +95,7 @@ impl Repository {
                 "ethereum" => spectraplex_core::models::Chain::Ethereum,
                 _ => return Err(anyhow::anyhow!("Unknown chain: {}", chain_str)),
             };
-            
+
             txs.push(Transaction {
                 id: row.try_get("id")?,
                 user_id: row.try_get("user_id")?,
@@ -106,7 +109,10 @@ impl Repository {
         Ok(txs)
     }
 
-    pub async fn get_ledger_entries_by_wallet(&self, wallet: &str) -> anyhow::Result<Vec<LedgerEntry>> {
+    pub async fn get_ledger_entries_by_wallet(
+        &self,
+        wallet: &str,
+    ) -> anyhow::Result<Vec<LedgerEntry>> {
         // Optimized: Query directly on indexed wallet_address column
         let rows = sqlx::query(
             r#"
@@ -116,7 +122,7 @@ impl Repository {
             FROM ledger_entries
             WHERE wallet_address = $1
             ORDER BY created_at ASC
-            "#
+            "#,
         )
         .bind(wallet)
         .fetch_all(&self.pool)

--- a/adapters/src/solana.rs
+++ b/adapters/src/solana.rs
@@ -1,10 +1,10 @@
-use spectraplex_core::models::{Chain, Transaction, ChainIngestor};
+use serde_json::json;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use solana_transaction_status::UiTransactionEncoding;
+use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
 use std::str::FromStr;
 use uuid::Uuid;
-use serde_json::json;
 
 pub struct SolanaAdapter {
     client: RpcClient,
@@ -24,16 +24,19 @@ impl ChainIngestor for SolanaAdapter {
         let pubkey = Pubkey::from_str(wallet)?;
         // Fetch signatures (transaction history list)
         let signatures = self.client.get_signatures_for_address(&pubkey)?;
-        
+
         let mut transactions = Vec::new();
 
         for sig_info in signatures.iter().take(limit) {
             let sig = Signature::from_str(&sig_info.signature)?;
-            
+
             // Fetch full transaction details in JSON format
-            // We use UiTransactionEncoding::JsonParsed to get as much detail as possible, 
+            // We use UiTransactionEncoding::JsonParsed to get as much detail as possible,
             // or Json for raw structure. "Json" is often safer for raw storage.
-            match self.client.get_transaction(&sig, UiTransactionEncoding::Json) {
+            match self
+                .client
+                .get_transaction(&sig, UiTransactionEncoding::Json)
+            {
                 Ok(tx) => {
                     // Serialize the entire response to a JSON Value
                     let raw_metadata = serde_json::to_value(&tx).unwrap_or(json!({}));

--- a/adapters/src/solana_grpc.rs
+++ b/adapters/src/solana_grpc.rs
@@ -1,4 +1,4 @@
-use spectraplex_core::models::{Transaction, ChainIngestor};
+use spectraplex_core::models::{ChainIngestor, Transaction};
 
 pub struct SolanaGrpcAdapter {
     _endpoint: String,
@@ -16,7 +16,11 @@ impl SolanaGrpcAdapter {
 
 #[async_trait::async_trait]
 impl ChainIngestor for SolanaGrpcAdapter {
-    async fn fetch_history(&self, _wallet: &str, _limit: usize) -> anyhow::Result<Vec<Transaction>> {
+    async fn fetch_history(
+        &self,
+        _wallet: &str,
+        _limit: usize,
+    ) -> anyhow::Result<Vec<Transaction>> {
         println!("gRPC Adapter: connect method needs verification. Returning empty.");
         // Stub to allow compilation.
         Ok(vec![])

--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -1,16 +1,19 @@
-use spectraplex_core::models::{Transaction, LedgerEntry, EntryType};
-use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionStatusMeta};
-use solana_transaction_status::option_serializer::OptionSerializer;
-use uuid::Uuid;
 use bigdecimal::{BigDecimal, FromPrimitive};
+use solana_transaction_status::option_serializer::OptionSerializer;
+use solana_transaction_status::{
+    EncodedConfirmedTransactionWithStatusMeta, UiTransactionStatusMeta,
+};
+use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
+use uuid::Uuid;
 
 pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry>> {
     let mut entries = Vec::new();
-    
+
     // 1. Deserialize the raw metadata back to the Solana SDK structure
     // Note: We are using the structure from `solana_transaction_status` which matches what `get_transaction` returns (EncodedConfirmedTransactionWithStatusMeta)
-    let sol_tx: EncodedConfirmedTransactionWithStatusMeta = serde_json::from_value(tx.raw_metadata.clone())?;
-    
+    let sol_tx: EncodedConfirmedTransactionWithStatusMeta =
+        serde_json::from_value(tx.raw_metadata.clone())?;
+
     // Safety check: Ensure meta exists
     let meta = match &sol_tx.transaction.meta {
         Some(m) => m,
@@ -21,31 +24,38 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
     // We need to look at account_keys to find the index of `tx.wallet_address`
     let transaction = &sol_tx.transaction.transaction;
     if let solana_transaction_status::EncodedTransaction::Json(ui_tx) = transaction {
-            if let solana_transaction_status::UiMessage::Parsed(message) = &ui_tx.message {
-                // Find index of wallet in account_keys
-                if let Some(idx) = message.account_keys.iter().position(|k| k.pubkey == tx.wallet_address) {
-                    let sol_change = extract_sol_change(meta, idx);
-                    
-                    if sol_change.abs() > 0.000001 {
-                        entries.push(LedgerEntry {
-                            id: Uuid::new_v4(),
-                            transaction_id: tx.id,
-                            user_id: tx.user_id,
-                            wallet_address: tx.wallet_address.clone(),
-                            asset_symbol: "SOL".to_string(),
-                            amount: BigDecimal::from_f64(sol_change).unwrap_or_default(),
-                            entry_type: if sol_change > 0.0 { EntryType::Transfer } else { EntryType::Transfer }, // Simplified for now
-                            fiat_value: None,
-                        });
-                    }
+        if let solana_transaction_status::UiMessage::Parsed(message) = &ui_tx.message {
+            // Find index of wallet in account_keys
+            if let Some(idx) = message
+                .account_keys
+                .iter()
+                .position(|k| k.pubkey == tx.wallet_address)
+            {
+                let sol_change = extract_sol_change(meta, idx);
+
+                if sol_change.abs() > 0.000001 {
+                    entries.push(LedgerEntry {
+                        id: Uuid::new_v4(),
+                        transaction_id: tx.id,
+                        user_id: tx.user_id,
+                        wallet_address: tx.wallet_address.clone(),
+                        asset_symbol: "SOL".to_string(),
+                        amount: BigDecimal::from_f64(sol_change).unwrap_or_default(),
+                        entry_type: if sol_change > 0.0 {
+                            EntryType::Transfer
+                        } else {
+                            EntryType::Transfer
+                        }, // Simplified for now
+                        fiat_value: None,
+                    });
                 }
             }
+        }
     }
 
     // 3. Extract SPL Token Changes
     if let OptionSerializer::Some(pre_token_balances) = &meta.pre_token_balances {
         if let OptionSerializer::Some(post_token_balances) = &meta.post_token_balances {
-            
             // We iterate over post_token_balances where owner == wallet_address
             for post in post_token_balances {
                 let owner_match = match &post.owner {
@@ -56,27 +66,28 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
 
                 if owner_match {
                     let mint = post.mint.clone();
-                    
+
                     // Find corresponding pre-balance for this account index
-                    let pre_amount = pre_token_balances.iter()
-                       .find(|p| p.account_index == post.account_index)
-                       .map(|p| p.ui_token_amount.ui_amount.unwrap_or(0.0))
-                       .unwrap_or(0.0); // If not found, it's a new token account (0 balance)
+                    let pre_amount = pre_token_balances
+                        .iter()
+                        .find(|p| p.account_index == post.account_index)
+                        .map(|p| p.ui_token_amount.ui_amount.unwrap_or(0.0))
+                        .unwrap_or(0.0); // If not found, it's a new token account (0 balance)
 
                     let post_amount = post.ui_token_amount.ui_amount.unwrap_or(0.0);
                     let delta = post_amount - pre_amount;
 
                     if delta.abs() > 0.000001 {
-                         entries.push(LedgerEntry {
-                             id: Uuid::new_v4(),
-                             transaction_id: tx.id,
-                             user_id: tx.user_id,
-                             wallet_address: tx.wallet_address.clone(),
-                             asset_symbol: mint,
-                             amount: BigDecimal::from_f64(delta).unwrap_or_default(),
-                             entry_type: EntryType::Transfer,
-                             fiat_value: None,
-                         });
+                        entries.push(LedgerEntry {
+                            id: Uuid::new_v4(),
+                            transaction_id: tx.id,
+                            user_id: tx.user_id,
+                            wallet_address: tx.wallet_address.clone(),
+                            asset_symbol: mint,
+                            amount: BigDecimal::from_f64(delta).unwrap_or_default(),
+                            entry_type: EntryType::Transfer,
+                            fiat_value: None,
+                        });
                     }
                 }
             }

--- a/adapters/tests/solana_parser_test.rs
+++ b/adapters/tests/solana_parser_test.rs
@@ -1,13 +1,13 @@
+use bigdecimal::{BigDecimal, FromPrimitive};
+use serde_json::json;
 use spectraplex_adapters::solana_parser;
 use spectraplex_core::models::{Chain, Transaction};
-use serde_json::json;
 use uuid::Uuid;
-use bigdecimal::{BigDecimal, FromPrimitive};
 
 #[test]
 fn test_parse_solana_native_transfer() {
     let wallet = "WalletAddress111111111111111111111111111111";
-    
+
     let full_tx_json = json!({
         "slot": 123456,
         "transaction": {
@@ -47,13 +47,17 @@ fn test_parse_solana_native_transfer() {
     };
 
     let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
-    
-    assert_eq!(entries.len(), 1, "Should produce 1 entry for native SOL change");
-    
+
+    assert_eq!(
+        entries.len(),
+        1,
+        "Should produce 1 entry for native SOL change"
+    );
+
     let entry = &entries[0];
     assert_eq!(entry.wallet_address, wallet);
     assert_eq!(entry.asset_symbol, "SOL");
-    
+
     let expected_amount = BigDecimal::from_f64(-0.5).unwrap();
     assert_eq!(entry.amount, expected_amount);
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -70,13 +70,16 @@ async fn trigger_ingest(
 ) -> Result<Json<String>, StatusCode> {
     // In a real system, this should spawn a background task or push to a queue (e.g. Redis/bullmq)
     // For prototype, we'll just run it inline (blocking the request until done - not ideal for prod but ok for demo)
-    
+
     let adapter = SolanaAdapter::new(&payload.rpc_url);
     // Hardcoded limit for API safety
-    let events = adapter.fetch_history(&payload.wallet, 50).await.map_err(|e| {
-        eprintln!("Ingest Error: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let events = adapter
+        .fetch_history(&payload.wallet, 50)
+        .await
+        .map_err(|e| {
+            eprintln!("Ingest Error: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let repo = Repository::new(state.pool.clone());
     repo.save_transactions(&events).await.map_err(|e| {
@@ -92,24 +95,32 @@ async fn trigger_normalize(
     Json(payload): Json<NormalizeRequest>,
 ) -> Result<Json<String>, StatusCode> {
     let repo = Repository::new(state.pool.clone());
-    
-    let txs = repo.get_transactions_by_wallet(&payload.wallet).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
+    let txs = repo
+        .get_transactions_by_wallet(&payload.wallet)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
     let mut all_entries = Vec::new();
 
     for tx in txs {
         let entries = match tx.chain {
             spectraplex_core::models::Chain::Solana => {
                 solana_parser::parse_solana_transaction(&tx).unwrap_or_default()
-            },
-            _ => vec![]
+            }
+            _ => vec![],
         };
         all_entries.extend(entries);
     }
 
-    repo.save_ledger_entries(&all_entries).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    repo.save_ledger_entries(&all_entries)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(Json(format!("Normalized {} ledger entries", all_entries.len())))
+    Ok(Json(format!(
+        "Normalized {} ledger entries",
+        all_entries.len()
+    )))
 }
 
 async fn get_transactions(
@@ -117,7 +128,10 @@ async fn get_transactions(
     Path(wallet): Path<String>,
 ) -> Result<Json<Vec<Transaction>>, StatusCode> {
     let repo = Repository::new(state.pool.clone());
-    let txs = repo.get_transactions_by_wallet(&wallet).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let txs = repo
+        .get_transactions_by_wallet(&wallet)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(txs))
 }
 
@@ -126,6 +140,9 @@ async fn get_ledger(
     Path(wallet): Path<String>,
 ) -> Result<Json<Vec<LedgerEntry>>, StatusCode> {
     let repo = Repository::new(state.pool.clone());
-    let entries = repo.get_ledger_entries_by_wallet(&wallet).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    Ok(Json(entries)) 
+    let entries = repo
+        .get_ledger_entries_by_wallet(&wallet)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(entries))
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
-use spectraplex_adapters::{solana::SolanaAdapter, solana_grpc::SolanaGrpcAdapter, solana_parser, repo::Repository};
+use spectraplex_adapters::{
+    repo::Repository, solana::SolanaAdapter, solana_grpc::SolanaGrpcAdapter, solana_parser,
+};
 use spectraplex_core::models::{ChainIngestor, Transaction};
-use std::path::PathBuf;
-use std::fs::File;
-use std::io::{Write, BufReader, BufRead};
 use sqlx::postgres::PgPoolOptions;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(about = "Spectraplex CLI", long_about = None)]
@@ -20,7 +22,7 @@ struct Cli {
 enum Commands {
     /// Initialize the database schema
     InitDb,
-    
+
     /// Ingest raw data from blockchain to Bronze layer (JSONL)
     Ingest {
         #[arg(short, long)]
@@ -31,7 +33,7 @@ enum Commands {
 
         #[arg(short, long, default_value = "bronze_transactions.jsonl")]
         output: PathBuf,
-        
+
         #[arg(long)]
         rpc: Option<String>,
 
@@ -40,7 +42,7 @@ enum Commands {
 
         #[arg(long)]
         x_token: Option<String>,
-        
+
         #[arg(long, default_value_t = 10)]
         limit: usize,
     },
@@ -51,7 +53,7 @@ enum Commands {
 
         #[arg(short, long, default_value = "silver_ledger.jsonl")]
         output: PathBuf,
-    }
+    },
 }
 
 #[tokio::main]
@@ -76,7 +78,15 @@ async fn main() -> anyhow::Result<()> {
                 println!("Error: --db-url is required for InitDb");
             }
         }
-        Commands::Ingest { chain, wallet, output, rpc, grpc_url, x_token, limit } => {
+        Commands::Ingest {
+            chain,
+            wallet,
+            output,
+            rpc,
+            grpc_url,
+            x_token,
+            limit,
+        } => {
             println!("Starting ingestion for {} on chain {}", wallet, chain);
 
             let events = match chain.as_str() {
@@ -114,7 +124,6 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Normalize { input, output } => {
             let transactions = if let Some(p) = pool.clone() {
-                
                 let input_str = input.to_string_lossy();
                 if input_str.starts_with("db:") {
                     let wallet = input_str.strip_prefix("db:").unwrap();
@@ -153,9 +162,12 @@ async fn main() -> anyhow::Result<()> {
                 let entries = match tx.chain {
                     spectraplex_core::models::Chain::Solana => {
                         solana_parser::parse_solana_transaction(&tx)?
-                    },
+                    }
                     _ => {
-                        println!("Skipping unsupported chain for normalization: {:?}", tx.chain);
+                        println!(
+                            "Skipping unsupported chain for normalization: {:?}",
+                            tx.chain
+                        );
                         vec![]
                     }
                 };

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -1,6 +1,6 @@
+use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use bigdecimal::BigDecimal;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Chain {
@@ -38,7 +38,7 @@ pub struct LedgerEntry {
     pub user_id: Uuid,
     pub wallet_address: String,
     pub asset_symbol: String,
-    pub amount: BigDecimal, 
+    pub amount: BigDecimal,
     pub entry_type: EntryType,
     pub fiat_value: Option<BigDecimal>,
 }


### PR DESCRIPTION
## Summary
- Run `cargo fmt --all` to fix pre-existing formatting violations across the entire workspace
- Affects 9 files in adapters, api, cli, and core crates
- **HIGH PRIORITY**: This unblocks all other PRs from passing the CI formatting check

## Files changed
- `adapters/src/lib.rs` — import ordering
- `adapters/src/repo.rs` — trailing whitespace, line wrapping, import ordering
- `adapters/src/solana.rs` — import ordering, trailing whitespace, line wrapping
- `adapters/src/solana_grpc.rs` — formatting fixes
- `adapters/src/solana_parser.rs` — formatting fixes
- `adapters/tests/solana_parser_test.rs` — formatting fixes
- `api/src/main.rs` — line wrapping, trailing whitespace
- `cli/src/main.rs` — import grouping, match arm formatting, line wrapping
- `core/src/models.rs` — import ordering, trailing whitespace, trailing newline

## Test plan
- [ ] `cargo fmt --all --check` passes (this is what the PR fixes)
- [ ] No functional changes — purely whitespace/formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)