### PR TITLE
feat: save checkpoints atomically in API trigger_ingest

### DIFF
--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -39,6 +39,44 @@ fn str_to_entry_type(s: &str) -> EntryType {
     }
 }
 
+pub fn build_checkpoint(
+    chain: &str,
+    wallet: &str,
+    txs: &[Transaction],
+) -> Option<IndexerCheckpoint> {
+    if txs.is_empty() {
+        return None;
+    }
+
+    let chain_enum = str_to_chain(chain).ok()?;
+    let latest = txs.iter().max_by_key(|tx| tx.timestamp)?;
+
+    let last_slot = match chain {
+        "solana" => txs
+            .iter()
+            .filter_map(|tx| tx.raw_metadata.get("slot").and_then(|v| v.as_i64()))
+            .max(),
+        _ => None,
+    };
+
+    let last_block = match chain {
+        "ethereum" => txs
+            .iter()
+            .filter_map(|tx| tx.raw_metadata.get("block_number").and_then(|v| v.as_i64()))
+            .max(),
+        _ => None,
+    };
+
+    Some(IndexerCheckpoint {
+        chain: chain_enum,
+        wallet_address: wallet.to_string(),
+        last_signature: Some(latest.tx_hash.clone()),
+        last_slot,
+        last_block,
+        last_timestamp: Some(latest.timestamp),
+    })
+}
+
 pub struct Repository {
     pool: PgPool,
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -8,8 +8,13 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use spectraplex_adapters::{
-    evm::EvmAdapter, evm_parser, hyperliquid::HyperliquidAdapter, hyperliquid_parser,
-    repo::Repository, solana::SolanaAdapter, solana_parser,
+    evm::EvmAdapter,
+    evm_parser,
+    hyperliquid::HyperliquidAdapter,
+    hyperliquid_parser,
+    repo::{build_checkpoint, Repository},
+    solana::SolanaAdapter,
+    solana_parser,
 };
 use spectraplex_core::config::AppConfig;
 use spectraplex_core::models::{ChainIngestor, IndexerCheckpoint, LedgerEntry, Transaction};
@@ -282,8 +287,16 @@ async fn trigger_ingest(
                         .await?
                 }
             };
-            state_clone.repo.save_transactions(&events).await?;
-            Ok::<usize, anyhow::Error>(events.len())
+            let count = events.len();
+            if let Some(cp) = build_checkpoint(&chain, &wallet, &events) {
+                state_clone
+                    .repo
+                    .save_transactions_and_checkpoint(&events, &cp)
+                    .await?;
+            } else {
+                state_clone.repo.save_transactions(&events).await?;
+            }
+            Ok::<usize, anyhow::Error>(count)
         }
         .await;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,15 @@
 use clap::{Parser, Subcommand};
 use spectraplex_adapters::{
-    evm::EvmAdapter, evm_parser, hyperliquid::HyperliquidAdapter, hyperliquid_parser,
-    repo::Repository, solana::SolanaAdapter, solana_grpc::SolanaGrpcAdapter, solana_parser,
+    evm::EvmAdapter,
+    evm_parser,
+    hyperliquid::HyperliquidAdapter,
+    hyperliquid_parser,
+    repo::{build_checkpoint, Repository},
+    solana::SolanaAdapter,
+    solana_grpc::SolanaGrpcAdapter,
+    solana_parser,
 };
-use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
+use spectraplex_core::models::{ChainIngestor, Transaction};
 use sqlx::postgres::PgPoolOptions;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -273,54 +279,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_checkpoint(chain: &str, wallet: &str, txs: &[Transaction]) -> Option<IndexerCheckpoint> {
-    if txs.is_empty() {
-        return None;
-    }
-
-    let chain_enum = match chain {
-        "solana" => Chain::Solana,
-        "ethereum" => Chain::Ethereum,
-        "hyperliquid" => Chain::Hyperliquid,
-        _ => return None,
-    };
-
-    let latest = txs.iter().max_by_key(|tx| tx.timestamp)?;
-
-    let last_signature = Some(latest.tx_hash.clone());
-    let last_timestamp = Some(latest.timestamp);
-
-    let last_slot = match chain {
-        "solana" => txs
-            .iter()
-            .filter_map(|tx| tx.raw_metadata.get("slot").and_then(|v| v.as_i64()))
-            .max(),
-        _ => None,
-    };
-
-    let last_block = match chain {
-        "ethereum" => txs
-            .iter()
-            .filter_map(|tx| tx.raw_metadata.get("block_number").and_then(|v| v.as_i64()))
-            .max(),
-        _ => None,
-    };
-
-    Some(IndexerCheckpoint {
-        chain: chain_enum,
-        wallet_address: wallet.to_string(),
-        last_signature,
-        last_slot,
-        last_block,
-        last_timestamp,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::Parser;
     use serde_json::json;
+    use spectraplex_core::models::Chain;
 
     fn make_tx(
         chain: Chain,


### PR DESCRIPTION
## Summary

- Move `build_checkpoint` from CLI's `main.rs` to `adapters::repo` as a shared public function, eliminating duplication
- API `trigger_ingest` now builds a checkpoint from ingested events and saves it atomically via `save_transactions_and_checkpoint`, matching CLI behavior
- CLI updated to import shared `build_checkpoint` from adapters crate

## Test plan

- [x] All 113 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Existing `build_checkpoint` tests in CLI still pass (now test the shared function)