### PR TITLE
feat: batch ingestion endpoint and multi-wallet CLI

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -153,6 +153,7 @@ async fn main() -> anyhow::Result<()> {
 
     let protected = Router::new()
         .route("/v1/ingest", post(trigger_ingest))
+        .route("/v1/ingest/batch", post(trigger_batch_ingest))
         .route("/v1/normalize", post(trigger_normalize))
         .route("/v1/jobs/{job_id}", get(get_job_status))
         .route("/v1/transactions/{wallet}", get(get_transactions))
@@ -222,6 +223,11 @@ struct IngestRequest {
     chain: String,
     wallet: String,
     user_id: Option<Uuid>,
+}
+
+#[derive(Deserialize)]
+struct BatchIngestRequest {
+    wallets: Vec<IngestRequest>,
 }
 
 #[derive(Deserialize)]
@@ -390,6 +396,58 @@ async fn trigger_ingest(
         state: JobState::Pending,
         message: Some("Job queued".to_string()),
     }))
+}
+
+const MAX_BATCH_SIZE: usize = 50;
+
+async fn trigger_batch_ingest(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<BatchIngestRequest>,
+) -> Result<Json<Vec<JobStatus>>, AppError> {
+    if payload.wallets.is_empty() {
+        return Err(AppError::bad_request("wallets array must not be empty"));
+    }
+    if payload.wallets.len() > MAX_BATCH_SIZE {
+        return Err(AppError::bad_request(format!(
+            "batch size {} exceeds maximum of {MAX_BATCH_SIZE}",
+            payload.wallets.len()
+        )));
+    }
+
+    for item in &payload.wallets {
+        validate_wallet(&item.wallet)?;
+        check_wallet_allowed(&item.wallet, &state.allowed_wallets)?;
+        match item.chain.as_str() {
+            "solana" | "ethereum" | "hyperliquid" => {}
+            other => {
+                return Err(AppError::bad_request(format!(
+                    "Unsupported chain: {other}. Supported chains: solana, ethereum, hyperliquid"
+                )));
+            }
+        }
+    }
+
+    let mut jobs = Vec::with_capacity(payload.wallets.len());
+    for item in payload.wallets {
+        let single = Json(IngestRequest {
+            chain: item.chain,
+            wallet: item.wallet,
+            user_id: item.user_id,
+        });
+        match trigger_ingest(State(Arc::clone(&state)), single).await {
+            Ok(Json(status)) => jobs.push(status),
+            Err(e) if e.status == StatusCode::SERVICE_UNAVAILABLE => {
+                return Err(AppError::service_unavailable(format!(
+                    "Concurrency limit reached after queuing {} of {} jobs",
+                    jobs.len(),
+                    jobs.len() + 1
+                )));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(Json(jobs))
 }
 
 async fn trigger_normalize(
@@ -583,6 +641,7 @@ mod tests {
     fn test_router_with_state(state: Arc<AppState>) -> Router {
         let protected = Router::new()
             .route("/v1/ingest", post(trigger_ingest))
+            .route("/v1/ingest/batch", post(trigger_batch_ingest))
             .route("/v1/normalize", post(trigger_normalize))
             .route("/v1/jobs/{job_id}", get(get_job_status))
             .route("/v1/transactions/{wallet}", get(get_transactions))
@@ -1300,5 +1359,135 @@ mod tests {
         let err = AppError::forbidden("not allowed");
         assert_eq!(err.status, StatusCode::FORBIDDEN);
         assert_eq!(err.message, "not allowed");
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_multiple_wallets() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": [
+                        {"chain": "solana", "wallet": "abc123"},
+                        {"chain": "ethereum", "wallet": "0xdef456"}
+                    ]
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let jobs: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0]["state"], "pending");
+        assert_eq!(jobs[1]["state"], "pending");
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_empty_wallets() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": []
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_invalid_chain() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": [
+                        {"chain": "bitcoin", "wallet": "abc123"}
+                    ]
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_invalid_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": [
+                        {"chain": "solana", "wallet": "bad;wallet"}
+                    ]
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_respects_wallet_scoping() {
+        let state = test_state_with_config(Some("secret".to_string()), Some("abc123".to_string()));
+        let app = test_router_with_state(state);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer secret")
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": [
+                        {"chain": "solana", "wallet": "notallowed"}
+                    ]
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_requires_auth() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/ingest/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "wallets": [
+                        {"chain": "solana", "wallet": "abc123"}
+                    ]
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,8 +37,9 @@ enum Commands {
         #[arg(short, long)]
         chain: String,
 
-        #[arg(short, long)]
-        wallet: String,
+        /// Wallet address(es) to ingest. Pass multiple times for batch ingestion.
+        #[arg(short, long, required = true, num_args = 1..)]
+        wallet: Vec<String>,
 
         #[arg(short, long, default_value = "bronze_transactions.jsonl")]
         output: PathBuf,
@@ -100,7 +101,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Ingest {
             chain,
-            wallet,
+            wallet: wallets,
             output,
             rpc,
             grpc_url,
@@ -113,12 +114,81 @@ async fn main() -> anyhow::Result<()> {
                 info!(user_id = %id, "No --user-id provided, auto-generated");
                 id
             });
-            info!(wallet = %wallet, chain = %chain, "Starting ingestion");
 
-            let checkpoint = if let Some(ref p) = pool {
-                let repo = Repository::new(p.clone());
-                match repo.get_checkpoint(&chain, &wallet).await? {
-                    Some(cp) => {
+            for wallet in &wallets {
+                info!(wallet = %wallet, chain = %chain, "Starting ingestion");
+
+                let checkpoint = if let Some(ref p) = pool {
+                    let repo = Repository::new(p.clone());
+                    match repo.get_checkpoint(&chain, wallet).await? {
+                        Some(cp) => {
+                            info!(
+                                chain = %chain,
+                                wallet = %wallet,
+                                last_signature = ?cp.last_signature,
+                                last_slot = ?cp.last_slot,
+                                last_block = ?cp.last_block,
+                                last_timestamp = ?cp.last_timestamp,
+                                "Resuming from checkpoint"
+                            );
+                            Some(cp)
+                        }
+                        None => {
+                            info!(chain = %chain, wallet = %wallet, "No existing checkpoint, full ingestion");
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let events = match chain.as_str() {
+                    "solana" => {
+                        if let Some(ref endpoint) = grpc_url {
+                            let adapter = SolanaGrpcAdapter::new(endpoint, x_token.clone());
+                            if let Some(ref cp) = checkpoint {
+                                if let Some(slot) = cp.last_slot {
+                                    adapter.checkpoint().update(slot as u64);
+                                }
+                            }
+                            adapter
+                                .fetch_history(wallet, limit, user_id, checkpoint.as_ref())
+                                .await?
+                        } else if let Some(ref rpc_url) = rpc {
+                            let adapter = SolanaAdapter::new(rpc_url);
+                            adapter
+                                .fetch_history(wallet, limit, user_id, checkpoint.as_ref())
+                                .await?
+                        } else {
+                            anyhow::bail!("Either --grpc-url or --rpc must be provided for Solana");
+                        }
+                    }
+                    "hyperliquid" => {
+                        let adapter = HyperliquidAdapter::new();
+                        adapter
+                            .fetch_history(wallet, limit, user_id, checkpoint.as_ref())
+                            .await?
+                    }
+                    "ethereum" => {
+                        let rpc_url = rpc
+                            .as_ref()
+                            .ok_or_else(|| anyhow::anyhow!("--rpc is required for Ethereum"))?;
+                        let adapter = EvmAdapter::new(rpc_url)?;
+                        adapter
+                            .fetch_history(wallet, limit, user_id, checkpoint.as_ref())
+                            .await?
+                    }
+                    _ => {
+                        warn!(chain = %chain, "Unsupported chain");
+                        return Ok(());
+                    }
+                };
+
+                if let Some(ref p) = pool {
+                    let repo = Repository::new(p.clone());
+                    if let Some(cp) = build_checkpoint(&chain, wallet, &events) {
+                        repo.save_transactions_and_checkpoint(&events, &cp).await?;
+                        info!(count = events.len(), wallet = %wallet, "Saved transactions to database");
                         info!(
                             chain = %chain,
                             wallet = %wallet,
@@ -126,90 +196,24 @@ async fn main() -> anyhow::Result<()> {
                             last_slot = ?cp.last_slot,
                             last_block = ?cp.last_block,
                             last_timestamp = ?cp.last_timestamp,
-                            "Resuming from checkpoint"
+                            "Checkpoint saved atomically"
                         );
-                        Some(cp)
-                    }
-                    None => {
-                        info!(chain = %chain, wallet = %wallet, "No existing checkpoint, full ingestion");
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            let events = match chain.as_str() {
-                "solana" => {
-                    if let Some(endpoint) = grpc_url {
-                        let adapter = SolanaGrpcAdapter::new(&endpoint, x_token);
-                        if let Some(ref cp) = checkpoint {
-                            if let Some(slot) = cp.last_slot {
-                                adapter.checkpoint().update(slot as u64);
-                            }
-                        }
-                        adapter
-                            .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
-                            .await?
-                    } else if let Some(rpc_url) = rpc {
-                        let adapter = SolanaAdapter::new(&rpc_url);
-                        adapter
-                            .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
-                            .await?
                     } else {
-                        anyhow::bail!("Either --grpc-url or --rpc must be provided for Solana");
+                        repo.save_transactions(&events).await?;
+                        info!(
+                            count = events.len(),
+                            wallet = %wallet,
+                            "Saved transactions to database (no checkpoint)"
+                        );
                     }
-                }
-                "hyperliquid" => {
-                    let adapter = HyperliquidAdapter::new();
-                    adapter
-                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
-                        .await?
-                }
-                "ethereum" => {
-                    let rpc_url =
-                        rpc.ok_or_else(|| anyhow::anyhow!("--rpc is required for Ethereum"))?;
-                    let adapter = EvmAdapter::new(&rpc_url)?;
-                    adapter
-                        .fetch_history(&wallet, limit, user_id, checkpoint.as_ref())
-                        .await?
-                }
-                _ => {
-                    warn!(chain = %chain, "Unsupported chain");
-                    return Ok(());
-                }
-            };
-
-            // Strategy: DB first, fallback to File
-            if let Some(p) = pool {
-                let repo = Repository::new(p);
-                if let Some(cp) = build_checkpoint(&chain, &wallet, &events) {
-                    repo.save_transactions_and_checkpoint(&events, &cp).await?;
-                    info!(count = events.len(), "Saved transactions to database");
-                    info!(
-                        chain = %chain,
-                        wallet = %wallet,
-                        last_signature = ?cp.last_signature,
-                        last_slot = ?cp.last_slot,
-                        last_block = ?cp.last_block,
-                        last_timestamp = ?cp.last_timestamp,
-                        "Checkpoint saved atomically"
-                    );
                 } else {
-                    repo.save_transactions(&events).await?;
-                    info!(
-                        count = events.len(),
-                        "Saved transactions to database (no checkpoint)"
-                    );
+                    let mut file = File::create(&output)?;
+                    for event in events {
+                        serde_json::to_writer(&file, &event)?;
+                        writeln!(file)?;
+                    }
+                    info!(path = ?output, wallet = %wallet, "Data written to file");
                 }
-            } else {
-                // Write to JSONL
-                let mut file = File::create(&output)?;
-                for event in events {
-                    serde_json::to_writer(&file, &event)?;
-                    writeln!(file)?;
-                }
-                info!(path = ?output, "Data written to file");
             }
         }
         Commands::Normalize { input, output } => {
@@ -402,7 +406,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(chain, "solana");
-                assert_eq!(wallet, "abc123");
+                assert_eq!(wallet, vec!["abc123"]);
                 assert_eq!(rpc.unwrap(), "https://api.mainnet.solana.com");
                 assert_eq!(limit, 10);
                 assert_eq!(output, PathBuf::from("bronze_transactions.jsonl"));
@@ -456,12 +460,37 @@ mod tests {
                 ..
             } => {
                 assert_eq!(chain, "solana");
-                assert_eq!(wallet, "abc123");
+                assert_eq!(wallet, vec!["abc123"]);
                 assert_eq!(output, PathBuf::from("custom.jsonl"));
                 assert_eq!(grpc_url.unwrap(), "https://grpc.example.com");
                 assert_eq!(x_token.unwrap(), "secret");
                 assert_eq!(limit, 50);
                 assert!(user_id.is_some());
+            }
+            _ => panic!("expected Ingest command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ingest_multiple_wallets() {
+        let cli = Cli::try_parse_from([
+            "spectraplex",
+            "ingest",
+            "--chain",
+            "solana",
+            "--wallet",
+            "abc123",
+            "--wallet",
+            "def456",
+            "--wallet",
+            "ghi789",
+            "--rpc",
+            "https://api.mainnet.solana.com",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Ingest { wallet, .. } => {
+                assert_eq!(wallet, vec!["abc123", "def456", "ghi789"]);
             }
             _ => panic!("expected Ingest command"),
         }


### PR DESCRIPTION
## Summary

- Add `POST /v1/ingest/batch` endpoint accepting `{"wallets": [{chain, wallet, user_id?}, ...]}` and returning an array of job statuses
- Validates all wallets and chains upfront before queuing any jobs
- Enforces max batch size of 50, respects existing semaphore concurrency limits
- Update CLI `ingest` command to accept multiple `--wallet` flags for sequential multi-wallet ingestion

## Test plan

- [x] `test_batch_ingest_multiple_wallets` - queues 2 wallets, returns 2 pending jobs
- [x] `test_batch_ingest_empty_wallets` - rejects empty array with 400
- [x] `test_batch_ingest_invalid_chain` - rejects unsupported chain with 400
- [x] `test_batch_ingest_invalid_wallet` - rejects bad wallet format with 400
- [x] `test_batch_ingest_respects_wallet_scoping` - enforces ALLOWED_WALLETS with 403
- [x] `test_batch_ingest_requires_auth` - returns 401 without API key
- [x] `test_parse_ingest_multiple_wallets` - CLI parses multiple --wallet flags
- [x] All 150 tests pass