### PR TITLE
feat: add /v1/balances/:wallet endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,6 +7043,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "bigdecimal",
  "dotenvy",
  "http-body-util",
  "serde",

--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -285,6 +285,56 @@ impl Repository {
         Ok(entries)
     }
 
+    pub async fn get_balances(
+        &self,
+        wallet: &str,
+        at: Option<i64>,
+    ) -> anyhow::Result<Vec<(String, bigdecimal::BigDecimal)>> {
+        let rows = match at {
+            Some(ts) => {
+                sqlx::query(
+                    r#"
+                    SELECT le.asset_symbol, SUM(le.amount) as balance
+                    FROM ledger_entries le
+                    JOIN transactions t ON le.transaction_id = t.id
+                    WHERE le.wallet_address = $1 AND t.timestamp <= $2
+                    GROUP BY le.asset_symbol
+                    HAVING SUM(le.amount) != 0
+                    ORDER BY le.asset_symbol
+                    "#,
+                )
+                .bind(wallet)
+                .bind(ts)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            None => {
+                sqlx::query(
+                    r#"
+                    SELECT asset_symbol, SUM(amount) as balance
+                    FROM ledger_entries
+                    WHERE wallet_address = $1
+                    GROUP BY asset_symbol
+                    HAVING SUM(amount) != 0
+                    ORDER BY asset_symbol
+                    "#,
+                )
+                .bind(wallet)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+
+        let mut balances = Vec::new();
+        for row in rows {
+            balances.push((
+                row.try_get::<String, _>("asset_symbol")?,
+                row.try_get::<bigdecimal::BigDecimal, _>("balance")?,
+            ));
+        }
+        Ok(balances)
+    }
+
     pub async fn get_checkpoint(
         &self,
         chain: &str,

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "bigdecimal"] }
 dotenvy = "0.15"
 anyhow = "1.0"
+bigdecimal = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.19", features = ["v4", "serde"] }
 subtle = "2"
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -6,6 +6,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 use spectraplex_adapters::{
     evm::EvmAdapter,
@@ -159,6 +160,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/transactions/{wallet}", get(get_transactions))
         .route("/v1/ledger/{wallet}", get(get_ledger))
         .route("/v1/export/{wallet}", get(export_ledger))
+        .route("/v1/balances/{wallet}", get(get_balances))
         .layer(middleware::from_fn_with_state(
             Arc::clone(&shared_state),
             require_auth,
@@ -248,6 +250,17 @@ struct PaginationParams {
 #[derive(Deserialize)]
 struct ExportParams {
     format: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BalanceParams {
+    at: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct AssetBalance {
+    asset_symbol: String,
+    balance: BigDecimal,
 }
 
 fn clamp_limit(limit: Option<i64>) -> i64 {
@@ -690,6 +703,28 @@ async fn export_ledger(
     }
 }
 
+async fn get_balances(
+    State(state): State<Arc<AppState>>,
+    Path(wallet): Path<String>,
+    Query(params): Query<BalanceParams>,
+) -> Result<Json<Vec<AssetBalance>>, AppError> {
+    validate_wallet(&wallet)?;
+    check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    let rows = state
+        .repo
+        .get_balances(&wallet, params.at)
+        .await
+        .map_err(AppError::internal)?;
+    let balances: Vec<AssetBalance> = rows
+        .into_iter()
+        .map(|(asset_symbol, balance)| AssetBalance {
+            asset_symbol,
+            balance,
+        })
+        .collect();
+    Ok(Json(balances))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -744,6 +779,7 @@ mod tests {
             .route("/v1/transactions/{wallet}", get(get_transactions))
             .route("/v1/ledger/{wallet}", get(get_ledger))
             .route("/v1/export/{wallet}", get(export_ledger))
+            .route("/v1/balances/{wallet}", get(get_balances))
             .layer(middleware::from_fn_with_state(
                 Arc::clone(&state),
                 require_auth,
@@ -1304,6 +1340,54 @@ mod tests {
         let err = AppError::service_unavailable("Too many concurrent jobs");
         assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(err.message, "Too many concurrent jobs");
+    }
+
+    #[tokio::test]
+    async fn test_balances_invalid_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/balances/bad%20wallet")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_balances_endpoint_exists() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/balances/abc123")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_asset_balance_serialization() {
+        let balance = AssetBalance {
+            asset_symbol: "SOL".to_string(),
+            balance: bigdecimal::BigDecimal::from(42),
+        };
+        let json = serde_json::to_value(&balance).unwrap();
+        assert_eq!(json["asset_symbol"], "SOL");
+        assert_eq!(json["balance"], "42");
+    }
+
+    #[tokio::test]
+    async fn test_balances_respects_wallet_scoping() {
+        let state = test_state_with_config(Some("secret".to_string()), Some("abc123".to_string()));
+        let app = test_router_with_state(state);
+        let req = axum::http::Request::builder()
+            .uri("/v1/balances/notallowed")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     fn make_tx(


### PR DESCRIPTION
## Summary

- Add `GET /v1/balances/:wallet` endpoint that returns current balances per asset
- Supports optional `?at=<timestamp>` query param for historical point-in-time balances
- Add `get_balances` method to `Repository` with SQL aggregation (`SUM(amount) GROUP BY asset_symbol HAVING SUM(amount) != 0`)
- When `at` param is provided, joins with `transactions` table to filter by `timestamp <= at`
- Protected by auth middleware like other wallet endpoints

## Files changed

- `adapters/src/repo.rs` - new `get_balances(wallet, at)` query method
- `api/Cargo.toml` - add `bigdecimal` dependency for `AssetBalance` response type
- `api/src/main.rs` - new endpoint, `AssetBalance` response struct, `BalanceParams` query struct, route registration, tests

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (135 tests)
- [x] Invalid wallet returns 400
- [x] Endpoint exists and is routed correctly (not 404)
- [x] `AssetBalance` serializes correctly (asset_symbol + balance fields)