### PR TITLE
fix: data integrity bugs (#61, #70, #72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5171,6 +5171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8470,6 +8476,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 tracing = "0.1"
 bs58 = "0.5"
-uuid = { version = "1.19.0", features = ["v4", "serde"] }
+uuid = { version = "1.19.0", features = ["v4", "v5", "serde"] }
 serde_json = "1.0"
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "macros", "uuid", "chrono", "json", "bigdecimal"] }
 chrono = { version = "0.4.42", features = ["serde"] }

--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -1,6 +1,7 @@
 use bigdecimal::BigDecimal;
 use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
-use uuid::Uuid;
+
+use crate::deterministic_id;
 
 /// ERC-20 Transfer event signature: keccak256("Transfer(address,address,uint256)")
 const ERC20_TRANSFER_TOPIC: &str =
@@ -14,6 +15,7 @@ const ERC20_TRANSFER_TOPIC: &str =
 /// - Gas fees (from raw_metadata)
 pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry>> {
     let mut entries = Vec::new();
+    let mut entry_index: u32 = 0;
     let wallet = tx.wallet_address.to_lowercase();
 
     // 1. Try to parse as an ERC-20 Transfer log
@@ -47,7 +49,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                 if from == wallet {
                     // Outgoing transfer
                     entries.push(LedgerEntry {
-                        id: Uuid::new_v4(),
+                        id: deterministic_id(tx.id, entry_index),
                         transaction_id: tx.id,
                         user_id: tx.user_id,
                         wallet_address: tx.wallet_address.clone(),
@@ -56,12 +58,13 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                         entry_type: EntryType::Transfer,
                         fiat_value: None,
                     });
+                    entry_index += 1;
                 }
 
                 if to == wallet {
                     // Incoming transfer
                     entries.push(LedgerEntry {
-                        id: Uuid::new_v4(),
+                        id: deterministic_id(tx.id, entry_index),
                         transaction_id: tx.id,
                         user_id: tx.user_id,
                         wallet_address: tx.wallet_address.clone(),
@@ -70,6 +73,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                         entry_type: EntryType::Transfer,
                         fiat_value: None,
                     });
+                    entry_index += 1;
                 }
             }
         }
@@ -97,7 +101,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
 
             if from == wallet {
                 entries.push(LedgerEntry {
-                    id: Uuid::new_v4(),
+                    id: deterministic_id(tx.id, entry_index),
                     transaction_id: tx.id,
                     user_id: tx.user_id,
                     wallet_address: tx.wallet_address.clone(),
@@ -106,11 +110,12 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                     entry_type: EntryType::Transfer,
                     fiat_value: None,
                 });
+                entry_index += 1;
             }
 
             if to == wallet {
                 entries.push(LedgerEntry {
-                    id: Uuid::new_v4(),
+                    id: deterministic_id(tx.id, entry_index),
                     transaction_id: tx.id,
                     user_id: tx.user_id,
                     wallet_address: tx.wallet_address.clone(),
@@ -119,6 +124,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                     entry_type: EntryType::Transfer,
                     fiat_value: None,
                 });
+                entry_index += 1;
             }
         }
     }
@@ -137,7 +143,7 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
         if fee_wei > 0 {
             let fee_eth = wei_to_eth(fee_wei);
             entries.push(LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, entry_index),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -146,9 +152,11 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                 entry_type: EntryType::Fee,
                 fiat_value: None,
             });
+            entry_index += 1;
         }
     }
 
+    let _ = entry_index;
     Ok(entries)
 }
 
