### PR TITLE
fix: SPL token symbol lookup and shared Repository

### DIFF
--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -108,12 +108,13 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
 
                     if delta_raw != 0 {
                         let amount = token_raw_to_decimal(delta_raw, decimals);
+                        let symbol = spl_token_symbol(&mint);
                         entries.push(LedgerEntry {
                             id: Uuid::new_v4(),
                             transaction_id: tx.id,
                             user_id: tx.user_id,
                             wallet_address: tx.wallet_address.clone(),
-                            asset_symbol: mint,
+                            asset_symbol: symbol,
                             amount,
                             entry_type: EntryType::Transfer,
                             fiat_value: None,
@@ -146,4 +147,22 @@ fn token_raw_to_decimal(raw: i128, decimals: u32) -> BigDecimal {
     let raw_bd = BigDecimal::from_str(&format!("{}", raw)).unwrap();
     let divisor = BigDecimal::from_str(&format!("1{}", "0".repeat(decimals as usize))).unwrap();
     raw_bd / divisor
+}
+
+/// Lookup a human-readable symbol for well-known SPL tokens.
+/// Falls back to the mint address for unknown tokens.
+fn spl_token_symbol(mint: &str) -> String {
+    match mint {
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" => "USDC".to_string(),
+        "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" => "USDT".to_string(),
+        "So11111111111111111111111111111111111111112" => "SOL".to_string(),
+        "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So" => "mSOL".to_string(),
+        "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs" => "WETH".to_string(),
+        "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" => "BONK".to_string(),
+        "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN" => "JUP".to_string(),
+        "7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj" => "stSOL".to_string(),
+        "RLBxxFkseAZ4RgJH3Sqn8jXxhmGoz9jWxDNJMh8pL7a" => "RLSOL".to_string(),
+        "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn" => "jitoSOL".to_string(),
+        _ => mint.to_string(),
+    }
 }

--- a/adapters/tests/solana_parser_test.rs
+++ b/adapters/tests/solana_parser_test.rs
@@ -275,7 +275,8 @@ fn test_spl_token_transfer() {
     let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
 
     // Wallet is not fee payer (index 1), no SOL change for wallet, but has SPL token change
-    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+    // USDC mint resolves to "USDC" symbol
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == "USDC").collect();
     assert_eq!(token_entries.len(), 1, "Should have one SPL token entry");
     assert_eq!(token_entries[0].amount, bd("50.5"));
     assert!(matches!(token_entries[0].entry_type, EntryType::Transfer));
@@ -344,7 +345,8 @@ fn test_spl_token_send() {
     let tx = make_tx(wallet, meta);
     let entries = solana_parser::parse_solana_transaction(&tx).expect("Parser failed");
 
-    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
+    // USDC mint resolves to "USDC" symbol
+    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == "USDC").collect();
     assert_eq!(token_entries.len(), 1);
     assert_eq!(token_entries[0].amount, bd("-75"));
 }
@@ -417,22 +419,28 @@ fn test_multi_asset_transaction() {
         .iter()
         .filter(|e| matches!(e.entry_type, EntryType::Fee))
         .collect();
+    // Wrapped SOL mint resolves to "SOL" symbol, so all SOL-related transfer
+    // entries share the same asset_symbol. Filter by amount to distinguish.
     let sol_transfers: Vec<_> = entries
         .iter()
         .filter(|e| e.asset_symbol == "SOL" && matches!(e.entry_type, EntryType::Transfer))
         .collect();
-    let token_entries: Vec<_> = entries.iter().filter(|e| e.asset_symbol == mint).collect();
 
     assert_eq!(fee_entries.len(), 1, "One fee entry");
     assert_eq!(fee_entries[0].amount, bd("-0.00001"));
 
-    // SOL transfer: total change = 4_899_990_000 - 5_000_000_000 = -100_010_000
-    // Fee = 10_000 lamports. Transfer = -100_010_000 + 10_000 = -100_000_000 = -0.1 SOL
-    assert_eq!(sol_transfers.len(), 1, "One SOL transfer entry");
-    assert_eq!(sol_transfers[0].amount, bd("-0.1"));
-
-    assert_eq!(token_entries.len(), 1, "One SPL token entry");
-    assert_eq!(token_entries[0].amount, bd("1"));
+    // Should have 2 SOL transfer entries: native SOL (-0.1) + wrapped SOL SPL token (+1)
+    assert_eq!(sol_transfers.len(), 2, "Native SOL + wrapped SOL transfers");
+    let native_sol: Vec<_> = sol_transfers
+        .iter()
+        .filter(|e| e.amount == bd("-0.1"))
+        .collect();
+    let wrapped_sol: Vec<_> = sol_transfers
+        .iter()
+        .filter(|e| e.amount == bd("1"))
+        .collect();
+    assert_eq!(native_sol.len(), 1, "One native SOL transfer");
+    assert_eq!(wrapped_sol.len(), 1, "One wrapped SOL SPL transfer");
 }
 
 // -----------------------------------------------------------------------

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -59,7 +59,7 @@ impl IntoResponse for AppError {
 }
 
 struct AppState {
-    pool: sqlx::PgPool,
+    repo: Repository,
     config: AppConfig,
     jobs: RwLock<HashMap<Uuid, JobEntry>>,
 }
@@ -116,7 +116,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     let shared_state = Arc::new(AppState {
-        pool,
+        repo: Repository::new(pool),
         config: config.clone(),
         jobs: RwLock::new(HashMap::new()),
     });
@@ -237,8 +237,7 @@ async fn trigger_ingest(
                     adapter.fetch_history(&wallet, limit, user_id).await?
                 }
             };
-            let repo = Repository::new(state_clone.pool.clone());
-            repo.save_transactions(&events).await?;
+            state_clone.repo.save_transactions(&events).await?;
             Ok::<usize, anyhow::Error>(events.len())
         }
         .await;
