### PR TITLE
fix: replace hardcoded Uuid::nil() with caller-provided user_id

### DIFF
--- a/adapters/src/hyperliquid.rs
+++ b/adapters/src/hyperliquid.rs
@@ -158,7 +158,7 @@ impl HyperliquidAdapter {
 
 #[async_trait::async_trait]
 impl ChainIngestor for HyperliquidAdapter {
-    async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>> {
+    async fn fetch_history(&self, wallet: &str, limit: usize, user_id: Uuid) -> anyhow::Result<Vec<Transaction>> {
         let mut transactions = Vec::new();
 
         // 1. Fetch fills (trades)
@@ -167,7 +167,7 @@ impl ChainIngestor for HyperliquidAdapter {
             let raw = serde_json::to_value(fill)?;
             transactions.push(Transaction {
                 id: Uuid::new_v4(),
-                user_id: Uuid::nil(),
+                user_id,
                 wallet_address: wallet.to_string(),
                 timestamp: (fill.time / 1000) as i64, // HL timestamps are in ms
                 tx_hash: fill.hash.clone(),
@@ -186,7 +186,7 @@ impl ChainIngestor for HyperliquidAdapter {
                 .unwrap_or_else(|| format!("funding-{}-{}", entry.coin, entry.time));
             transactions.push(Transaction {
                 id: Uuid::new_v4(),
-                user_id: Uuid::nil(),
+                user_id,
                 wallet_address: wallet.to_string(),
                 timestamp: (entry.time / 1000) as i64,
                 tx_hash: hash,
@@ -201,7 +201,7 @@ impl ChainIngestor for HyperliquidAdapter {
             let raw = serde_json::to_value(update)?;
             transactions.push(Transaction {
                 id: Uuid::new_v4(),
-                user_id: Uuid::nil(),
+                user_id,
                 wallet_address: wallet.to_string(),
                 timestamp: (update.time / 1000) as i64,
                 tx_hash: update.hash.clone(),
@@ -337,7 +337,7 @@ mod tests {
 
         let adapter = HyperliquidAdapter::with_base_url(&base_url);
         let txs = adapter
-            .fetch_history("0x1234567890abcdef1234567890abcdef12345678", 10)
+            .fetch_history("0x1234567890abcdef1234567890abcdef12345678", 10, Uuid::new_v4())
             .await
             .unwrap();
 

--- a/adapters/src/solana.rs
+++ b/adapters/src/solana.rs
@@ -21,7 +21,7 @@ impl SolanaAdapter {
 
 #[async_trait::async_trait]
 impl ChainIngestor for SolanaAdapter {
-    async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>> {
+    async fn fetch_history(&self, wallet: &str, limit: usize, user_id: Uuid) -> anyhow::Result<Vec<Transaction>> {
         let client = self.client.clone();
         let wallet = wallet.to_string();
 
@@ -40,7 +40,7 @@ impl ChainIngestor for SolanaAdapter {
 
                         transactions.push(Transaction {
                             id: Uuid::new_v4(),
-                            user_id: Uuid::nil(), // Placeholder
+                            user_id,
                             wallet_address: wallet.to_string(),
                             timestamp: tx.block_time.unwrap_or(0),
                             tx_hash: sig_info.signature.clone(),

--- a/adapters/src/solana_grpc.rs
+++ b/adapters/src/solana_grpc.rs
@@ -283,7 +283,7 @@ impl ChainIngestor for SolanaGrpcAdapter {
     ///
     /// The `wallet` parameter is used as the wallet_address on collected transactions.
     /// For real-time streaming, use `stream_transactions()` instead.
-    async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>> {
+    async fn fetch_history(&self, wallet: &str, limit: usize, user_id: Uuid) -> anyhow::Result<Vec<Transaction>> {
         let mut client = self.connect_client().await?;
 
         let from_slot = {
@@ -315,6 +315,7 @@ impl ChainIngestor for SolanaGrpcAdapter {
                     match convert_grpc_transaction(&tx_info, slot) {
                         Ok(mut transaction) => {
                             transaction.wallet_address = wallet.to_string();
+                            transaction.user_id = user_id;
                             transactions.push(transaction);
 
                             if transactions.len() >= limit {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -92,6 +92,7 @@ async fn health_check() -> &'static str {
 struct IngestRequest {
     _chain: String,
     wallet: String,
+    user_id: Option<Uuid>,
 }
 
 #[derive(Deserialize)]
@@ -133,6 +134,7 @@ async fn trigger_ingest(
     let wallet = payload.wallet.clone();
     let chain = payload._chain.clone();
     let limit = state.config.ingest_limit;
+    let user_id = payload.user_id.unwrap_or_else(Uuid::new_v4);
 
     tokio::spawn(async move {
         {
@@ -146,11 +148,11 @@ async fn trigger_ingest(
             let events: Vec<Transaction> = match chain.as_str() {
                 "hyperliquid" => {
                     let adapter = HyperliquidAdapter::new();
-                    adapter.fetch_history(&wallet, limit).await?
+                    adapter.fetch_history(&wallet, limit, user_id).await?
                 }
                 _ => {
                     let adapter = SolanaAdapter::new(&state_clone.config.solana_rpc_url);
-                    adapter.fetch_history(&wallet, limit).await?
+                    adapter.fetch_history(&wallet, limit, user_id).await?
                 }
             };
             let repo = Repository::new(state_clone.pool.clone());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 #[derive(Parser)]
 #[command(about = "Spectraplex CLI", long_about = None)]
@@ -47,6 +48,10 @@ enum Commands {
 
         #[arg(long, default_value_t = 10)]
         limit: usize,
+
+        /// User ID to associate with ingested transactions. Auto-generates if not provided.
+        #[arg(long)]
+        user_id: Option<Uuid>,
     },
     /// Normalize Bronze data to Silver layer (Ledger Entries)
     Normalize {
@@ -95,24 +100,30 @@ async fn main() -> anyhow::Result<()> {
             grpc_url,
             x_token,
             limit,
+            user_id,
         } => {
+            let user_id = user_id.unwrap_or_else(|| {
+                let id = Uuid::new_v4();
+                info!(user_id = %id, "No --user-id provided, auto-generated");
+                id
+            });
             info!(wallet = %wallet, chain = %chain, "Starting ingestion");
 
             let events = match chain.as_str() {
                 "solana" => {
                     if let Some(endpoint) = grpc_url {
                         let adapter = SolanaGrpcAdapter::new(&endpoint, x_token);
-                        adapter.fetch_history(&wallet, limit).await?
+                        adapter.fetch_history(&wallet, limit, user_id).await?
                     } else if let Some(rpc_url) = rpc {
                         let adapter = SolanaAdapter::new(&rpc_url);
-                        adapter.fetch_history(&wallet, limit).await?
+                        adapter.fetch_history(&wallet, limit, user_id).await?
                     } else {
                         anyhow::bail!("Either --grpc-url or --rpc must be provided for Solana");
                     }
                 }
                 "hyperliquid" => {
                     let adapter = HyperliquidAdapter::new();
-                    adapter.fetch_history(&wallet, limit).await?
+                    adapter.fetch_history(&wallet, limit, user_id).await?
                 }
                 _ => {
                     warn!(chain = %chain, "Unsupported chain");

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -54,5 +54,5 @@ pub struct IndexerCheckpoint {
 
 #[async_trait::async_trait]
 pub trait ChainIngestor {
-    async fn fetch_history(&self, wallet: &str, limit: usize) -> anyhow::Result<Vec<Transaction>>;
+    async fn fetch_history(&self, wallet: &str, limit: usize, user_id: Uuid) -> anyhow::Result<Vec<Transaction>>;
 }


### PR DESCRIPTION
## Summary
- Add `user_id: Uuid` parameter to the `ChainIngestor::fetch_history` trait
- Update all adapters (Solana RPC, Solana gRPC, Hyperliquid) to accept and use the caller-provided `user_id` instead of `Uuid::nil()`
- CLI: add `--user-id` flag (auto-generates a new UUID if omitted)
- API: accept optional `user_id` field in the ingest request body (auto-generates if omitted)

Closes #15

## Changes
| File | What changed |
|------|-------------|
| `core/src/models.rs` | Added `user_id: Uuid` param to `ChainIngestor::fetch_history` trait |
| `adapters/src/solana.rs` | Updated impl to accept and use `user_id` |
| `adapters/src/solana_grpc.rs` | Updated impl signature |
| `adapters/src/hyperliquid.rs` | Updated impl to accept and use `user_id` (was also using `Uuid::nil()`) |
| `cli/src/main.rs` | Added `--user-id` flag, passes to all adapter calls |
| `api/src/main.rs` | Added optional `user_id` field to `IngestRequest`, passes to adapter calls |
| `api/Cargo.toml` | Added `uuid` dependency for request deserialization |

## Test plan
- [ ] All 21 existing tests pass (11 parser + 10 adapter/Hyperliquid)
- [ ] `cargo fmt --all --check` passes
- [ ] CLI `--help` shows new `--user-id` flag
- [ ] API accepts `user_id` in ingest request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)