@@ -254,6 +262,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use spectraplex_core::models::Chain;
+    use uuid::Uuid;
 
     fn make_tx(metadata: serde_json::Value) -> Transaction {
         Transaction {
@@ -526,5 +535,22 @@ mod tests {
         // Value larger than u128 (u128::MAX + 1)
         let over_u128 = hex_to_bigdecimal("0x100000000000000000000000000000000");
         assert!(over_u128 > BigDecimal::from(u128::MAX));
+    }
+
+    #[test]
+    fn test_deterministic_ids_are_stable() {
+        let tx = make_tx(json!({
+            "topics": [],
+            "data": "0x",
+            "gas_used": "0x5208",
+            "effective_gas_price": "0x3b9aca00",
+        }));
+        let entries1 = parse_evm_transaction(&tx).unwrap();
+        let entries2 = parse_evm_transaction(&tx).unwrap();
+
+        assert_eq!(entries1.len(), entries2.len());
+        for (a, b) in entries1.iter().zip(entries2.iter()) {
+            assert_eq!(a.id, b.id);
+        }
     }
 }

--- a/adapters/src/hyperliquid_parser.rs
+++ b/adapters/src/hyperliquid_parser.rs
@@ -2,8 +2,8 @@ use bigdecimal::BigDecimal;
 use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
 use std::str::FromStr;
 use tracing::warn;
-use uuid::Uuid;
 
+use crate::deterministic_id;
 use crate::hyperliquid::{HlFill, HlFundingEntry, HlLedgerUpdate};
 
 pub fn parse_hyperliquid_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry>> {
@@ -24,6 +24,7 @@ pub fn parse_hyperliquid_transaction(tx: &Transaction) -> anyhow::Result<Vec<Led
 fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<LedgerEntry>> {
     let fill: HlFill = serde_json::from_value(data.clone())?;
     let mut entries = Vec::new();
+    let mut entry_index: u32 = 0;
 
     let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
     let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
@@ -35,7 +36,7 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
     let signed_size = if fill.side == "B" { size } else { -size };
 
     entries.push(LedgerEntry {
-        id: Uuid::new_v4(),
+        id: deterministic_id(tx.id, entry_index),
         transaction_id: tx.id,
         user_id: tx.user_id,
         wallet_address: tx.wallet_address.clone(),
@@ -44,6 +45,7 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
         entry_type: EntryType::Trade,
         fiat_value: Some(fiat_value),
     });
+    entry_index += 1;
 
     // Fee entry (if present)
     if let Some(ref fee_str) = fill.fee {
@@ -51,7 +53,7 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
         if fee != BigDecimal::from(0) {
             let fee_token = fill.fee_token.as_deref().unwrap_or("USDC");
             entries.push(LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, entry_index),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -60,6 +62,7 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
                 entry_type: EntryType::Fee,
                 fiat_value: None,
             });
+            entry_index += 1;
         }
     }
 
@@ -68,7 +71,7 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
         let pnl = BigDecimal::from_str(pnl_str).unwrap_or_default();
         if pnl != BigDecimal::from(0) {
             entries.push(LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, entry_index),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -77,9 +80,11 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
                 entry_type: EntryType::Income,
                 fiat_value: None,
             });
+            entry_index += 1;
         }
     }
 
+    let _ = entry_index;
     Ok(entries)
 }
 
