### PR TITLE
feat: add last_block column and atomic checkpoint saves

### DIFF
--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -1,5 +1,5 @@
 use spectraplex_core::models::{Chain, EntryType, IndexerCheckpoint, LedgerEntry, Transaction};
-use sqlx::{postgres::PgPool, Row};
+use sqlx::{postgres::PgPool, Executor, Postgres, Row};
 
 fn chain_to_str(chain: &Chain) -> &'static str {
     match chain {
@@ -254,7 +254,7 @@ impl Repository {
     ) -> anyhow::Result<Option<IndexerCheckpoint>> {
         let row = sqlx::query(
             r#"
-            SELECT chain::text, wallet_address, last_signature, last_slot, last_timestamp
+            SELECT chain::text, wallet_address, last_signature, last_slot, last_block, last_timestamp
             FROM indexer_checkpoints
             WHERE chain = $1::chain_enum AND wallet_address = $2
             "#,
@@ -273,6 +273,7 @@ impl Repository {
                     wallet_address: row.try_get("wallet_address")?,
                     last_signature: row.try_get("last_signature")?,
                     last_slot: row.try_get("last_slot")?,
+                    last_block: row.try_get("last_block")?,
                     last_timestamp: row.try_get("last_timestamp")?,
                 }))
             }
@@ -281,16 +282,27 @@ impl Repository {
     }
 
     pub async fn save_checkpoint(&self, checkpoint: &IndexerCheckpoint) -> anyhow::Result<()> {
+        Self::save_checkpoint_with(&self.pool, checkpoint).await
+    }
+
+    pub async fn save_checkpoint_with<'e, E>(
+        executor: E,
+        checkpoint: &IndexerCheckpoint,
+    ) -> anyhow::Result<()>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let chain_str = chain_to_str(&checkpoint.chain);
 
         sqlx::query(
             r#"
-            INSERT INTO indexer_checkpoints (chain, wallet_address, last_signature, last_slot, last_timestamp, updated_at)
-            VALUES ($1::chain_enum, $2, $3, $4, $5, NOW())
+            INSERT INTO indexer_checkpoints (chain, wallet_address, last_signature, last_slot, last_block, last_timestamp, updated_at)
+            VALUES ($1::chain_enum, $2, $3, $4, $5, $6, NOW())
             ON CONFLICT (chain, wallet_address)
             DO UPDATE SET
                 last_signature = EXCLUDED.last_signature,
                 last_slot = EXCLUDED.last_slot,
+                last_block = EXCLUDED.last_block,
                 last_timestamp = EXCLUDED.last_timestamp,
                 updated_at = NOW()
             "#,
@@ -299,10 +311,70 @@ impl Repository {
         .bind(&checkpoint.wallet_address)
         .bind(&checkpoint.last_signature)
         .bind(checkpoint.last_slot)
+        .bind(checkpoint.last_block)
         .bind(checkpoint.last_timestamp)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
+        Ok(())
+    }
+
+    pub async fn save_transactions_with<'e, E>(
+        executor: E,
+        txs: &[Transaction],
+    ) -> anyhow::Result<()>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let mut query = String::from(
+            "INSERT INTO transactions (id, user_id, wallet_address, timestamp, tx_hash, chain, raw_metadata) VALUES ",
+        );
+        let mut args = sqlx::postgres::PgArguments::default();
+        for (i, tx) in txs.iter().enumerate() {
+            let chain_str = chain_to_str(&tx.chain);
+            let base = i * 7;
+            if i > 0 {
+                query.push_str(", ");
+            }
+            query.push_str(&format!(
+                "(${}, ${}, ${}, ${}, ${}, ${}::chain_enum, ${})",
+                base + 1,
+                base + 2,
+                base + 3,
+                base + 4,
+                base + 5,
+                base + 6,
+                base + 7
+            ));
+            use sqlx::Arguments;
+            args.add(tx.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(tx.user_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(&tx.wallet_address)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(tx.timestamp).map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(&tx.tx_hash).map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(chain_str).map_err(|e| anyhow::anyhow!("{e}"))?;
+            args.add(&tx.raw_metadata)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        query.push_str(" ON CONFLICT (chain, tx_hash) DO NOTHING");
+        sqlx::query_with(&query, args).execute(executor).await?;
+        Ok(())
+    }
+
+    pub async fn save_transactions_and_checkpoint(
+        &self,
+        txs: &[Transaction],
+        checkpoint: &IndexerCheckpoint,
+    ) -> anyhow::Result<()> {
+        let mut db_tx = self.pool.begin().await?;
+
+        for chunk in txs.chunks(Self::BATCH_SIZE) {
+            Self::save_transactions_with(&mut *db_tx, chunk).await?;
+        }
+        Self::save_checkpoint_with(&mut *db_tx, checkpoint).await?;
+
+        db_tx.commit().await?;
         Ok(())
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -118,6 +118,7 @@ async fn main() -> anyhow::Result<()> {
                             wallet = %wallet,
                             last_signature = ?cp.last_signature,
                             last_slot = ?cp.last_slot,
+                            last_block = ?cp.last_block,
                             last_timestamp = ?cp.last_timestamp,
                             "Resuming from checkpoint"
                         );
@@ -168,18 +169,23 @@ async fn main() -> anyhow::Result<()> {
             // Strategy: DB first, fallback to File
             if let Some(p) = pool {
                 let repo = Repository::new(p);
-                repo.save_transactions(&events).await?;
-                info!(count = events.len(), "Saved transactions to database");
-
                 if let Some(cp) = build_checkpoint(&chain, &wallet, &events) {
-                    repo.save_checkpoint(&cp).await?;
+                    repo.save_transactions_and_checkpoint(&events, &cp).await?;
+                    info!(count = events.len(), "Saved transactions to database");
                     info!(
                         chain = %chain,
                         wallet = %wallet,
                         last_signature = ?cp.last_signature,
                         last_slot = ?cp.last_slot,
+                        last_block = ?cp.last_block,
                         last_timestamp = ?cp.last_timestamp,
-                        "Checkpoint saved"
+                        "Checkpoint saved atomically"
+                    );
+                } else {
+                    repo.save_transactions(&events).await?;
+                    info!(
+                        count = events.len(),
+                        "Saved transactions to database (no checkpoint)"
                     );
                 }
             } else {
@@ -277,13 +283,17 @@ fn build_checkpoint(chain: &str, wallet: &str, txs: &[Transaction]) -> Option<In
     let last_timestamp = Some(latest.timestamp);
 
     let last_slot = match chain {
-        "ethereum" => txs
-            .iter()
-            .filter_map(|tx| tx.raw_metadata.get("block_number").and_then(|v| v.as_i64()))
-            .max(),
         "solana" => txs
             .iter()
             .filter_map(|tx| tx.raw_metadata.get("slot").and_then(|v| v.as_i64()))
+            .max(),
+        _ => None,
+    };
+
+    let last_block = match chain {
+        "ethereum" => txs
+            .iter()
+            .filter_map(|tx| tx.raw_metadata.get("block_number").and_then(|v| v.as_i64()))
             .max(),
         _ => None,
     };
@@ -293,6 +303,7 @@ fn build_checkpoint(chain: &str, wallet: &str, txs: &[Transaction]) -> Option<In
         wallet_address: wallet.to_string(),
         last_signature,
         last_slot,
+        last_block,
         last_timestamp,
     })
 }
@@ -344,7 +355,8 @@ mod tests {
         assert_eq!(cp.wallet_address, "0xwallet");
         assert_eq!(cp.last_signature, Some("0xbbb".to_string()));
         assert_eq!(cp.last_timestamp, Some(200));
-        assert_eq!(cp.last_slot, Some(2000));
+        assert_eq!(cp.last_block, Some(2000));
+        assert_eq!(cp.last_slot, None);
     }
 
     #[test]
@@ -359,6 +371,7 @@ mod tests {
         assert_eq!(cp.last_signature, Some("sig2".to_string()));
         assert_eq!(cp.last_timestamp, Some(400));
         assert_eq!(cp.last_slot, Some(6000));
+        assert_eq!(cp.last_block, None);
     }
 
     #[test]
@@ -373,6 +386,7 @@ mod tests {
         assert_eq!(cp.last_signature, Some("hash2".to_string()));
         assert_eq!(cp.last_timestamp, Some(600));
         assert_eq!(cp.last_slot, None);
+        assert_eq!(cp.last_block, None);
     }
 
     #[test]

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -49,6 +49,7 @@ pub struct IndexerCheckpoint {
     pub wallet_address: String,
     pub last_signature: Option<String>,
     pub last_slot: Option<i64>,
+    pub last_block: Option<i64>,
     pub last_timestamp: Option<i64>,
 }
 

--- a/migrations/20260218000000_add_last_block_to_checkpoints.sql
+++ b/migrations/20260218000000_add_last_block_to_checkpoints.sql
@@ -1,0 +1,1 @@
+ALTER TABLE indexer_checkpoints ADD COLUMN last_block BIGINT;


### PR DESCRIPTION
## Summary

- Add `last_block BIGINT` column to `indexer_checkpoints` table via migration for proper EVM block-based cursoring (separate from Solana's `last_slot`)
- Add generic `save_checkpoint_with` and `save_transactions_with` methods that accept any `sqlx::Executor` for composability
- Add `save_transactions_and_checkpoint` method that wraps both saves in a single `sqlx::Transaction` for atomicity
- Update `build_checkpoint()` to populate `last_block` from EVM transactions and `last_slot` from Solana transactions
- Wire atomic save into CLI ingestion pipeline when checkpoint is available

## Test plan

- [x] All 55 existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] 5 unit tests cover `build_checkpoint()` per-chain cursor extraction