@@ -303,8 +302,7 @@ async fn trigger_normalize(
         }
 
         let result = async {
-            let repo = Repository::new(state_clone.pool.clone());
-            let txs = repo.get_transactions_by_wallet(&wallet).await?;
+            let txs = state_clone.repo.get_transactions_by_wallet(&wallet).await?;
 
             let mut all_entries = Vec::new();
             for tx in txs {
@@ -323,7 +321,7 @@ async fn trigger_normalize(
             }
 
             let count = all_entries.len();
-            repo.save_ledger_entries(&all_entries).await?;
+            state_clone.repo.save_ledger_entries(&all_entries).await?;
             Ok::<usize, anyhow::Error>(count)
         }
         .await;
@@ -375,8 +373,8 @@ async fn get_transactions(
     validate_wallet(&wallet)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
-    let repo = Repository::new(state.pool.clone());
-    let txs = repo
+    let txs = state
+        .repo
         .get_transactions_by_wallet_paginated(&wallet, limit, offset)
         .await
         .map_err(AppError::internal)?;
@@ -391,8 +389,8 @@ async fn get_ledger(
     validate_wallet(&wallet)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
-    let repo = Repository::new(state.pool.clone());
-    let entries = repo
+    let entries = state
+        .repo
         .get_ledger_entries_by_wallet_paginated(&wallet, limit, offset)
         .await
         .map_err(AppError::internal)?;


### PR DESCRIPTION
## Summary
- **#18**: Add `spl_token_symbol()` lookup for well-known SPL tokens (USDC, USDT, SOL, mSOL, BONK, JUP, stSOL, jitoSOL) so ledger entries show human-readable symbols instead of raw mint addresses
- **#17**: Move `Repository` into `AppState` as a shared instance instead of creating a new one per request, eliminating redundant `PgPool` clones

Closes #18, closes #17

## Test plan
- [x] `cargo test` passes (all 11 solana parser tests updated + passing)
- [x] `cargo clippy --all-targets` passes with zero warnings
- [x] `cargo fmt --all -- --check` passes
- [x] Tests updated to verify symbol resolution (USDC mint → "USDC", wrapped SOL mint → "SOL")

🤖 Generated with [Claude Code](https://claude.com/claude-code)