### PR TITLE
feat: date range filtering for transactions, ledger, and export

### DIFF
--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -202,20 +202,42 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<Transaction>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, user_id, wallet_address, timestamp, tx_hash, chain::text, raw_metadata
-            FROM transactions
-            WHERE wallet_address = $1
-            ORDER BY timestamp ASC
-            LIMIT $2 OFFSET $3
-            "#,
-        )
-        .bind(wallet)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+        self.get_transactions_by_wallet_filtered(wallet, limit, offset, None, None)
+            .await
+    }
+
+    pub async fn get_transactions_by_wallet_filtered(
+        &self,
+        wallet: &str,
+        limit: i64,
+        offset: i64,
+        from: Option<i64>,
+        to: Option<i64>,
+    ) -> anyhow::Result<Vec<Transaction>> {
+        let mut sql = String::from(
+            "SELECT id, user_id, wallet_address, timestamp, tx_hash, chain::text, raw_metadata \
+             FROM transactions WHERE wallet_address = $1",
+        );
+        if from.is_some() {
+            sql.push_str(" AND timestamp >= $4");
+        }
+        if to.is_some() {
+            sql.push_str(if from.is_some() {
+                " AND timestamp <= $5"
+            } else {
+                " AND timestamp <= $4"
+            });
+        }
+        sql.push_str(" ORDER BY timestamp ASC LIMIT $2 OFFSET $3");
+
+        let mut query = sqlx::query(&sql).bind(wallet).bind(limit).bind(offset);
+        if let Some(f) = from {
+            query = query.bind(f);
+        }
+        if let Some(t) = to {
+            query = query.bind(t);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         let mut txs = Vec::new();
         for row in rows {
@@ -249,22 +271,46 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<LedgerEntry>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT
-                id, transaction_id, user_id, wallet_address, asset_symbol, amount,
-                entry_type::text, fiat_value
-            FROM ledger_entries
-            WHERE wallet_address = $1
-            ORDER BY created_at ASC
-            LIMIT $2 OFFSET $3
-            "#,
-        )
-        .bind(wallet)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+        self.get_ledger_entries_by_wallet_filtered(wallet, limit, offset, None, None)
+            .await
+    }
+
+    pub async fn get_ledger_entries_by_wallet_filtered(
+        &self,
+        wallet: &str,
+        limit: i64,
+        offset: i64,
+        from: Option<i64>,
+        to: Option<i64>,
+    ) -> anyhow::Result<Vec<LedgerEntry>> {
+        let mut sql = String::from(
+            "SELECT l.id, l.transaction_id, l.user_id, l.wallet_address, l.asset_symbol, \
+             l.amount, l.entry_type::text, l.fiat_value \
+             FROM ledger_entries l",
+        );
+        let needs_join = from.is_some() || to.is_some();
+        if needs_join {
+            sql.push_str(" JOIN transactions t ON l.transaction_id = t.id");
+        }
+        sql.push_str(" WHERE l.wallet_address = $1");
+        let mut param_idx = 4_usize;
+        if from.is_some() {
+            sql.push_str(&format!(" AND t.timestamp >= ${param_idx}"));
+            param_idx += 1;
+        }
+        if to.is_some() {
+            sql.push_str(&format!(" AND t.timestamp <= ${param_idx}"));
+        }
+        sql.push_str(" ORDER BY l.created_at ASC LIMIT $2 OFFSET $3");
+
+        let mut query = sqlx::query(&sql).bind(wallet).bind(limit).bind(offset);
+        if let Some(f) = from {
+            query = query.bind(f);
+        }
+        if let Some(t) = to {
+            query = query.bind(t);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         let mut entries = Vec::new();
         for row in rows {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -243,11 +243,15 @@ const MAX_PAGE_LIMIT: i64 = 1000;
 struct PaginationParams {
     limit: Option<i64>,
     offset: Option<i64>,
+    from: Option<i64>,
+    to: Option<i64>,
 }
 
 #[derive(Deserialize)]
 struct ExportParams {
     format: Option<String>,
+    from: Option<i64>,
+    to: Option<i64>,
 }
 
 fn clamp_limit(limit: Option<i64>) -> i64 {
@@ -256,6 +260,15 @@ fn clamp_limit(limit: Option<i64>) -> i64 {
 
 fn clamp_offset(offset: Option<i64>) -> i64 {
     offset.unwrap_or(0).max(0)
+}
+
+fn validate_date_range(from: Option<i64>, to: Option<i64>) -> Result<(), AppError> {
+    if let (Some(f), Some(t)) = (from, to) {
+        if f > t {
+            return Err(AppError::bad_request("'from' must be <= 'to'"));
+        }
+    }
+    Ok(())
 }
 
 /// Basic wallet address validation. Rejects obviously invalid inputs.
@@ -580,11 +593,12 @@ async fn get_transactions(
 ) -> Result<Json<Vec<Transaction>>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    validate_date_range(params.from, params.to)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
     let txs = state
         .repo
-        .get_transactions_by_wallet_paginated(&wallet, limit, offset)
+        .get_transactions_by_wallet_filtered(&wallet, limit, offset, params.from, params.to)
         .await
         .map_err(AppError::internal)?;
     Ok(Json(txs))
@@ -597,11 +611,12 @@ async fn get_ledger(
 ) -> Result<Json<Vec<LedgerEntry>>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    validate_date_range(params.from, params.to)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
     let entries = state
         .repo
-        .get_ledger_entries_by_wallet_paginated(&wallet, limit, offset)
+        .get_ledger_entries_by_wallet_filtered(&wallet, limit, offset, params.from, params.to)
         .await
         .map_err(AppError::internal)?;
     Ok(Json(entries))
@@ -634,6 +649,7 @@ async fn export_ledger(
 ) -> Result<Response, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    validate_date_range(params.from, params.to)?;
 
     let format = params.format.as_deref().unwrap_or("json");
     if format != "csv" && format != "json" {
@@ -644,7 +660,7 @@ async fn export_ledger(
 
     let entries = state
         .repo
-        .get_ledger_entries_by_wallet_paginated(&wallet, MAX_EXPORT_LIMIT, 0)
+        .get_ledger_entries_by_wallet_filtered(&wallet, MAX_EXPORT_LIMIT, 0, params.from, params.to)
         .await
         .map_err(AppError::internal)?;
 
@@ -1686,5 +1702,108 @@ mod tests {
         assert_eq!(format_entry_type(&EntryType::Transfer), "transfer");
         assert_eq!(format_entry_type(&EntryType::Staking), "staking");
         assert_eq!(format_entry_type(&EntryType::Income), "income");
+    }
+
+    #[test]
+    fn test_validate_date_range_both_none() {
+        assert!(validate_date_range(None, None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_date_range_only_from() {
+        assert!(validate_date_range(Some(1000), None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_date_range_only_to() {
+        assert!(validate_date_range(None, Some(2000)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_date_range_valid() {
+        assert!(validate_date_range(Some(1000), Some(2000)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_date_range_equal() {
+        assert!(validate_date_range(Some(1000), Some(1000)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_date_range_invalid() {
+        let err = validate_date_range(Some(2000), Some(1000)).unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_transactions_with_date_range_params() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/abc123?from=1700000000&to=1700100000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_transactions_invalid_date_range() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/abc123?from=2000&to=1000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_ledger_with_date_range_params() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/ledger/abc123?from=1700000000&to=1700100000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_ledger_invalid_date_range() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/ledger/abc123?from=2000&to=1000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_export_with_date_range_params() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/export/abc123?format=csv&from=1700000000&to=1700100000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_export_invalid_date_range() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/export/abc123?from=2000&to=1000")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `?from=<unix_ts>&to=<unix_ts>` query params to `/v1/transactions/:wallet`, `/v1/ledger/:wallet`, and `/v1/export/:wallet`
- Validates `from <= to` when both provided (400 otherwise)
- Ledger filtering joins on transactions table to filter by transaction timestamp
- 12 new tests covering validation logic and endpoint integration

## Test plan
- [x] `validate_date_range` unit tests (both_none, only_from, only_to, valid, equal, invalid)
- [x] Integration tests for transactions, ledger, and export endpoints with date range params
- [x] Integration tests for invalid date range on all three endpoints
- [x] All 173 existing + new tests pass
- [x] cargo fmt and cargo clippy clean