### PR TITLE
feat: add single transaction lookup and wallet stats endpoints

### DIFF
--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -77,6 +77,15 @@ pub fn build_checkpoint(
     })
 }
 
+pub struct WalletStatsRow {
+    pub tx_count: i64,
+    pub earliest_timestamp: Option<i64>,
+    pub latest_timestamp: Option<i64>,
+    pub chain_count: i64,
+    pub unique_assets: i64,
+    pub per_chain: Vec<(String, i64)>,
+}
+
 pub struct Repository {
     pool: PgPool,
 }
@@ -413,6 +422,104 @@ impl Repository {
             }
             None => Ok(None),
         }
+    }
+
+    pub async fn get_transaction_by_hash(
+        &self,
+        wallet: &str,
+        tx_hash: &str,
+    ) -> anyhow::Result<Option<Transaction>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, user_id, wallet_address, timestamp, tx_hash, chain::text, raw_metadata
+            FROM transactions
+            WHERE wallet_address = $1 AND tx_hash = $2
+            "#,
+        )
+        .bind(wallet)
+        .bind(tx_hash)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => {
+                let chain_str: String = row.try_get("chain")?;
+                let chain = str_to_chain(&chain_str)?;
+                Ok(Some(Transaction {
+                    id: row.try_get("id")?,
+                    user_id: row.try_get("user_id")?,
+                    wallet_address: row.try_get("wallet_address")?,
+                    timestamp: row.try_get("timestamp")?,
+                    tx_hash: row.try_get("tx_hash")?,
+                    chain,
+                    raw_metadata: row.try_get("raw_metadata")?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn get_wallet_stats(&self, wallet: &str) -> anyhow::Result<WalletStatsRow> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                COUNT(*) AS tx_count,
+                MIN(timestamp) AS earliest_timestamp,
+                MAX(timestamp) AS latest_timestamp,
+                COUNT(DISTINCT chain::text) AS chain_count
+            FROM transactions
+            WHERE wallet_address = $1
+            "#,
+        )
+        .bind(wallet)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let tx_count: i64 = row.try_get("tx_count")?;
+        let earliest_timestamp: Option<i64> = row.try_get("earliest_timestamp")?;
+        let latest_timestamp: Option<i64> = row.try_get("latest_timestamp")?;
+        let chain_count: i64 = row.try_get("chain_count")?;
+
+        let unique_assets: i64 = sqlx::query(
+            r#"
+            SELECT COUNT(DISTINCT asset_symbol) AS unique_assets
+            FROM ledger_entries
+            WHERE wallet_address = $1
+            "#,
+        )
+        .bind(wallet)
+        .fetch_one(&self.pool)
+        .await?
+        .try_get("unique_assets")?;
+
+        let chain_tx_counts = sqlx::query(
+            r#"
+            SELECT chain::text AS chain, COUNT(*) AS count
+            FROM transactions
+            WHERE wallet_address = $1
+            GROUP BY chain
+            ORDER BY chain
+            "#,
+        )
+        .bind(wallet)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut per_chain: Vec<(String, i64)> = Vec::new();
+        for r in chain_tx_counts {
+            let chain: String = r.try_get("chain")?;
+            let count: i64 = r.try_get("count")?;
+            per_chain.push((chain, count));
+        }
+
+        Ok(WalletStatsRow {
+            tx_count,
+            earliest_timestamp,
+            latest_timestamp,
+            chain_count,
+            unique_assets,
+            per_chain,
+        })
     }
 
     pub async fn save_checkpoint(&self, checkpoint: &IndexerCheckpoint) -> anyhow::Result<()> {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -161,6 +161,11 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/ledger/{wallet}", get(get_ledger))
         .route("/v1/export/{wallet}", get(export_ledger))
         .route("/v1/balances/{wallet}", get(get_balances))
+        .route(
+            "/v1/transactions/{wallet}/{tx_hash}",
+            get(get_single_transaction),
+        )
+        .route("/v1/stats/{wallet}", get(get_wallet_stats))
         .layer(middleware::from_fn_with_state(
             Arc::clone(&shared_state),
             require_auth,
@@ -265,6 +270,22 @@ struct BalanceParams {
 struct AssetBalance {
     asset_symbol: String,
     balance: BigDecimal,
+}
+
+#[derive(Serialize)]
+struct ChainTxCount {
+    chain: String,
+    count: i64,
+}
+
+#[derive(Serialize)]
+struct WalletStats {
+    total_transactions: i64,
+    earliest_timestamp: Option<i64>,
+    latest_timestamp: Option<i64>,
+    total_chains: i64,
+    unique_assets: i64,
+    transactions_per_chain: Vec<ChainTxCount>,
 }
 
 fn clamp_limit(limit: Option<i64>) -> i64 {
@@ -741,6 +762,52 @@ async fn get_balances(
     Ok(Json(balances))
 }
 
+async fn get_single_transaction(
+    State(state): State<Arc<AppState>>,
+    Path((wallet, tx_hash)): Path<(String, String)>,
+) -> Result<Json<Transaction>, AppError> {
+    validate_wallet(&wallet)?;
+    check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+
+    let tx = state
+        .repo
+        .get_transaction_by_hash(&wallet, &tx_hash)
+        .await
+        .map_err(AppError::internal)?;
+
+    match tx {
+        Some(tx) => Ok(Json(tx)),
+        None => Err(AppError::not_found("Transaction not found")),
+    }
+}
+
+async fn get_wallet_stats(
+    State(state): State<Arc<AppState>>,
+    Path(wallet): Path<String>,
+) -> Result<Json<WalletStats>, AppError> {
+    validate_wallet(&wallet)?;
+    check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+
+    let stats = state
+        .repo
+        .get_wallet_stats(&wallet)
+        .await
+        .map_err(AppError::internal)?;
+
+    Ok(Json(WalletStats {
+        total_transactions: stats.tx_count,
+        earliest_timestamp: stats.earliest_timestamp,
+        latest_timestamp: stats.latest_timestamp,
+        total_chains: stats.chain_count,
+        unique_assets: stats.unique_assets,
+        transactions_per_chain: stats
+            .per_chain
+            .into_iter()
+            .map(|(chain, count)| ChainTxCount { chain, count })
+            .collect(),
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -796,6 +863,11 @@ mod tests {
             .route("/v1/ledger/{wallet}", get(get_ledger))
             .route("/v1/export/{wallet}", get(export_ledger))
             .route("/v1/balances/{wallet}", get(get_balances))
+            .route(
+                "/v1/transactions/{wallet}/{tx_hash}",
+                get(get_single_transaction),
+            )
+            .route("/v1/stats/{wallet}", get(get_wallet_stats))
             .layer(middleware::from_fn_with_state(
                 Arc::clone(&state),
                 require_auth,
@@ -1889,5 +1961,135 @@ mod tests {
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_single_transaction_invalid_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/bad%20wallet/0xabc")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_single_transaction_requires_auth() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/abc123/0xdeadbeef")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_single_transaction_respects_wallet_scoping() {
+        let state = test_state_with_config(Some("secret".to_string()), Some("abc123".to_string()));
+        let app = test_router_with_state(state);
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/notallowed/0xabc")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_single_transaction_passes_validation() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/abc123/0xdeadbeef")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_stats_invalid_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/stats/bad%20wallet")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_stats_requires_auth() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/stats/abc123")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_stats_respects_wallet_scoping() {
+        let state = test_state_with_config(Some("secret".to_string()), Some("abc123".to_string()));
+        let app = test_router_with_state(state);
+        let req = axum::http::Request::builder()
+            .uri("/v1/stats/notallowed")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_stats_passes_validation() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/stats/abc123")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_wallet_stats_serialization() {
+        let stats = WalletStats {
+            total_transactions: 42,
+            earliest_timestamp: Some(1700000000),
+            latest_timestamp: Some(1700100000),
+            total_chains: 2,
+            unique_assets: 5,
+            transactions_per_chain: vec![
+                ChainTxCount {
+                    chain: "ethereum".to_string(),
+                    count: 20,
+                },
+                ChainTxCount {
+                    chain: "solana".to_string(),
+                    count: 22,
+                },
+            ],
+        };
+        let json = serde_json::to_value(&stats).unwrap();
+        assert_eq!(json["total_transactions"], 42);
+        assert_eq!(json["earliest_timestamp"], 1700000000);
+        assert_eq!(json["latest_timestamp"], 1700100000);
+        assert_eq!(json["total_chains"], 2);
+        assert_eq!(json["unique_assets"], 5);
+        assert_eq!(json["transactions_per_chain"].as_array().unwrap().len(), 2);
+        assert_eq!(json["transactions_per_chain"][0]["chain"], "ethereum");
+        assert_eq!(json["transactions_per_chain"][0]["count"], 20);
     }
 }


### PR DESCRIPTION
## Summary

- Add `GET /v1/transactions/:wallet/:tx_hash` endpoint for drilling into individual transactions with full `raw_metadata`
- Add `GET /v1/stats/:wallet` endpoint returning wallet summary statistics:
  - Total transaction count
  - Earliest/latest timestamp (date range of indexed data)
  - Count of distinct chains ingested
  - Count of unique assets traded
  - Transaction count broken down per chain
- Both endpoints protected by auth middleware and wallet scoping (`check_wallet_allowed`)

## Files changed

- `adapters/src/repo.rs` - new `get_transaction_by_hash` and `get_wallet_stats` query methods, `WalletStatsRow` struct
- `api/src/main.rs` - new handlers, response structs (`WalletStats`, `ChainTxCount`), route registration, 10 new tests

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (170 tests)
- [x] Invalid wallet returns 400 on both endpoints
- [x] Auth required on both endpoints
- [x] Wallet scoping enforced on both endpoints
- [x] WalletStats serialization verified