### PR TITLE
fix: resolve blocking RPC and SSRF vulnerabilities

### DIFF
--- a/adapters/src/solana.rs
+++ b/adapters/src/solana.rs
@@ -4,16 +4,17 @@ use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use solana_transaction_status::UiTransactionEncoding;
 use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
 use std::str::FromStr;
+use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct SolanaAdapter {
-    client: RpcClient,
+    client: Arc<RpcClient>,
 }
 
 impl SolanaAdapter {
     pub fn new(rpc_url: &str) -> Self {
         Self {
-            client: RpcClient::new(rpc_url.to_string()),
+            client: Arc::new(RpcClient::new(rpc_url.to_string())),
         }
     }
 }
@@ -21,42 +22,40 @@ impl SolanaAdapter {
 #[async_trait::async_trait]
 impl ChainIngestor for SolanaAdapter {
     async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>> {
-        let pubkey = Pubkey::from_str(wallet)?;
-        // Fetch signatures (transaction history list)
-        let signatures = self.client.get_signatures_for_address(&pubkey)?;
+        let client = self.client.clone();
+        let wallet = wallet.to_string();
 
-        let mut transactions = Vec::new();
+        tokio::task::spawn_blocking(move || {
+            let pubkey = Pubkey::from_str(&wallet)?;
+            let signatures = client.get_signatures_for_address(&pubkey)?;
 
-        for sig_info in signatures.iter().take(limit) {
-            let sig = Signature::from_str(&sig_info.signature)?;
+            let mut transactions = Vec::new();
 
-            // Fetch full transaction details in JSON format
-            // We use UiTransactionEncoding::JsonParsed to get as much detail as possible,
-            // or Json for raw structure. "Json" is often safer for raw storage.
-            match self
-                .client
-                .get_transaction(&sig, UiTransactionEncoding::Json)
-            {
-                Ok(tx) => {
-                    // Serialize the entire response to a JSON Value
-                    let raw_metadata = serde_json::to_value(&tx).unwrap_or(json!({}));
+            for sig_info in signatures.iter().take(limit) {
+                let sig = Signature::from_str(&sig_info.signature)?;
 
-                    transactions.push(Transaction {
-                        id: Uuid::new_v4(),
-                        user_id: Uuid::nil(), // Placeholder
-                        wallet_address: wallet.to_string(),
-                        timestamp: tx.block_time.unwrap_or(0),
-                        tx_hash: sig_info.signature.clone(),
-                        chain: Chain::Solana,
-                        raw_metadata,
-                    });
-                }
-                Err(e) => {
-                    eprintln!("Failed to fetch tx {}: {}", sig_info.signature, e);
+                match client.get_transaction(&sig, UiTransactionEncoding::Json) {
+                    Ok(tx) => {
+                        let raw_metadata = serde_json::to_value(&tx).unwrap_or(json!({}));
+
+                        transactions.push(Transaction {
+                            id: Uuid::new_v4(),
+                            user_id: Uuid::nil(), // Placeholder
+                            wallet_address: wallet.to_string(),
+                            timestamp: tx.block_time.unwrap_or(0),
+                            tx_hash: sig_info.signature.clone(),
+                            chain: Chain::Solana,
+                            raw_metadata,
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to fetch tx {}: {}", sig_info.signature, e);
+                    }
                 }
             }
-        }
 
-        Ok(transactions)
+            Ok(transactions)
+        })
+        .await?
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -14,9 +14,9 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-// App State to share DB Pool
 struct AppState {
     pool: PgPool,
+    solana_rpc_url: String,
 }
 
 #[tokio::main]
@@ -25,12 +25,18 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let solana_rpc_url = std::env::var("SOLANA_RPC_URL")
+        .unwrap_or_else(|_| "https://api.mainnet-beta.solana.com".to_string());
+
     let pool = PgPoolOptions::new()
         .max_connections(10)
         .connect(&database_url)
         .await?;
 
-    let shared_state = Arc::new(AppState { pool });
+    let shared_state = Arc::new(AppState {
+        pool,
+        solana_rpc_url,
+    });
 
     let app = Router::new()
         .route("/health", get(health_check))
@@ -52,20 +58,16 @@ async fn health_check() -> &'static str {
     "OK"
 }
 
-// Request Models
 #[derive(Deserialize)]
 struct IngestRequest {
     _chain: String,
     wallet: String,
-    rpc_url: String,
 }
 
 #[derive(Deserialize)]
 struct NormalizeRequest {
     wallet: String,
 }
-
-// Handlers
 
 async fn trigger_ingest(
     State(state): State<Arc<AppState>>,
@@ -83,7 +85,7 @@ async fn trigger_ingest(
                 })?
         }
         _ => {
-            let adapter = SolanaAdapter::new(&payload.rpc_url);
+            let adapter = SolanaAdapter::new(&state.solana_rpc_url);
             adapter
                 .fetch_history(&payload.wallet, 50)
                 .await


### PR DESCRIPTION
## Summary
- **Issue #4 - Blocking RPC in async context:** Wrapped all synchronous `solana_client::RpcClient` calls inside `tokio::task::spawn_blocking()` to prevent blocking the Tokio runtime. The `RpcClient` is now stored in an `Arc` for safe sharing into the blocking closure.
- **Issue #3 - SSRF risk:** Removed the user-supplied `rpc_url` field from the `IngestRequest` body. The Solana RPC URL is now read from the `SOLANA_RPC_URL` environment variable at server startup and stored in `AppState`. Falls back to `https://api.mainnet-beta.solana.com` if not set.

## Test plan
- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo test --workspace` — 11/11 tests pass
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [ ] Manual: verify ingest endpoint no longer accepts `rpc_url` in request body
- [ ] Manual: verify `SOLANA_RPC_URL` env var is read at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)