@@ -89,7 +94,7 @@ fn parse_funding(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<V
 
     // Funding payments: positive = received, negative = paid
     Ok(vec![LedgerEntry {
-        id: Uuid::new_v4(),
+        id: deterministic_id(tx.id, 0),
         transaction_id: tx.id,
         user_id: tx.user_id,
         wallet_address: tx.wallet_address.clone(),
@@ -114,7 +119,7 @@ fn parse_ledger_update(
             let usdc = delta["usdc"].as_str().unwrap_or("0");
             let amount = BigDecimal::from_str(usdc).unwrap_or_default();
             Ok(vec![LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -128,7 +133,7 @@ fn parse_ledger_update(
             let usdc = delta["usdc"].as_str().unwrap_or("0");
             let amount = BigDecimal::from_str(usdc).unwrap_or_default();
             Ok(vec![LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -146,7 +151,7 @@ fn parse_ledger_update(
                 .unwrap_or("0");
             let amount = BigDecimal::from_str(usdc).unwrap_or_default();
             Ok(vec![LedgerEntry {
-                id: Uuid::new_v4(),
+                id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
                 user_id: tx.user_id,
                 wallet_address: tx.wallet_address.clone(),
@@ -167,6 +172,7 @@ fn parse_ledger_update(
 mod tests {
     use super::*;
     use spectraplex_core::models::Chain;
+    use uuid::Uuid;
 
     fn make_tx(raw_type: &str, data: serde_json::Value) -> Transaction {
         Transaction {

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -7,3 +7,45 @@ pub mod repo;
 pub mod solana;
 pub mod solana_grpc;
 pub mod solana_parser;
+
+use uuid::Uuid;
+
+const LEDGER_ENTRY_NS: Uuid = Uuid::from_bytes([
+    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30,
+    0xc8,
+]);
+
+pub fn deterministic_id(transaction_id: Uuid, entry_index: u32) -> Uuid {
+    let name = format!("{}:{}", transaction_id, entry_index);
+    Uuid::new_v5(&LEDGER_ENTRY_NS, name.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_id_is_stable() {
+        let tx_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let id1 = deterministic_id(tx_id, 0);
+        let id2 = deterministic_id(tx_id, 0);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_deterministic_id_varies_by_index() {
+        let tx_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let id0 = deterministic_id(tx_id, 0);
+        let id1 = deterministic_id(tx_id, 1);
+        assert_ne!(id0, id1);
+    }
+
+    #[test]
+    fn test_deterministic_id_varies_by_tx() {
+        let tx_a = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let tx_b = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        let id_a = deterministic_id(tx_a, 0);
+        let id_b = deterministic_id(tx_b, 0);
+        assert_ne!(id_a, id_b);
+    }
+}

--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -5,10 +5,12 @@ use solana_transaction_status::{
 };
 use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
 use std::str::FromStr;
-use uuid::Uuid;
+
+use crate::deterministic_id;
 
 pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry>> {
     let mut entries = Vec::new();
+    let mut entry_index: u32 = 0;
 
     let sol_tx: EncodedConfirmedTransactionWithStatusMeta =
         serde_json::from_value(tx.raw_metadata.clone())?;
@@ -38,9 +40,9 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                 // If this wallet is the fee payer, separate fee from the net transfer
                 if is_fee_payer && fee_lamports > 0 {
                     // Fee entry (always negative)
-                    let fee_amount = lamports_to_sol(-(fee_lamports as i64));
+                    let fee_amount = lamports_to_sol(-(fee_lamports as i128));
                     entries.push(LedgerEntry {
-                        id: Uuid::new_v4(),
+                        id: deterministic_id(tx.id, entry_index),
                         transaction_id: tx.id,
                         user_id: tx.user_id,
                         wallet_address: tx.wallet_address.clone(),
@@ -49,13 +51,14 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                         entry_type: EntryType::Fee,
                         fiat_value: None,
                     });
+                    entry_index += 1;
 
                     // Net transfer amount = total balance change + fee (since fee is included in the balance change)
-                    let transfer_lamports = lamport_change + fee_lamports as i64;
+                    let transfer_lamports = lamport_change + fee_lamports as i128;
                     if transfer_lamports != 0 {
                         let transfer_amount = lamports_to_sol(transfer_lamports);
                         entries.push(LedgerEntry {
-                            id: Uuid::new_v4(),
+                            id: deterministic_id(tx.id, entry_index),
                             transaction_id: tx.id,
                             user_id: tx.user_id,
                             wallet_address: tx.wallet_address.clone(),
@@ -64,12 +67,13 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                             entry_type: EntryType::Transfer,
                             fiat_value: None,
                         });
+                        entry_index += 1;
                     }
                 } else if lamport_change != 0 {
                     // Non-fee-payer: entire balance change is a transfer
                     let amount = lamports_to_sol(lamport_change);
                     entries.push(LedgerEntry {
-                        id: Uuid::new_v4(),
+                        id: deterministic_id(tx.id, entry_index),
                         transaction_id: tx.id,
                         user_id: tx.user_id,
                         wallet_address: tx.wallet_address.clone(),
@@ -78,6 +82,7 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                         entry_type: EntryType::Transfer,
                         fiat_value: None,
                     });
+                    entry_index += 1;
                 }
             }
         }
@@ -110,7 +115,7 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                         let amount = token_raw_to_decimal(delta_raw, decimals);
                         let symbol = spl_token_symbol(&mint);
                         entries.push(LedgerEntry {
-                            id: Uuid::new_v4(),
+                            id: deterministic_id(tx.id, entry_index),
                             transaction_id: tx.id,
                             user_id: tx.user_id,
                             wallet_address: tx.wallet_address.clone(),
@@ -119,24 +124,27 @@ pub fn parse_solana_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEn
                             entry_type: EntryType::Transfer,
                             fiat_value: None,
                         });
+                        entry_index += 1;
                     }
                 }
             }
         }
     }
 
+    let _ = entry_index;
     Ok(entries)
 }
 
 /// Extract the raw lamport balance change for a given account index.
-fn extract_sol_change_lamports(meta: &UiTransactionStatusMeta, wallet_index: usize) -> i64 {
-    let pre = meta.pre_balances.get(wallet_index).copied().unwrap_or(0) as i64;
-    let post = meta.post_balances.get(wallet_index).copied().unwrap_or(0) as i64;
+/// Uses i128 to avoid truncation when u64 values exceed i64::MAX.
+fn extract_sol_change_lamports(meta: &UiTransactionStatusMeta, wallet_index: usize) -> i128 {
+    let pre = meta.pre_balances.get(wallet_index).copied().unwrap_or(0) as i128;
+    let post = meta.post_balances.get(wallet_index).copied().unwrap_or(0) as i128;
     post - pre
 }
 
-/// Convert lamports (i64) to SOL as BigDecimal without floating-point precision loss.
-fn lamports_to_sol(lamports: i64) -> BigDecimal {
+/// Convert lamports (i128) to SOL as BigDecimal without floating-point precision loss.
+fn lamports_to_sol(lamports: i128) -> BigDecimal {
     let raw = BigDecimal::from_str(&format!("{}", lamports)).unwrap();
     let divisor = BigDecimal::from_str("1000000000").unwrap();
     raw / divisor
@@ -164,5 +172,59 @@ fn spl_token_symbol(mint: &str) -> String {
         "RLBxxFkseAZ4RgJH3Sqn8jXxhmGoz9jWxDNJMh8pL7a" => "RLSOL".to_string(),
         "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn" => "jitoSOL".to_string(),
         _ => mint.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_lamports_to_sol_large_positive() {
+        let result = lamports_to_sol(10_000_000_000i128);
+        assert_eq!(result, BigDecimal::from(10));
+    }
+
+    #[test]
+    fn test_lamports_to_sol_negative() {
+        let result = lamports_to_sol(-1_000_000_000i128);
+        assert_eq!(result, BigDecimal::from(-1));
+    }
+
+    #[test]
+    fn test_lamports_to_sol_beyond_i64_max() {
+        let large: i128 = i64::MAX as i128 + 1_000_000_000;
+        let result = lamports_to_sol(large);
+        let expected = BigDecimal::from_str(&format!("{}", large)).unwrap()
+            / BigDecimal::from_str("1000000000").unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_extract_sol_change_no_truncation() {
+        use solana_transaction_status::UiTransactionStatusMeta;
+
+        let pre_val: u64 = u64::MAX - 1_000_000_000;
+        let post_val: u64 = u64::MAX;
+        let meta = UiTransactionStatusMeta {
+            err: None,
+            status: Ok(()),
+            fee: 0,
+            pre_balances: vec![pre_val],
+            post_balances: vec![post_val],
+            inner_instructions: solana_transaction_status::option_serializer::OptionSerializer::None,
+            log_messages: solana_transaction_status::option_serializer::OptionSerializer::None,
+            pre_token_balances: solana_transaction_status::option_serializer::OptionSerializer::None,
+            post_token_balances: solana_transaction_status::option_serializer::OptionSerializer::None,
+            rewards: solana_transaction_status::option_serializer::OptionSerializer::None,
+            loaded_addresses: solana_transaction_status::option_serializer::OptionSerializer::None,
+            return_data: solana_transaction_status::option_serializer::OptionSerializer::None,
+            compute_units_consumed: solana_transaction_status::option_serializer::OptionSerializer::None,
+            cost_units: solana_transaction_status::option_serializer::OptionSerializer::None,
+        };
+
+        let change = extract_sol_change_lamports(&meta, 0);
+        assert_eq!(change, 1_000_000_000i128);
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -12,7 +12,7 @@ use spectraplex_adapters::{
     repo::Repository, solana::SolanaAdapter, solana_parser,
 };
 use spectraplex_core::config::AppConfig;
-use spectraplex_core::models::{ChainIngestor, IndexerCheckpoint, LedgerEntry, Transaction};
+use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, LedgerEntry, Transaction};
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -282,8 +282,16 @@ async fn trigger_ingest(
                         .await?
                 }
             };
-            state_clone.repo.save_transactions(&events).await?;
-            Ok::<usize, anyhow::Error>(events.len())
+            let count = events.len();
+            if let Some(cp) = build_checkpoint(&chain, &wallet, &events) {
+                state_clone
+                    .repo
+                    .save_transactions_and_checkpoint(&events, &cp)
+                    .await?;
+            } else {
+                state_clone.repo.save_transactions(&events).await?;
+            }
+            Ok::<usize, anyhow::Error>(count)
         }
         .await;
 
@@ -445,6 +453,49 @@ async fn get_ledger(
         .await
         .map_err(AppError::internal)?;
     Ok(Json(entries))
+}
+
+fn build_checkpoint(chain: &str, wallet: &str, txs: &[Transaction]) -> Option<IndexerCheckpoint> {
+    if txs.is_empty() {
+        return None;
+    }
+
+    let chain_enum = match chain {
+        "solana" => Chain::Solana,
+        "ethereum" => Chain::Ethereum,
+        "hyperliquid" => Chain::Hyperliquid,
+        _ => return None,
+    };
+
+    let latest = txs.iter().max_by_key(|tx| tx.timestamp)?;
+
+    let last_signature = Some(latest.tx_hash.clone());
+    let last_timestamp = Some(latest.timestamp);
+
+    let last_slot = match chain {
+        "solana" => txs
+            .iter()
+            .filter_map(|tx| tx.raw_metadata.get("slot").and_then(|v| v.as_i64()))
+            .max(),
+        _ => None,
+    };
+
+    let last_block = match chain {
+        "ethereum" => txs
+            .iter()
+            .filter_map(|tx| tx.raw_metadata.get("block_number").and_then(|v| v.as_i64()))
+            .max(),
+        _ => None,
+    };
+
+    Some(IndexerCheckpoint {
+        chain: chain_enum,
+        wallet_address: wallet.to_string(),
+        last_signature,
+        last_slot,
+        last_block,
+        last_timestamp,
+    })
 }
 
 #[cfg(test)]
@@ -924,5 +975,85 @@ mod tests {
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn make_tx(
+        chain: Chain,
+        tx_hash: &str,
+        timestamp: i64,
+        metadata: serde_json::Value,
+    ) -> Transaction {
+        Transaction {
+            id: Uuid::new_v4(),
+            user_id: Uuid::nil(),
+            wallet_address: "test_wallet".to_string(),
+            timestamp,
+            tx_hash: tx_hash.to_string(),
+            chain,
+            raw_metadata: metadata,
+        }
+    }
+
+    #[test]
+    fn test_build_checkpoint_empty() {
+        assert!(build_checkpoint("solana", "wallet", &[]).is_none());
+    }
+
+    #[test]
+    fn test_build_checkpoint_unknown_chain() {
+        let tx = make_tx(Chain::Ethereum, "0xaaa", 100, serde_json::json!({}));
+        assert!(build_checkpoint("bitcoin", "wallet", &[tx]).is_none());
+    }
+
+    #[test]
+    fn test_build_checkpoint_solana() {
+        let txs = vec![
+            make_tx(
+                Chain::Solana,
+                "sig1",
+                100,
+                serde_json::json!({"slot": 5000}),
+            ),
+            make_tx(
+                Chain::Solana,
+                "sig2",
+                200,
+                serde_json::json!({"slot": 6000}),
+            ),
+        ];
+        let cp = build_checkpoint("solana", "wallet", &txs).unwrap();
+        assert!(matches!(cp.chain, Chain::Solana));
+        assert_eq!(cp.last_signature, Some("sig2".to_string()));
+        assert_eq!(cp.last_timestamp, Some(200));
+        assert_eq!(cp.last_slot, Some(6000));
+        assert_eq!(cp.last_block, None);
+    }
+
+    #[test]
+    fn test_build_checkpoint_ethereum() {
+        let txs = vec![make_tx(
+            Chain::Ethereum,
+            "0xaaa",
+            100,
+            serde_json::json!({"block_number": 1000}),
+        )];
+        let cp = build_checkpoint("ethereum", "0xwallet", &txs).unwrap();
+        assert!(matches!(cp.chain, Chain::Ethereum));
+        assert_eq!(cp.last_block, Some(1000));
+        assert_eq!(cp.last_slot, None);
+    }
+
+    #[test]
+    fn test_build_checkpoint_hyperliquid() {
+        let txs = vec![make_tx(
+            Chain::Hyperliquid,
+            "hash1",
+            500,
+            serde_json::json!({}),
+        )];
+        let cp = build_checkpoint("hyperliquid", "0xhl", &txs).unwrap();
+        assert!(matches!(cp.chain, Chain::Hyperliquid));
+        assert_eq!(cp.last_signature, Some("hash1".to_string()));
+        assert_eq!(cp.last_timestamp, Some(500));
     }
 }


### PR DESCRIPTION
## Summary

- **#61 - Deterministic ledger entry IDs**: Replace `Uuid::new_v4()` with UUID v5 derived from `(transaction_id, entry_index)` in all parsers (Solana, EVM, Hyperliquid). The existing `ON CONFLICT (id) DO NOTHING` now correctly deduplicates on re-ingestion instead of creating duplicates every time.
- **#70 - API checkpoint save**: The API ingest handler now builds a checkpoint from fetched transactions and calls `save_transactions_and_checkpoint()` (matching the CLI behavior), so resume cursors are persisted after API-driven ingestion.
- **#72 - Solana u64 truncation**: `extract_sol_change_lamports` now uses `i128` for the subtraction instead of casting `u64` to `i64`, preventing silent truncation when balances exceed `i64::MAX` (~9.2 SOL).

## Test plan

- [x] All 126 existing + new tests pass via `cargo test`
- [x] New tests for deterministic ID stability, u64 truncation edge case, and API checkpoint building