### PR TITLE
feat: add Hyperliquid WebSocket streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7044,6 +7044,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bigdecimal",
+ "chrono",
  "dotenvy",
  "http-body-util",
  "reqwest",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "bigdecimal"] }
 dotenvy = "0.15"
 anyhow = "1.0"
+chrono = "0.4"
 bigdecimal = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.19", features = ["v4", "serde"] }
 subtle = "2"

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -13,6 +13,7 @@ use spectraplex_adapters::{
     evm_parser,
     hyperliquid::HyperliquidAdapter,
     hyperliquid_parser,
+    hyperliquid_ws::HyperliquidWsClient,
     repo::{build_checkpoint, Repository},
     solana::SolanaAdapter,
     solana_grpc::SolanaGrpcAdapter,
@@ -99,6 +100,8 @@ struct AppState {
 
 struct StreamEntry {
     id: Uuid,
+    chain: String,
+    wallet: Option<String>,
     cancel: CancellationToken,
     started_at: Instant,
     tx_count: Arc<std::sync::atomic::AtomicU64>,
@@ -108,6 +111,9 @@ struct StreamEntry {
 #[derive(Serialize)]
 struct StreamInfo {
     id: Uuid,
+    chain: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wallet: Option<String>,
     uptime_secs: u64,
     transactions_ingested: u64,
     last_slot: u64,
@@ -932,26 +938,38 @@ async fn get_wallet_stats(
 #[derive(Deserialize)]
 struct StartStreamRequest {
     chain: String,
+    wallet: Option<String>,
 }
 
 async fn start_stream(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<StartStreamRequest>,
 ) -> Result<Json<StreamInfo>, AppError> {
-    if payload.chain != "solana" {
-        return Err(AppError::bad_request(
-            "Streaming is currently only supported for solana",
-        ));
+    match payload.chain.as_str() {
+        "solana" => {
+            if state
+                .config
+                .solana_grpc_url
+                .as_deref()
+                .filter(|u| !u.is_empty())
+                .is_none()
+            {
+                return Err(AppError::bad_request(
+                    "Solana gRPC URL not configured (set SOLANA_GRPC_URL)",
+                ));
+            }
+        }
+        "hyperliquid" => {
+            let wallet = payload.wallet.as_deref().unwrap_or("");
+            validate_wallet(wallet)?;
+            check_wallet_allowed(wallet, &state.allowed_wallets)?;
+        }
+        other => {
+            return Err(AppError::bad_request(format!(
+                "Unsupported streaming chain: {other}. Supported: solana, hyperliquid"
+            )));
+        }
     }
-
-    let grpc_url = state
-        .config
-        .solana_grpc_url
-        .as_deref()
-        .filter(|u| !u.is_empty())
-        .ok_or_else(|| {
-            AppError::bad_request("Solana gRPC URL not configured (set SOLANA_GRPC_URL)")
-        })?;
 
     let _permit = state
         .stream_semaphore
@@ -963,9 +981,8 @@ async fn start_stream(
     let cancel = CancellationToken::new();
     let tx_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let last_slot = Arc::new(std::sync::atomic::AtomicU64::new(0));
-
-    let adapter = SolanaGrpcAdapter::new(grpc_url, state.config.solana_grpc_token.clone());
-    let (mut rx, grpc_handle) = adapter.stream_transactions();
+    let chain = payload.chain.clone();
+    let wallet = payload.wallet.clone();
 
     let cancel_clone = cancel.clone();
     let tx_count_clone = Arc::clone(&tx_count);
@@ -973,58 +990,152 @@ async fn start_stream(
     let repo = state.repo.clone();
     let state_clone = Arc::clone(&state);
 
-    tokio::spawn(async move {
-        let _permit = _permit;
-        let mut batch: Vec<Transaction> = Vec::new();
-        let mut last_flush = Instant::now();
-        const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
-        const BATCH_SIZE: usize = 100;
+    match chain.as_str() {
+        "solana" => {
+            let grpc_url = state.config.solana_grpc_url.clone().unwrap();
+            let grpc_token = state.config.solana_grpc_token.clone();
+            let adapter = SolanaGrpcAdapter::new(&grpc_url, grpc_token);
+            let (mut rx, grpc_handle) = adapter.stream_transactions();
 
-        loop {
-            tokio::select! {
-                _ = cancel_clone.cancelled() => {
-                    info!(stream_id = %stream_id, "Stream cancelled");
-                    break;
-                }
-                maybe_tx = rx.recv() => {
-                    match maybe_tx {
-                        Some(tx) => {
-                            if let Some(slot) = tx.raw_metadata.get("slot").and_then(|v| v.as_u64()) {
-                                last_slot_clone.store(slot, std::sync::atomic::Ordering::Relaxed);
-                            }
-                            batch.push(tx);
-                            tx_count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            tokio::spawn(async move {
+                let _permit = _permit;
+                let mut batch: Vec<Transaction> = Vec::new();
+                let mut last_flush = Instant::now();
+                const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+                const BATCH_SIZE: usize = 100;
 
-                            if batch.len() >= BATCH_SIZE || last_flush.elapsed() >= FLUSH_INTERVAL {
-                                if let Err(e) = repo.save_transactions(&batch).await {
-                                    error!(stream_id = %stream_id, error = %e, "Failed to save streamed transactions");
-                                }
-                                batch.clear();
-                                last_flush = Instant::now();
-                            }
-                        }
-                        None => {
-                            info!(stream_id = %stream_id, "gRPC stream channel closed");
+                loop {
+                    tokio::select! {
+                        _ = cancel_clone.cancelled() => {
+                            info!(stream_id = %stream_id, "Stream cancelled");
                             break;
+                        }
+                        maybe_tx = rx.recv() => {
+                            match maybe_tx {
+                                Some(tx) => {
+                                    if let Some(slot) = tx.raw_metadata.get("slot").and_then(|v| v.as_u64()) {
+                                        last_slot_clone.store(slot, std::sync::atomic::Ordering::Relaxed);
+                                    }
+                                    batch.push(tx);
+                                    tx_count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                                    if batch.len() >= BATCH_SIZE || last_flush.elapsed() >= FLUSH_INTERVAL {
+                                        if let Err(e) = repo.save_transactions(&batch).await {
+                                            error!(stream_id = %stream_id, error = %e, "Failed to save streamed transactions");
+                                        }
+                                        batch.clear();
+                                        last_flush = Instant::now();
+                                    }
+                                }
+                                None => {
+                                    info!(stream_id = %stream_id, "gRPC stream channel closed");
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
 
-        if !batch.is_empty() {
-            if let Err(e) = repo.save_transactions(&batch).await {
-                error!(stream_id = %stream_id, error = %e, "Failed to flush final batch");
-            }
-        }
+                if !batch.is_empty() {
+                    if let Err(e) = repo.save_transactions(&batch).await {
+                        error!(stream_id = %stream_id, error = %e, "Failed to flush final batch");
+                    }
+                }
 
-        grpc_handle.abort();
-        state_clone.streams.write().await.remove(&stream_id);
-        info!(stream_id = %stream_id, "Stream removed from active set");
-    });
+                grpc_handle.abort();
+                state_clone.streams.write().await.remove(&stream_id);
+                info!(stream_id = %stream_id, "Stream removed from active set");
+            });
+        }
+        "hyperliquid" => {
+            let hl_wallet = wallet.clone().unwrap();
+            let (sender, mut receiver) = tokio::sync::mpsc::channel::<serde_json::Value>(1000);
+
+            let ws_cancel = cancel_clone.clone();
+            let ws_wallet = hl_wallet.clone();
+            let ws_handle = tokio::spawn(async move {
+                let client = HyperliquidWsClient::new();
+                tokio::select! {
+                    result = client.subscribe_user(&ws_wallet, |msg| {
+                        if let Some(data) = msg.data {
+                            let _ = sender.try_send(data);
+                        }
+                    }) => {
+                        if let Err(e) = result {
+                            error!(error = %e, "Hyperliquid WebSocket error");
+                        }
+                    }
+                    _ = ws_cancel.cancelled() => {
+                        info!("Hyperliquid stream cancelled");
+                    }
+                }
+            });
+
+            let hl_wallet_owned = hl_wallet.clone();
+            tokio::spawn(async move {
+                let _permit = _permit;
+                let mut batch: Vec<Transaction> = Vec::new();
+                let mut last_flush = Instant::now();
+                let user_id = Uuid::new_v4();
+                const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+                const BATCH_SIZE: usize = 100;
+
+                loop {
+                    tokio::select! {
+                        _ = cancel_clone.cancelled() => {
+                            info!(stream_id = %stream_id, "Hyperliquid stream cancelled");
+                            break;
+                        }
+                        msg = receiver.recv() => {
+                            match msg {
+                                Some(data) => {
+                                    let tx = Transaction {
+                                        id: Uuid::new_v4(),
+                                        user_id,
+                                        wallet_address: hl_wallet_owned.clone(),
+                                        timestamp: chrono::Utc::now().timestamp(),
+                                        tx_hash: format!("hl-ws-{}", Uuid::new_v4()),
+                                        chain: spectraplex_core::models::Chain::Hyperliquid,
+                                        raw_metadata: data,
+                                    };
+                                    batch.push(tx);
+                                    tx_count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                                    if batch.len() >= BATCH_SIZE || last_flush.elapsed() >= FLUSH_INTERVAL {
+                                        if let Err(e) = repo.save_transactions(&batch).await {
+                                            error!(stream_id = %stream_id, error = %e, "Failed to save HL stream batch");
+                                        }
+                                        batch.clear();
+                                        last_flush = Instant::now();
+                                    }
+                                }
+                                None => {
+                                    info!(stream_id = %stream_id, "Hyperliquid WS channel closed");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !batch.is_empty() {
+                    if let Err(e) = repo.save_transactions(&batch).await {
+                        error!(stream_id = %stream_id, error = %e, "Failed to flush final HL batch");
+                    }
+                }
+
+                ws_handle.abort();
+                state_clone.streams.write().await.remove(&stream_id);
+                info!(stream_id = %stream_id, "Hyperliquid stream removed from active set");
+            });
+        }
+        _ => unreachable!("chain validated above"),
+    }
 
     let entry = StreamEntry {
         id: stream_id,
+        chain: chain.clone(),
+        wallet: wallet.clone(),
         cancel: cancel.clone(),
         started_at: Instant::now(),
         tx_count: Arc::clone(&tx_count),
@@ -1033,6 +1144,8 @@ async fn start_stream(
 
     let info = StreamInfo {
         id: stream_id,
+        chain,
+        wallet,
         uptime_secs: 0,
         transactions_ingested: 0,
         last_slot: 0,
@@ -1069,6 +1182,8 @@ async fn list_streams(
         .values()
         .map(|entry| StreamInfo {
             id: entry.id,
+            chain: entry.chain.clone(),
+            wallet: entry.wallet.clone(),
             uptime_secs: entry.started_at.elapsed().as_secs(),
             transactions_ingested: entry.tx_count.load(std::sync::atomic::Ordering::Relaxed),
             last_slot: entry.last_slot.load(std::sync::atomic::Ordering::Relaxed),
@@ -2565,7 +2680,7 @@ mod tests {
         assert!(json["error"]
             .as_str()
             .unwrap()
-            .contains("only supported for solana"));
+            .contains("Unsupported streaming chain"));
     }
 
     #[tokio::test]
@@ -2667,6 +2782,8 @@ mod tests {
             stream_id,
             StreamEntry {
                 id: stream_id,
+                chain: "solana".to_string(),
+                wallet: None,
                 cancel: cancel.clone(),
                 started_at: Instant::now(),
                 tx_count: Arc::new(std::sync::atomic::AtomicU64::new(42)),
@@ -2699,6 +2816,8 @@ mod tests {
             stream_id,
             StreamEntry {
                 id: stream_id,
+                chain: "solana".to_string(),
+                wallet: None,
                 cancel: CancellationToken::new(),
                 started_at: Instant::now(),
                 tx_count: Arc::new(std::sync::atomic::AtomicU64::new(100)),
@@ -2719,6 +2838,7 @@ mod tests {
         let streams: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(streams.len(), 1);
         assert_eq!(streams[0]["id"], stream_id.to_string());
+        assert_eq!(streams[0]["chain"], "solana");
         assert_eq!(streams[0]["transactions_ingested"], 100);
         assert_eq!(streams[0]["last_slot"], 50000);
     }
@@ -2762,13 +2882,111 @@ mod tests {
     fn test_stream_info_serialization() {
         let info = StreamInfo {
             id: Uuid::nil(),
+            chain: "solana".to_string(),
+            wallet: None,
             uptime_secs: 120,
             transactions_ingested: 5000,
             last_slot: 300000,
         };
         let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["chain"], "solana");
+        assert!(json.get("wallet").is_none());
         assert_eq!(json["uptime_secs"], 120);
         assert_eq!(json["transactions_ingested"], 5000);
         assert_eq!(json["last_slot"], 300000);
+
+        let info_hl = StreamInfo {
+            id: Uuid::nil(),
+            chain: "hyperliquid".to_string(),
+            wallet: Some("0xabc123".to_string()),
+            uptime_secs: 60,
+            transactions_ingested: 10,
+            last_slot: 0,
+        };
+        let json_hl = serde_json::to_value(&info_hl).unwrap();
+        assert_eq!(json_hl["chain"], "hyperliquid");
+        assert_eq!(json_hl["wallet"], "0xabc123");
+    }
+
+    #[tokio::test]
+    async fn test_stream_start_hyperliquid_missing_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/stream/start")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({"chain": "hyperliquid"})).unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid wallet address length"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_start_hyperliquid_invalid_wallet() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/stream/start")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "chain": "hyperliquid",
+                    "wallet": "bad wallet!@#"
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"]
+            .as_str()
+            .unwrap()
+            .contains("invalid characters"));
+    }
+
+    #[tokio::test]
+    async fn test_list_streams_includes_chain_and_wallet() {
+        let state = test_state();
+        let stream_id = Uuid::new_v4();
+        state.streams.write().await.insert(
+            stream_id,
+            StreamEntry {
+                id: stream_id,
+                chain: "hyperliquid".to_string(),
+                wallet: Some("0xabc123".to_string()),
+                cancel: CancellationToken::new(),
+                started_at: Instant::now(),
+                tx_count: Arc::new(std::sync::atomic::AtomicU64::new(5)),
+                last_slot: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            },
+        );
+
+        let app = test_router_with_state(Arc::clone(&state));
+        let req = axum::http::Request::builder()
+            .uri("/v1/streams")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let streams: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(streams.len(), 1);
+        assert_eq!(streams[0]["chain"], "hyperliquid");
+        assert_eq!(streams[0]["wallet"], "0xabc123");
+        assert_eq!(streams[0]["transactions_ingested"], 5);
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing Solana-only streaming endpoints (from PR #94) to also support Hyperliquid real-time WebSocket streaming.

- Multi-chain dispatch in `start_stream` routes to either `SolanaGrpcAdapter` or `HyperliquidWsClient` based on the `chain` field
- Hyperliquid streams require a `wallet` address parameter and validate it before starting
- Uses mpsc channel to bridge sync WS callbacks into the async batch-flush pipeline (same pattern as Solana gRPC)
- `StreamEntry` and `StreamInfo` now include `chain` and optional `wallet` fields
- `list_streams` response includes chain/wallet; wallet is omitted when None (solana streams)

## Test plan

- [x] All 214 tests pass (120 API + 60+11 adapter + 18 CLI + 5 core)
- [x] Clippy clean with `-D warnings`
- [x] Cargo fmt clean
- [x] New tests: HL missing wallet, HL invalid wallet, chain+wallet in list output, StreamInfo serialization with/without wallet
- [x] Existing streaming tests updated with new chain/wallet fields