### PR TITLE
Add unique constraint on (chain, tx_hash) to prevent duplicates

### DIFF
--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -23,8 +23,8 @@ impl Repository {
                 r#"
                 INSERT INTO transactions (id, user_id, wallet_address, timestamp, tx_hash, chain, raw_metadata)
                 VALUES ($1, $2, $3, $4, $5, $6::chain_enum, $7)
-                ON CONFLICT (id) DO NOTHING
-                "#
+                ON CONFLICT (chain, tx_hash) DO NOTHING
+                "#,
             )
             .bind(tx.id)
             .bind(tx.user_id)

--- a/migrations/20260217100000_add_unique_chain_tx_hash.sql
+++ b/migrations/20260217100000_add_unique_chain_tx_hash.sql
@@ -1,0 +1,5 @@
+-- Add unique constraint on (chain, tx_hash) to prevent duplicate transaction ingestion.
+-- The same tx_hash can exist on different chains, but must be unique within a chain.
+-- Drop the old non-unique index first since the unique constraint implicitly creates one.
+DROP INDEX IF EXISTS idx_transactions_tx_hash;
+ALTER TABLE transactions ADD CONSTRAINT uq_transactions_chain_tx_hash UNIQUE (chain, tx_hash);


### PR DESCRIPTION
## Summary
- Adds migration `20260217100000_add_unique_chain_tx_hash.sql` that drops the old non-unique `idx_transactions_tx_hash` index and creates a `UNIQUE(chain, tx_hash)` constraint on the `transactions` table
- Updates `repo.rs` to use `ON CONFLICT (chain, tx_hash) DO NOTHING` instead of `ON CONFLICT (id)` -- the old approach was ineffective since UUIDs are generated fresh via `Uuid::new_v4()` on every call, meaning duplicate transactions were never deduplicated

Closes #10

## Test plan
- [x] `cargo test --workspace` -- all 21 tests pass
- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo clippy --workspace` -- no errors
- [ ] Manual: run `ingest` twice for the same wallet and verify no duplicate rows in `transactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)