### PR TITLE
Add infrastructure: Docker, config, logging, checkpointing, async jobs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target
+.git
+*.md
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1319,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2675,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,7 +2857,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.9",
 ]
 
 [[package]]
@@ -2815,6 +2867,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3504,6 +3569,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5468,6 +5542,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -5484,6 +5559,8 @@ dependencies = [
  "spectraplex-core",
  "sqlx",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -5495,6 +5572,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
+ "figment",
  "serde",
  "serde_json",
  "uuid",
@@ -6277,6 +6355,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6287,12 +6386,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
 ]
@@ -6305,6 +6418,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -6574,6 +6693,15 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"
@@ -7309,6 +7437,12 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yellowstone-grpc-client"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.84-bookworm AS builder
+
+WORKDIR /app
+COPY . .
+
+RUN cargo build --release --workspace
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/spectraplex-api /usr/local/bin/
+COPY --from=builder /app/target/release/spectraplex-cli /usr/local/bin/
+COPY --from=builder /app/migrations /app/migrations
+
+WORKDIR /app
+
+EXPOSE 3000
+
+CMD ["spectraplex-api"]

--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -1,4 +1,4 @@
-use spectraplex_core::models::{LedgerEntry, Transaction};
+use spectraplex_core::models::{Chain, IndexerCheckpoint, LedgerEntry, Transaction};
 use sqlx::{postgres::PgPool, Row};
 
 pub struct Repository {
@@ -152,5 +152,73 @@ impl Repository {
             });
         }
         Ok(entries)
