### PR TITLE
fix: uint256 precision, gRPC timestamps, wallet validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,27 +1893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7136,7 +7115,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "csv",
  "dotenv",
  "serde",
  "serde_json",

--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -29,7 +29,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                     .get("data")
                     .and_then(|d| d.as_str())
                     .unwrap_or("0x0");
-                let amount_raw = hex_to_u128(data_hex);
+                let amount_bd = hex_to_bigdecimal(data_hex);
 
                 // The contract address is the token address
                 let token_address = tx
@@ -41,7 +41,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
 
                 let decimals = token_decimals(&token_address);
                 let symbol = token_symbol(&token_address);
-                let normalized = normalize_amount(amount_raw, decimals);
+                let normalized = normalize_bigdecimal(amount_bd, decimals);
 
                 // Determine if this wallet sent or received
                 if from == wallet {
@@ -164,7 +164,29 @@ fn topic_to_address(topic: &str) -> String {
     }
 }
 
+/// Parse a hex string (with optional 0x prefix) into BigDecimal.
+/// Handles full uint256 range without truncation.
+fn hex_to_bigdecimal(hex: &str) -> BigDecimal {
+    let stripped = hex.strip_prefix("0x").unwrap_or(hex);
+    if stripped.is_empty() {
+        return BigDecimal::from(0);
+    }
+    // Parse hex digits in chunks to build a BigDecimal without overflow
+    let mut result = BigDecimal::from(0);
+    let base = BigDecimal::from(16);
+    for ch in stripped.chars() {
+        let digit = match ch.to_ascii_lowercase() {
+            '0'..='9' => ch as u32 - '0' as u32,
+            'a'..='f' => ch as u32 - 'a' as u32 + 10,
+            _ => return BigDecimal::from(0),
+        };
+        result = result * &base + BigDecimal::from(digit);
+    }
+    result
+}
+
 /// Parse a hex string (with optional 0x prefix) into u128.
+/// Suitable for values known to fit in u128 (e.g., gas values).
 fn hex_to_u128(hex: &str) -> u128 {
     let stripped = hex.strip_prefix("0x").unwrap_or(hex);
     if stripped.is_empty() {
@@ -214,12 +236,12 @@ fn token_symbol(contract_address: &str) -> String {
 }
 
 /// Normalize a raw token amount by dividing by 10^decimals.
-fn normalize_amount(raw: u128, decimals: u32) -> BigDecimal {
-    use bigdecimal::FromPrimitive;
-    let raw_bd = BigDecimal::from_u128(raw).unwrap_or_default();
-    let divisor =
-        BigDecimal::from_u128(10u128.pow(decimals)).unwrap_or_else(|| BigDecimal::from(1));
-    raw_bd / divisor
+/// Normalize a BigDecimal raw amount by dividing by 10^decimals.
+fn normalize_bigdecimal(raw: BigDecimal, decimals: u32) -> BigDecimal {
+    use std::str::FromStr;
+    let divisor = BigDecimal::from_str(&format!("1{}", "0".repeat(decimals as usize)))
+        .unwrap_or_else(|_| BigDecimal::from(1));
+    raw / divisor
 }
 
 /// Negate a BigDecimal value.
@@ -407,13 +429,25 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_amount() {
+    fn test_normalize_bigdecimal() {
         // 1_000_000 raw with 6 decimals = 1.0
-        let result = normalize_amount(1_000_000, 6);
+        let result = normalize_bigdecimal(BigDecimal::from(1_000_000), 6);
         assert_eq!(result, BigDecimal::from(1));
 
         // 100_000_000 raw with 8 decimals = 1.0
-        let result = normalize_amount(100_000_000, 8);
+        let result = normalize_bigdecimal(BigDecimal::from(100_000_000), 8);
         assert_eq!(result, BigDecimal::from(1));
+    }
+
+    #[test]
+    fn test_hex_to_bigdecimal() {
+        // Small value
+        assert_eq!(hex_to_bigdecimal("0xff"), BigDecimal::from(255));
+        // u128 max = 0xffffffffffffffffffffffffffffffff
+        let u128_max = hex_to_bigdecimal("0xffffffffffffffffffffffffffffffff");
+        assert_eq!(u128_max, BigDecimal::from(u128::MAX));
+        // Value larger than u128 (u128::MAX + 1)
+        let over_u128 = hex_to_bigdecimal("0x100000000000000000000000000000000");
+        assert!(over_u128 > BigDecimal::from(u128::MAX));
     }
 }

--- a/adapters/src/solana_grpc.rs
+++ b/adapters/src/solana_grpc.rs
@@ -485,7 +485,11 @@ fn build_raw_metadata(
             "rewards": [],
             "status": status
         },
-        "block_time": 0i64
+        // Yellowstone gRPC transaction updates don't include block_time;
+        // it's a block-level attribute. Use current time as approximation
+        // for real-time streaming. For historical accuracy, callers should
+        // enrich timestamps from block data.
+        "block_time": chrono::Utc::now().timestamp()
     }))
 }
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -41,6 +41,13 @@ impl AppError {
             message: msg.into(),
         }
     }
