### PR TITLE
feat: wire checkpoint resume cursors into all adapters

### DIFF
--- a/adapters/src/evm.rs
+++ b/adapters/src/evm.rs
@@ -9,7 +9,7 @@ use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::{Filter, Log};
 use governor::{Quota, RateLimiter};
 use serde_json::json;
-use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
+use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -112,15 +112,19 @@ impl ChainIngestor for EvmAdapter {
         wallet: &str,
         limit: usize,
         user_id: Uuid,
+        checkpoint: Option<&IndexerCheckpoint>,
     ) -> anyhow::Result<Vec<Transaction>> {
         let address: Address = wallet.parse()?;
 
         self.rate_limiter.until_ready().await;
         let latest_block = self.provider.get_block_number().await?;
 
-        // Scan backwards from head — limit translates to how many chunks to scan.
-        let total_blocks = (limit as u64) * self.block_chunk;
-        let from_block = latest_block.saturating_sub(total_blocks);
+        let from_block = if let Some(block) = checkpoint.and_then(|cp| cp.last_block) {
+            (block as u64).saturating_add(1)
+        } else {
+            let total_blocks = (limit as u64) * self.block_chunk;
+            latest_block.saturating_sub(total_blocks)
+        };
 
         let logs = self.fetch_logs(address, from_block, latest_block).await?;
 

--- a/adapters/src/hyperliquid.rs
+++ b/adapters/src/hyperliquid.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
+use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
 use uuid::Uuid;
 
 const HL_INFO_URL: &str = "https://api.hyperliquid.xyz/info";
@@ -163,26 +163,39 @@ impl ChainIngestor for HyperliquidAdapter {
         wallet: &str,
         limit: usize,
         user_id: Uuid,
+        checkpoint: Option<&IndexerCheckpoint>,
     ) -> anyhow::Result<Vec<Transaction>> {
         let mut transactions = Vec::new();
 
-        // 1. Fetch fills (trades)
+        // Resume timestamp in milliseconds (HL API uses ms).
+        // Add 1ms to avoid re-fetching the last seen event.
+        let resume_ms = checkpoint
+            .and_then(|cp| cp.last_timestamp)
+            .map(|ts| (ts * 1000) + 1)
+            .unwrap_or(0);
+
+        // 1. Fetch fills (trades) — the fills endpoint has no startTime param,
+        //    so we filter client-side.
         let fills = self.fetch_user_fills(wallet).await?;
-        for fill in fills.iter().take(limit) {
+        for fill in fills
+            .iter()
+            .filter(|f| f.time >= resume_ms as u64)
+            .take(limit)
+        {
             let raw = serde_json::to_value(fill)?;
             transactions.push(Transaction {
                 id: Uuid::new_v4(),
                 user_id,
                 wallet_address: wallet.to_string(),
-                timestamp: (fill.time / 1000) as i64, // HL timestamps are in ms
+                timestamp: (fill.time / 1000) as i64,
                 tx_hash: fill.hash.clone(),
                 chain: Chain::Hyperliquid,
                 raw_metadata: serde_json::json!({ "type": "fill", "data": raw }),
             });
         }
 
-        // 2. Fetch funding payments (from epoch 0 to get all)
-        let funding = self.fetch_user_funding(wallet, 0).await?;
+        // 2. Fetch funding payments
+        let funding = self.fetch_user_funding(wallet, resume_ms).await?;
         for entry in funding.iter().take(limit) {
             let raw = serde_json::to_value(entry)?;
             let hash = entry
@@ -201,7 +214,7 @@ impl ChainIngestor for HyperliquidAdapter {
         }
 
         // 3. Fetch non-funding ledger updates (deposits, withdrawals, liquidations)
-        let ledger_updates = self.fetch_user_ledger_updates(wallet, 0).await?;
+        let ledger_updates = self.fetch_user_ledger_updates(wallet, resume_ms).await?;
         for update in ledger_updates.iter().take(limit) {
             let raw = serde_json::to_value(update)?;
             transactions.push(Transaction {
@@ -346,6 +359,7 @@ mod tests {
                 "0x1234567890abcdef1234567890abcdef12345678",
                 10,
                 Uuid::new_v4(),
+                None,
             )
             .await
             .unwrap();
@@ -366,6 +380,69 @@ mod tests {
         // Check ledger update transaction
         let ledger_tx = &txs[2];
         assert_eq!(ledger_tx.raw_metadata["type"], "ledger_update");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_history_with_checkpoint_filters_old_data() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut stream = stream;
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let response_body = if request.contains("userFills") {
+                        r#"[{"coin":"BTC","px":"40000.0","sz":"0.1","side":"A","time":1700000000000,"hash":"0xold"}]"#
+                    } else {
+                        "[]"
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+
+        let checkpoint = IndexerCheckpoint {
+            chain: Chain::Hyperliquid,
+            wallet_address: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            last_signature: None,
+            last_slot: None,
+            last_block: None,
+            last_timestamp: Some(1700000000), // same second as mock data
+        };
+
+        let adapter = HyperliquidAdapter::with_base_url(&base_url);
+        let txs = adapter
+            .fetch_history(
+                "0x1234567890abcdef1234567890abcdef12345678",
+                10,
+                Uuid::new_v4(),
+                Some(&checkpoint),
+            )
+            .await
+            .unwrap();
+
+        // Fill at time=1700000000000ms should be filtered out because
+        // resume_ms = (1700000000 * 1000) + 1 = 1700000000001 > 1700000000000
+        assert_eq!(txs.len(), 0);
 
         server.abort();
     }

--- a/adapters/src/solana.rs
+++ b/adapters/src/solana.rs
@@ -1,7 +1,7 @@
-use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient};
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use solana_transaction_status::UiTransactionEncoding;
-use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
+use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::warn;
@@ -26,13 +26,22 @@ impl ChainIngestor for SolanaAdapter {
         wallet: &str,
         limit: usize,
         user_id: Uuid,
+        checkpoint: Option<&IndexerCheckpoint>,
     ) -> anyhow::Result<Vec<Transaction>> {
         let client = self.client.clone();
         let wallet = wallet.to_string();
+        let until_sig = checkpoint
+            .and_then(|cp| cp.last_signature.clone())
+            .and_then(|s| Signature::from_str(&s).ok());
 
         tokio::task::spawn_blocking(move || {
             let pubkey = Pubkey::from_str(&wallet)?;
-            let signatures = client.get_signatures_for_address(&pubkey)?;
+            let config = GetConfirmedSignaturesForAddress2Config {
+                until: until_sig,
+                limit: Some(limit),
+                ..Default::default()
+            };
+            let signatures = client.get_signatures_for_address_with_config(&pubkey, config)?;
 
             let mut transactions = Vec::new();
 

--- a/adapters/src/solana_grpc.rs
+++ b/adapters/src/solana_grpc.rs
@@ -14,7 +14,7 @@ use yellowstone_grpc_proto::prelude::{
     SubscribeRequestFilterTransactions,
 };
 
-use spectraplex_core::models::{Chain, ChainIngestor, Transaction};
+use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
 
 /// Default program IDs to monitor when none are specified.
 const DEFAULT_PROGRAM_IDS: &[&str] = &[
@@ -288,6 +288,7 @@ impl ChainIngestor for SolanaGrpcAdapter {
         wallet: &str,
         limit: usize,
         user_id: Uuid,
+        _checkpoint: Option<&IndexerCheckpoint>,
     ) -> anyhow::Result<Vec<Transaction>> {
         let mut client = self.connect_client().await?;
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -11,7 +11,7 @@ use spectraplex_adapters::{
     repo::Repository, solana::SolanaAdapter, solana_parser,
 };
 use spectraplex_core::config::AppConfig;
-use spectraplex_core::models::{ChainIngestor, LedgerEntry, Transaction};
+use spectraplex_core::models::{ChainIngestor, IndexerCheckpoint, LedgerEntry, Transaction};
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -223,18 +223,30 @@ async fn trigger_ingest(
         }
 
         let result = async {
+            let checkpoint: Option<IndexerCheckpoint> = state_clone
+                .repo
+                .get_checkpoint(&chain, &wallet)
+                .await
+                .unwrap_or(None);
+
             let events: Vec<Transaction> = match chain.as_str() {
                 "hyperliquid" => {
                     let adapter = HyperliquidAdapter::new();
-                    adapter.fetch_history(&wallet, limit, user_id).await?
+                    adapter
+                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                        .await?
                 }
                 "ethereum" => {
                     let adapter = EvmAdapter::new(&state_clone.config.evm_rpc_url).await?;
-                    adapter.fetch_history(&wallet, limit, user_id).await?
+                    adapter
+                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                        .await?
                 }
                 _ => {
                     let adapter = SolanaAdapter::new(&state_clone.config.solana_rpc_url);
-                    adapter.fetch_history(&wallet, limit, user_id).await?
+                    adapter
+                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                        .await?
                 }
             };
             state_clone.repo.save_transactions(&events).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -142,23 +142,31 @@ async fn main() -> anyhow::Result<()> {
                                 adapter.checkpoint().update(slot as u64);
                             }
                         }
-                        adapter.fetch_history(&wallet, limit, user_id).await?
+                        adapter
+                            .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                            .await?
                     } else if let Some(rpc_url) = rpc {
                         let adapter = SolanaAdapter::new(&rpc_url);
-                        adapter.fetch_history(&wallet, limit, user_id).await?
+                        adapter
+                            .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                            .await?
                     } else {
                         anyhow::bail!("Either --grpc-url or --rpc must be provided for Solana");
                     }
                 }
                 "hyperliquid" => {
                     let adapter = HyperliquidAdapter::new();
-                    adapter.fetch_history(&wallet, limit, user_id).await?
+                    adapter
+                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                        .await?
                 }
                 "ethereum" => {
                     let rpc_url =
                         rpc.ok_or_else(|| anyhow::anyhow!("--rpc is required for Ethereum"))?;
                     let adapter = EvmAdapter::new(&rpc_url).await?;
-                    adapter.fetch_history(&wallet, limit, user_id).await?
+                    adapter
+                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
+                        .await?
                 }
                 _ => {
                     warn!(chain = %chain, "Unsupported chain");

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -60,5 +60,6 @@ pub trait ChainIngestor {
         wallet: &str,
         limit: usize,
         user_id: Uuid,
+        checkpoint: Option<&IndexerCheckpoint>,
     ) -> anyhow::Result<Vec<Transaction>>;
 }


### PR DESCRIPTION
## Summary

- Add `checkpoint: Option<&IndexerCheckpoint>` parameter to `ChainIngestor::fetch_history` trait
- EVM: use `last_block + 1` as `from_block` instead of scanning backwards from chain head
- Hyperliquid: use `last_timestamp` to filter fills client-side and as `startTime` for funding/ledger API calls
- Solana RPC: use `last_signature` as `until` param for `getSignaturesForAddress` to fetch only newer transactions
- Solana gRPC: accepts the new parameter (already manages slot checkpoint internally)
- API `trigger_ingest`: reads checkpoint from DB before ingestion, matching CLI behavior
- Add mock server test verifying Hyperliquid checkpoint timestamp filtering

## Test plan

- [x] All 106 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] New test: `test_fetch_history_with_checkpoint_filters_old_data` verifies fills are filtered when checkpoint timestamp >= fill time