### PR TITLE
fix: deduplicate EVM gas fees for multi-log transactions (#51)

### DIFF
--- a/adapters/src/evm.rs
+++ b/adapters/src/evm.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use alloy::consensus::Transaction as TransactionTrait;
 use alloy::primitives::{Address, B256};
@@ -179,6 +179,7 @@ impl ChainIngestor for EvmAdapter {
         }
 
         let mut transactions = Vec::new();
+        let mut emitted_tx_hashes = HashSet::new();
 
         for log in &logs {
             let tx_hash = match log.transaction_hash {
@@ -198,14 +199,18 @@ impl ChainIngestor for EvmAdapter {
                 "data": format!("0x{}", alloy::hex::encode(log.data().data.as_ref())),
             });
 
-            // Merge transaction and receipt fields into raw_metadata
-            if let Some((tx_fields, receipt_fields)) = seen_tx_hashes.get(&tx_hash) {
-                if let Some(obj) = raw_metadata.as_object_mut() {
-                    if let Some(tx_obj) = tx_fields.as_object() {
-                        obj.extend(tx_obj.iter().map(|(k, v)| (k.clone(), v.clone())));
-                    }
-                    if let Some(rx_obj) = receipt_fields.as_object() {
-                        obj.extend(rx_obj.iter().map(|(k, v)| (k.clone(), v.clone())));
+            // Only attach tx-level fields (value, from, to, gas_used, effective_gas_price)
+            // to the first log per tx hash to avoid duplicate gas fee / value entries.
+            let is_first_log = emitted_tx_hashes.insert(tx_hash.clone());
+            if is_first_log {
+                if let Some((tx_fields, receipt_fields)) = seen_tx_hashes.get(&tx_hash) {
+                    if let Some(obj) = raw_metadata.as_object_mut() {
+                        if let Some(tx_obj) = tx_fields.as_object() {
+                            obj.extend(tx_obj.iter().map(|(k, v)| (k.clone(), v.clone())));
+                        }
+                        if let Some(rx_obj) = receipt_fields.as_object() {
+                            obj.extend(rx_obj.iter().map(|(k, v)| (k.clone(), v.clone())));
+                        }
                     }
                 }
             }

--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -440,6 +440,83 @@ mod tests {
     }
 
     #[test]
+    fn test_gas_fee_not_duplicated_across_logs() {
+        let wallet = "0xabcdef1234567890abcdef1234567890abcdef12";
+        let from_padded = format!(
+            "0x000000000000000000000000{}",
+            "1111111111111111111111111111111111111111"
+        );
+        let to_padded = format!("0x000000000000000000000000{}", &wallet[2..]);
+        let tx_hash = "0xaaa";
+        let user_id = Uuid::nil();
+        let tx_id = Uuid::new_v4();
+
+        // First log: has gas fields (adapter attaches to first log only)
+        let first_log = Transaction {
+            id: tx_id,
+            user_id,
+            wallet_address: wallet.to_string(),
+            timestamp: 1700000000,
+            tx_hash: tx_hash.to_string(),
+            chain: Chain::Ethereum,
+            raw_metadata: json!({
+                "topics": [ERC20_TRANSFER_TOPIC, &from_padded, &to_padded],
+                "data": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "gas_used": "0x5208",
+                "effective_gas_price": "0x3b9aca00",
+                "value": "0x0",
+                "from": "0x1111111111111111111111111111111111111111",
+                "to": wallet,
+            }),
+        };
+
+        // Second log: same tx hash, no gas fields (adapter omits them)
+        let second_log = Transaction {
+            id: Uuid::new_v4(),
+            user_id,
+            wallet_address: wallet.to_string(),
+            timestamp: 1700000000,
+            tx_hash: tx_hash.to_string(),
+            chain: Chain::Ethereum,
+            raw_metadata: json!({
+                "topics": [ERC20_TRANSFER_TOPIC, &from_padded, &to_padded],
+                "data": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            }),
+        };
+
+        let entries_1 = parse_evm_transaction(&first_log).unwrap();
+        let entries_2 = parse_evm_transaction(&second_log).unwrap();
+
+        let all_entries: Vec<_> = entries_1.iter().chain(entries_2.iter()).collect();
+
+        let fee_count = all_entries
+            .iter()
+            .filter(|e| matches!(e.entry_type, EntryType::Fee))
+            .count();
+        assert_eq!(
+            fee_count, 1,
+            "gas fee should appear exactly once across all logs of the same tx"
+        );
+    }
+
+    #[test]
+    fn test_gas_fields_absent_produces_no_fee() {
+        let metadata = json!({
+            "topics": [],
+            "data": "0x",
+        });
+        let tx = make_tx(metadata);
+        let entries = parse_evm_transaction(&tx).unwrap();
+        let fee_count = entries
+            .iter()
+            .filter(|e| matches!(e.entry_type, EntryType::Fee))
+            .count();
+        assert_eq!(fee_count, 0);
+    }
+
+    #[test]
     fn test_hex_to_bigdecimal() {
         // Small value
         assert_eq!(hex_to_bigdecimal("0xff"), BigDecimal::from(255));


### PR DESCRIPTION
## Summary

- Only attach tx-level fields (value, from, to, gas_used, effective_gas_price) to the first log entry per tx hash in the EVM adapter
- Previously every log for the same transaction received these fields, causing the parser to generate N duplicate gas fee and ETH value transfer entries
- Added tests verifying gas fees appear exactly once across multi-log transactions

## Test plan

- [x] New test `test_gas_fee_not_duplicated_across_logs` verifies only 1 fee entry across 2 logs sharing a tx hash
- [x] New test `test_gas_fields_absent_produces_no_fee` verifies no fee when gas fields are absent
- [x] All existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

Closes #51