### PR TITLE
fix: replace unmaintained dotenv with dotenvy (RUSTSEC-2021-0141)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,12 +2130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7095,7 +7089,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
- "dotenv",
+ "dotenvy",
  "http-body-util",
  "serde",
  "serde_json",
@@ -7116,7 +7110,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dotenv",
+ "dotenvy",
  "serde",
  "serde_json",
  "spectraplex-adapters",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,7 +14,7 @@ tower-http = { version = "0.5", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "bigdecimal"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 anyhow = "1.0"
 uuid = { version = "1.19", features = ["v4", "serde"] }
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -99,7 +99,7 @@ pub enum JobState {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let config = AppConfig::load()?;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.5.53", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
-dotenv = "0.15"
+dotenvy = "0.15"
 serde_json = "1.0.145"
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "macros", "uuid", "chrono", "json"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,7 +65,7 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     tracing_subscriber::fmt()
         .with_env_filter(


### PR DESCRIPTION
## Summary
- Replace `dotenv` 0.15.0 with `dotenvy` 0.15.7 in api and cli crates
- `dotenv` has been unmaintained since June 2020 (RUSTSEC-2021-0141)
- `dotenvy` is a maintained drop-in fork with identical API
- Zero behavior change: just dependency name and import path swap

## Changes
- `api/Cargo.toml`: `dotenv` -> `dotenvy`
- `cli/Cargo.toml`: `dotenv` -> `dotenvy`
- `api/src/main.rs`: `dotenv::dotenv()` -> `dotenvy::dotenv()`
- `cli/src/main.rs`: `dotenv::dotenv()` -> `dotenvy::dotenv()`
- `Cargo.lock`: removes old `dotenv` crate, adds `dotenvy`

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (105/105 tests)