+
+    fn bad_request(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: msg.into(),
+        }
+    }
 }
 
 impl IntoResponse for AppError {
@@ -165,10 +172,27 @@ fn clamp_offset(offset: Option<i64>) -> i64 {
     offset.unwrap_or(0).max(0)
 }
 
+/// Basic wallet address validation. Rejects obviously invalid inputs.
+fn validate_wallet(wallet: &str) -> Result<(), AppError> {
+    if wallet.is_empty() || wallet.len() > 128 {
+        return Err(AppError::bad_request("Invalid wallet address length"));
+    }
+    if !wallet
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == 'x')
+    {
+        return Err(AppError::bad_request(
+            "Wallet address contains invalid characters",
+        ));
+    }
+    Ok(())
+}
+
 async fn trigger_ingest(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<IngestRequest>,
 ) -> Result<Json<JobStatus>, AppError> {
+    validate_wallet(&payload.wallet)?;
     let job_id = Uuid::new_v4();
     let job = JobStatus {
         id: job_id,
@@ -251,6 +275,7 @@ async fn trigger_normalize(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<NormalizeRequest>,
 ) -> Result<Json<JobStatus>, AppError> {
+    validate_wallet(&payload.wallet)?;
     let job_id = Uuid::new_v4();
     let job = JobStatus {
         id: job_id,
@@ -347,6 +372,7 @@ async fn get_transactions(
     Path(wallet): Path<String>,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<Transaction>>, AppError> {
+    validate_wallet(&wallet)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
     let repo = Repository::new(state.pool.clone());
@@ -362,6 +388,7 @@ async fn get_ledger(
     Path(wallet): Path<String>,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<LedgerEntry>>, AppError> {
+    validate_wallet(&wallet)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
     let repo = Repository::new(state.pool.clone());

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,6 @@ spectraplex-core = { path = "../core" }
 spectraplex-adapters = { path = "../adapters" }
 clap = { version = "4.5.53", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
-csv = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 dotenv = "0.15"


### PR DESCRIPTION
## Summary
- **#40**: Parse EVM token amounts as `BigDecimal` via `hex_to_bigdecimal()` to handle full uint256 range without u128 truncation
- **#35**: Use `chrono::Utc::now()` for gRPC transaction timestamps instead of hardcoded 0 (block_time is a block-level attribute in Yellowstone)
- **#7**: Add wallet address validation (length + character checks) to all API endpoints, returning 400 Bad Request for invalid input
- **#39**: Remove unused `csv` dependency from CLI crate

Closes #40, closes #35, closes #7, closes #39

## Test plan
- [x] `cargo check` passes with zero warnings
- [x] `cargo clippy --all-targets` passes with zero warnings
- [x] `cargo test` passes (all tests green)
- [x] `cargo fmt --all -- --check` passes
- [x] New tests: `test_hex_to_bigdecimal` verifies values > u128::MAX parse correctly
- [x] New tests: `test_normalize_bigdecimal` verifies decimal scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)