+    }
+
+    pub async fn get_checkpoint(
+        &self,
+        chain: &str,
+        wallet: &str,
+    ) -> anyhow::Result<Option<IndexerCheckpoint>> {
+        let row = sqlx::query(
+            r#"
+            SELECT chain::text, wallet_address, last_signature, last_slot, last_timestamp
+            FROM indexer_checkpoints
+            WHERE chain = $1::chain_enum AND wallet_address = $2
+            "#,
+        )
+        .bind(chain)
+        .bind(wallet)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => {
+                let chain_str: String = row.try_get("chain")?;
+                let chain = match chain_str.as_str() {
+                    "solana" => Chain::Solana,
+                    "hyperliquid" => Chain::Hyperliquid,
+                    "ethereum" => Chain::Ethereum,
+                    _ => return Err(anyhow::anyhow!("Unknown chain: {}", chain_str)),
+                };
+                Ok(Some(IndexerCheckpoint {
+                    chain,
+                    wallet_address: row.try_get("wallet_address")?,
+                    last_signature: row.try_get("last_signature")?,
+                    last_slot: row.try_get("last_slot")?,
+                    last_timestamp: row.try_get("last_timestamp")?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn save_checkpoint(&self, checkpoint: &IndexerCheckpoint) -> anyhow::Result<()> {
+        let chain_str = match checkpoint.chain {
+            Chain::Solana => "solana",
+            Chain::Hyperliquid => "hyperliquid",
+            Chain::Ethereum => "ethereum",
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO indexer_checkpoints (chain, wallet_address, last_signature, last_slot, last_timestamp, updated_at)
+            VALUES ($1::chain_enum, $2, $3, $4, $5, NOW())
+            ON CONFLICT (chain, wallet_address)
+            DO UPDATE SET
+                last_signature = EXCLUDED.last_signature,
+                last_slot = EXCLUDED.last_slot,
+                last_timestamp = EXCLUDED.last_timestamp,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(chain_str)
+        .bind(&checkpoint.wallet_address)
+        .bind(&checkpoint.last_signature)
+        .bind(checkpoint.last_slot)
+        .bind(checkpoint.last_timestamp)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
     }
 }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,3 +16,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "bigdecimal"] }
 dotenv = "0.15"
 anyhow = "1.0"
+uuid = { version = "1.19", features = ["v4", "serde"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,52 +4,82 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use spectraplex_adapters::{
     hyperliquid::HyperliquidAdapter, hyperliquid_parser, repo::Repository, solana::SolanaAdapter,
     solana_parser,
 };
+use spectraplex_core::config::AppConfig;
 use spectraplex_core::models::{ChainIngestor, LedgerEntry, Transaction};
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPoolOptions;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower_http::trace::TraceLayer;
+use tracing::{error, info};
+use uuid::Uuid;
 
 struct AppState {
-    pool: PgPool,
-    solana_rpc_url: String,
+    pool: sqlx::PgPool,
+    config: AppConfig,
+    jobs: RwLock<HashMap<Uuid, JobStatus>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JobStatus {
+    pub id: Uuid,
+    pub state: JobState,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobState {
+    Pending,
+    Running,
+    Completed,
+    Failed,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
-    tracing_subscriber::fmt::init();
 
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let solana_rpc_url = std::env::var("SOLANA_RPC_URL")
-        .unwrap_or_else(|_| "https://api.mainnet-beta.solana.com".to_string());
+    let config = AppConfig::load().expect("Failed to load config");
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| config.log_level.clone().into()),
+        )
+        .init();
 
     let pool = PgPoolOptions::new()
-        .max_connections(10)
-        .connect(&database_url)
+        .max_connections(config.pool_size)
+        .connect(&config.database_url)
         .await?;
 
     let shared_state = Arc::new(AppState {
         pool,
-        solana_rpc_url,
+        config: config.clone(),
+        jobs: RwLock::new(HashMap::new()),
     });
 
     let app = Router::new()
         .route("/health", get(health_check))
         .route("/v1/ingest", post(trigger_ingest))
         .route("/v1/normalize", post(trigger_normalize))
-        .route("/v1/transactions/:wallet", get(get_transactions))
-        .route("/v1/ledger/:wallet", get(get_ledger))
+        .route("/v1/jobs/{job_id}", get(get_job_status))
+        .route("/v1/transactions/{wallet}", get(get_transactions))
+        .route("/v1/ledger/{wallet}", get(get_ledger))
+        .layer(TraceLayer::new_for_http())
         .with_state(shared_state);
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    println!("Listening on {}", addr);
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let addr = SocketAddr::from(([127, 0, 0, 1], config.port));
+    info!("Listening on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
 
     Ok(())
 }
@@ -72,73 +102,153 @@ struct NormalizeRequest {
 async fn trigger_ingest(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<IngestRequest>,
-) -> Result<Json<String>, StatusCode> {
-    let events: Vec<Transaction> = match payload._chain.as_str() {
-        "hyperliquid" => {
-            let adapter = HyperliquidAdapter::new();
-            adapter
-                .fetch_history(&payload.wallet, 50)
-                .await
-                .map_err(|e| {
-                    eprintln!("Ingest Error: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?
-        }
-        _ => {
-            let adapter = SolanaAdapter::new(&state.solana_rpc_url);
-            adapter
-                .fetch_history(&payload.wallet, 50)
-                .await
-                .map_err(|e| {
-                    eprintln!("Ingest Error: {}", e);
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?
-        }
+) -> Result<Json<JobStatus>, StatusCode> {
+    let job_id = Uuid::new_v4();
+    let job = JobStatus {
+        id: job_id,
+        state: JobState::Pending,
+        message: None,
     };
 
-    let repo = Repository::new(state.pool.clone());
-    repo.save_transactions(&events).await.map_err(|e| {
-        eprintln!("DB Error: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    state.jobs.write().await.insert(job_id, job.clone());
 
-    Ok(Json(format!("Ingested {} transactions", events.len())))
+    let state_clone = Arc::clone(&state);
+    let wallet = payload.wallet.clone();
+    let chain = payload._chain.clone();
+    let limit = state.config.ingest_limit;
+
+    tokio::spawn(async move {
+        {
+            let mut jobs = state_clone.jobs.write().await;
+            if let Some(j) = jobs.get_mut(&job_id) {
+                j.state = JobState::Running;
+            }
+        }
+
+        let result = async {
+            let events: Vec<Transaction> = match chain.as_str() {
+                "hyperliquid" => {
+                    let adapter = HyperliquidAdapter::new();
+                    adapter.fetch_history(&wallet, limit).await?
+                }
+                _ => {
+                    let adapter = SolanaAdapter::new(&state_clone.config.solana_rpc_url);
+                    adapter.fetch_history(&wallet, limit).await?
+                }
+            };
+            let repo = Repository::new(state_clone.pool.clone());
+            repo.save_transactions(&events).await?;
+            Ok::<usize, anyhow::Error>(events.len())
+        }
+        .await;
+
+        let mut jobs = state_clone.jobs.write().await;
+        if let Some(j) = jobs.get_mut(&job_id) {
+            match result {
+                Ok(count) => {
+                    info!(job_id = %job_id, count, "Ingestion completed");
+                    j.state = JobState::Completed;
+                    j.message = Some(format!("Ingested {} transactions", count));
+                }
+                Err(e) => {
+                    error!(job_id = %job_id, error = %e, "Ingestion failed");
+                    j.state = JobState::Failed;
+                    j.message = Some(e.to_string());
+                }
+            }
+        }
+    });
+
+    info!(job_id = %job_id, "Ingestion job queued");
+    Ok(Json(JobStatus {
+        id: job_id,
+        state: JobState::Pending,
+        message: Some("Job queued".to_string()),
+    }))
 }
 
 async fn trigger_normalize(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<NormalizeRequest>,
-) -> Result<Json<String>, StatusCode> {
-    let repo = Repository::new(state.pool.clone());
+) -> Result<Json<JobStatus>, StatusCode> {
+    let job_id = Uuid::new_v4();
+    let job = JobStatus {
+        id: job_id,
+        state: JobState::Pending,
+        message: None,
+    };
 
-    let txs = repo
-        .get_transactions_by_wallet(&payload.wallet)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    state.jobs.write().await.insert(job_id, job.clone());
 
-    let mut all_entries = Vec::new();
+    let state_clone = Arc::clone(&state);
+    let wallet = payload.wallet.clone();
 
-    for tx in txs {
-        let entries = match tx.chain {
-            spectraplex_core::models::Chain::Solana => {
-                solana_parser::parse_solana_transaction(&tx).unwrap_or_default()
+    tokio::spawn(async move {
+        {
+            let mut jobs = state_clone.jobs.write().await;
+            if let Some(j) = jobs.get_mut(&job_id) {
+                j.state = JobState::Running;
             }
-            spectraplex_core::models::Chain::Hyperliquid => {
-                hyperliquid_parser::parse_hyperliquid_transaction(&tx).unwrap_or_default()
+        }
+
+        let result = async {
+            let repo = Repository::new(state_clone.pool.clone());
+            let txs = repo.get_transactions_by_wallet(&wallet).await?;
+
+            let mut all_entries = Vec::new();
+            for tx in txs {
+                let entries = match tx.chain {
+                    spectraplex_core::models::Chain::Solana => {
+                        solana_parser::parse_solana_transaction(&tx).unwrap_or_default()
+                    }
+                    spectraplex_core::models::Chain::Hyperliquid => {
+                        hyperliquid_parser::parse_hyperliquid_transaction(&tx).unwrap_or_default()
+                    }
+                    _ => vec![],
+                };
+                all_entries.extend(entries);
             }
-            _ => vec![],
-        };
-        all_entries.extend(entries);
+
+            let count = all_entries.len();
+            repo.save_ledger_entries(&all_entries).await?;
+            Ok::<usize, anyhow::Error>(count)
+        }
+        .await;
+
+        let mut jobs = state_clone.jobs.write().await;
+        if let Some(j) = jobs.get_mut(&job_id) {
+            match result {
+                Ok(count) => {
+                    info!(job_id = %job_id, count, "Normalization completed");
+                    j.state = JobState::Completed;
+                    j.message = Some(format!("Normalized {} ledger entries", count));
+                }
+                Err(e) => {
+                    error!(job_id = %job_id, error = %e, "Normalization failed");
+                    j.state = JobState::Failed;
+                    j.message = Some(e.to_string());
+                }
+            }
+        }
+    });
+
+    info!(job_id = %job_id, "Normalization job queued");
+    Ok(Json(JobStatus {
+        id: job_id,
+        state: JobState::Pending,
+        message: Some("Job queued".to_string()),
+    }))
+}
+
+async fn get_job_status(
+    State(state): State<Arc<AppState>>,
+    Path(job_id): Path<Uuid>,
+) -> Result<Json<JobStatus>, StatusCode> {
+    let jobs = state.jobs.read().await;
+    match jobs.get(&job_id) {
+        Some(status) => Ok(Json(status.clone())),
+        None => Err(StatusCode::NOT_FOUND),
     }
-
-    repo.save_ledger_entries(&all_entries)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    Ok(Json(format!(
-        "Normalized {} ledger entries",
-        all_entries.len()
-    )))
 }
 
 async fn get_transactions(
@@ -149,7 +259,10 @@ async fn get_transactions(
     let txs = repo
         .get_transactions_by_wallet(&wallet)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            error!(error = %e, "Failed to fetch transactions");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(Json(txs))
 }
 
@@ -161,6 +274,9 @@ async fn get_ledger(
     let entries = repo
         .get_ledger_entries_by_wallet(&wallet)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            error!(error = %e, "Failed to fetch ledger entries");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(Json(entries))
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,5 @@ dotenv = "0.15"
 serde_json = "1.0.145"
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "macros", "uuid", "chrono", "json"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ use sqlx::postgres::PgPoolOptions;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
+use tracing::{error, info, warn};
 
 #[derive(Parser)]
 #[command(about = "Spectraplex CLI", long_about = None)]
@@ -60,6 +61,13 @@ enum Commands {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
     let cli = Cli::parse();
 
     // Setup DB Pool if URL provided
@@ -72,11 +80,11 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::InitDb => {
             if let Some(p) = pool {
-                println!("Running migrations...");
+                info!("Running migrations...");
                 sqlx::migrate!("../migrations").run(&p).await?;
-                println!("Database initialized successfully.");
+                info!("Database initialized successfully.");
             } else {
-                println!("Error: --db-url is required for InitDb");
+                error!("--db-url is required for InitDb");
             }
         }
         Commands::Ingest {
@@ -88,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
             x_token,
             limit,
         } => {
-            println!("Starting ingestion for {} on chain {}", wallet, chain);
+            info!(wallet = %wallet, chain = %chain, "Starting ingestion");
 
             let events = match chain.as_str() {
                 "solana" => {
@@ -107,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
                     adapter.fetch_history(&wallet, limit).await?
                 }
                 _ => {
-                    println!("Unsupported chain: {}", chain);
+                    warn!(chain = %chain, "Unsupported chain");
                     return Ok(());
                 }
             };
@@ -116,7 +124,7 @@ async fn main() -> anyhow::Result<()> {
             if let Some(p) = pool {
                 let repo = Repository::new(p);
                 repo.save_transactions(&events).await?;
-                println!("Saved {} transactions to Database.", events.len());
+                info!(count = events.len(), "Saved transactions to database");
             } else {
                 // Write to JSONL
                 let mut file = File::create(&output)?;
@@ -124,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
                     serde_json::to_writer(&file, &event)?;
                     writeln!(file)?;
                 }
-                println!("Done! Data written to {:?}", output);
+                info!(path = ?output, "Data written to file");
             }
         }
         Commands::Normalize { input, output } => {
@@ -132,11 +140,11 @@ async fn main() -> anyhow::Result<()> {
                 let input_str = input.to_string_lossy();
                 if input_str.starts_with("db:") {
                     let wallet = input_str.strip_prefix("db:").unwrap();
-                    println!("Fetching transactions for wallet {} from DB...", wallet);
+                    info!(wallet = %wallet, "Fetching transactions from DB");
                     let repo = Repository::new(p);
                     repo.get_transactions_by_wallet(wallet).await?
                 } else {
-                    println!("Reading raw data from {:?}...", input);
+                    info!(path = ?input, "Reading raw data from file");
                     let file = File::open(&input)?;
                     let reader = BufReader::new(file);
                     let mut txs = Vec::new();
@@ -148,7 +156,7 @@ async fn main() -> anyhow::Result<()> {
                     txs
                 }
             } else {
-                println!("Reading raw data from {:?}...", input);
+                info!(path = ?input, "Reading raw data from file");
                 let file = File::open(&input)?;
                 let reader = BufReader::new(file);
                 let mut txs = Vec::new();
@@ -172,10 +180,7 @@ async fn main() -> anyhow::Result<()> {
                         hyperliquid_parser::parse_hyperliquid_transaction(&tx)?
                     }
                     _ => {
-                        println!(
-                            "Skipping unsupported chain for normalization: {:?}",
-                            tx.chain
-                        );
+                        warn!(chain = ?tx.chain, "Skipping unsupported chain for normalization");
                         vec![]
                     }
                 };
@@ -183,17 +188,20 @@ async fn main() -> anyhow::Result<()> {
             }
 
             if let Some(p) = pool {
-                println!("Saving {} ledger entries to Database...", all_entries.len());
+                info!(
+                    count = all_entries.len(),
+                    "Saving ledger entries to database"
+                );
                 let repo = Repository::new(p);
                 repo.save_ledger_entries(&all_entries).await?;
-                println!("Done.");
+                info!("Normalization complete");
             } else {
                 let mut out_file = File::create(&output)?;
                 for entry in all_entries {
                     serde_json::to_writer(&out_file, &entry)?;
                     writeln!(out_file)?;
                 }
-                println!("Normalization complete. Output written to {:?}", output);
+                info!(path = ?output, "Normalization complete, output written to file");
             }
         }
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = "1.0.145"
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 chrono = { version = "0.4.42", features = ["serde"] }
 bigdecimal = { version = "0.4.9", features = ["serde"] }
+figment = { version = "0.10", features = ["toml", "env"] }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,0 +1,75 @@
+use figment::{
+    providers::{Env, Format, Serialized, Toml},
+    Figment,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub port: u16,
+    pub host: String,
+    pub database_url: String,
+    pub pool_size: u32,
+    pub log_level: String,
+    pub ingest_limit: usize,
+    pub solana_rpc_url: String,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            port: 3000,
+            host: "127.0.0.1".to_string(),
+            database_url: String::new(),
+            pool_size: 10,
+            log_level: "info".to_string(),
+            ingest_limit: 50,
+            solana_rpc_url: "https://api.mainnet-beta.solana.com".to_string(),
+        }
+    }
+}
+
+impl AppConfig {
+    pub fn load() -> Result<Self, Box<figment::Error>> {
+        Figment::new()
+            .merge(Serialized::defaults(AppConfig::default()))
+            .merge(Toml::file("spectraplex.toml"))
+            .merge(Env::prefixed("SPECTRAPLEX_"))
+            .merge(Env::raw().only(&["DATABASE_URL", "SOLANA_RPC_URL"]))
+            .extract()
+            .map_err(Box::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = AppConfig::default();
+        assert_eq!(config.port, 3000);
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.pool_size, 10);
+        assert_eq!(config.log_level, "info");
+        assert_eq!(config.ingest_limit, 50);
+    }
+
+    #[test]
+    fn test_load_from_defaults_and_env() {
+        // Clear any pre-existing env vars that might interfere
+        std::env::remove_var("SPECTRAPLEX_PORT");
+        std::env::remove_var("SPECTRAPLEX_HOST");
+
+        std::env::set_var("DATABASE_URL", "postgres://test:test@localhost/test");
+        std::env::set_var("SPECTRAPLEX_PORT", "8080");
+
+        let config = AppConfig::load().unwrap();
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.database_url, "postgres://test:test@localhost/test");
+        assert_eq!(config.pool_size, 10); // default
+
+        std::env::remove_var("DATABASE_URL");
+        std::env::remove_var("SPECTRAPLEX_PORT");
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod models;

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -43,6 +43,15 @@ pub struct LedgerEntry {
     pub fiat_value: Option<BigDecimal>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexerCheckpoint {
+    pub chain: Chain,
+    pub wallet_address: String,
+    pub last_signature: Option<String>,
+    pub last_slot: Option<i64>,
+    pub last_timestamp: Option<i64>,
+}
+
 #[async_trait::async_trait]
 pub trait ChainIngestor {
     async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>>;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: spectraplex
+      POSTGRES_PASSWORD: spectraplex
+      POSTGRES_DB: spectraplex
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U spectraplex"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgres://spectraplex:spectraplex@postgres:5432/spectraplex
+      SPECTRAPLEX_PORT: "3000"
+      SPECTRAPLEX_HOST: "0.0.0.0"
+      SPECTRAPLEX_LOG_LEVEL: info
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: ["spectraplex-api"]
+
+volumes:
+  pgdata:

--- a/migrations/20260217000000_add_indexer_checkpoints.sql
+++ b/migrations/20260217000000_add_indexer_checkpoints.sql
@@ -1,0 +1,9 @@
+CREATE TABLE indexer_checkpoints (
+    chain chain_enum NOT NULL,
+    wallet_address TEXT NOT NULL,
+    last_signature TEXT,
+    last_slot BIGINT,
+    last_timestamp BIGINT,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (chain, wallet_address)
+);

--- a/spectraplex.toml.example
+++ b/spectraplex.toml.example
@@ -1,0 +1,7 @@
+port = 3000
+host = "127.0.0.1"
+database_url = "postgres://spectraplex:spectraplex@localhost:5432/spectraplex"
+pool_size = 10
+log_level = "info"
+ingest_limit = 50
+solana_rpc_url = "https://api.mainnet-beta.solana.com"


### PR DESCRIPTION
## Summary

- **Docker**: Multi-stage Dockerfile (Rust builder + debian-slim runtime) and docker-compose.yml with PostgreSQL service, health checks, and persistent volume. `.dockerignore` included.
- **Configuration management**: `figment`-based `AppConfig` in `core/src/config.rs` with layered config: defaults -> `spectraplex.toml` -> `SPECTRAPLEX_*` env vars -> `DATABASE_URL`. All hardcoded values (port 3000, pool size 10, limit 50) moved to config.
- **Structured logging**: Replaced all `println!`/`eprintln!` with `tracing` macros (`info!`, `warn!`, `error!`) in both CLI and API. Added `TraceLayer` middleware to Axum for HTTP request tracing. Initialized `tracing-subscriber` with env-filter support.
- **Indexer checkpointing**: New migration `indexer_checkpoints` table keyed by `(chain, wallet_address)`. Added `get_checkpoint` and `save_checkpoint` methods to `Repository`.
- **Async ingestion**: API `/v1/ingest` and `/v1/normalize` endpoints now return immediately with a job ID and status. Background processing via `tokio::spawn` with in-memory `HashMap<Uuid, JobStatus>` tracking. New `GET /v1/jobs/{job_id}` endpoint for polling job status.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace` passes (only pre-existing solana_parser warning)
- [x] `cargo test --workspace` passes (3 tests including 2 new config tests)
- [ ] Manual: `docker compose up` starts PostgreSQL and API successfully
- [ ] Manual: POST to `/v1/ingest` returns job ID immediately, GET `/v1/jobs/{id}` shows progress