### PR TITLE
P2-W5: Hyperliquid target model

### DIFF
--- a/adapters/src/hyperliquid.rs
+++ b/adapters/src/hyperliquid.rs
@@ -1,14 +1,24 @@
 use std::time::Duration;
 
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use spectraplex_core::connector::{ConnectorCapabilities, MarketFilterSpec};
 use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, Transaction};
+use spectraplex_core::v2::{
+    ChainFamily, IndexTarget, IngestionBatch, RawTransaction, TargetKind, TargetMode,
+};
+use tokio::sync::mpsc;
+use tracing::info;
 use uuid::Uuid;
+
+use crate::hyperliquid_ws::HyperliquidWsClient;
 
 const HL_INFO_URL: &str = "https://api.hyperliquid.xyz/info";
 
 pub struct HyperliquidAdapter {
     client: reqwest::Client,
     base_url: String,
+    ws_url: Option<String>,
 }
 
 // --- Request types ---
@@ -33,6 +43,16 @@ struct UserLedgerUpdatesRequest<'a> {
     user: &'a str,
     #[serde(rename = "startTime")]
     start_time: i64,
+}
+
+#[derive(Serialize)]
+struct FundingHistoryRequest<'a> {
+    r#type: &'static str,
+    coin: &'a str,
+    #[serde(rename = "startTime")]
+    start_time: i64,
+    #[serde(rename = "endTime", skip_serializing_if = "Option::is_none")]
+    end_time: Option<i64>,
 }
 
 // --- Response types (for deserialization) ---
@@ -77,6 +97,16 @@ pub struct HlLedgerUpdate {
     pub delta: serde_json::Value,
 }
 
+/// Market-level funding rate record from the `fundingHistory` REST endpoint.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HlFundingRate {
+    pub coin: String,
+    #[serde(rename = "fundingRate")]
+    pub funding_rate: String,
+    pub premium: String,
+    pub time: u64,
+}
+
 impl Default for HyperliquidAdapter {
     fn default() -> Self {
         Self::new()
@@ -88,6 +118,7 @@ impl HyperliquidAdapter {
         Self {
             client: Self::build_client(),
             base_url: HL_INFO_URL.to_string(),
+            ws_url: None,
         }
     }
 
@@ -95,6 +126,15 @@ impl HyperliquidAdapter {
         Self {
             client: Self::build_client(),
             base_url: base_url.to_string(),
+            ws_url: None,
+        }
+    }
+
+    pub fn with_urls(base_url: &str, ws_url: &str) -> Self {
+        Self {
+            client: Self::build_client(),
+            base_url: base_url.to_string(),
+            ws_url: Some(ws_url.to_string()),
         }
     }
 
@@ -105,6 +145,10 @@ impl HyperliquidAdapter {
             .build()
             .expect("failed to build HTTP client")
     }
+
+    // -----------------------------------------------------------------------
+    // User-level REST methods (wallet targets)
+    // -----------------------------------------------------------------------
 
     pub async fn fetch_user_fills(&self, wallet: &str) -> anyhow::Result<Vec<HlFill>> {
         let body = UserFillsRequest {
@@ -164,7 +208,393 @@ impl HyperliquidAdapter {
         let updates: Vec<HlLedgerUpdate> = resp.json().await?;
         Ok(updates)
     }
+
+    // -----------------------------------------------------------------------
+    // Market-level REST methods (market targets)
+    // -----------------------------------------------------------------------
+
+    /// Fetch historical funding rates for a specific coin.
+    ///
+    /// Uses the `fundingHistory` REST endpoint which returns market-wide
+    /// funding rate records (not per-user). This is the primary market-level
+    /// backfill data source since Hyperliquid does not expose a `recentTrades`
+    /// REST endpoint.
+    pub async fn fetch_funding_history(
+        &self,
+        coin: &str,
+        start_time: i64,
+        end_time: Option<i64>,
+    ) -> anyhow::Result<Vec<HlFundingRate>> {
+        let body = FundingHistoryRequest {
+            r#type: "fundingHistory",
+            coin,
+            start_time,
+            end_time,
+        };
+        let resp = self.client.post(&self.base_url).json(&body).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Hyperliquid fundingHistory returned {}: {}", status, text);
+        }
+        let rates: Vec<HlFundingRate> = resp.json().await?;
+        Ok(rates)
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 Connector internal backfill methods
+    // -----------------------------------------------------------------------
+
+    /// Wallet backfill: fetch fills, funding, and ledger updates for a wallet
+    /// address, producing target-agnostic `RawTransaction` records.
+    async fn wallet_backfill(
+        &self,
+        target: &IndexTarget,
+        cursor: Option<&serde_json::Value>,
+        limit: usize,
+    ) -> anyhow::Result<IngestionBatch> {
+        let wallet_str = target
+            .address
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("wallet target must have an address"))?;
+
+        let resume_ms = cursor_to_start_time_ms(cursor);
+        let network = &target.network;
+        let mut records = Vec::new();
+
+        // 1. Fills — no startTime param, filter client-side
+        let fills = self.fetch_user_fills(wallet_str).await?;
+        for fill in fills
+            .iter()
+            .filter(|f| f.time >= resume_ms as u64)
+            .take(limit)
+        {
+            let raw = serde_json::to_value(fill)?;
+            records.push(RawTransaction {
+                id: Uuid::new_v4(),
+                network: network.clone(),
+                tx_hash: fill.hash.clone(),
+                timestamp: (fill.time / 1000) as i64,
+                block_number: None,
+                raw_metadata: serde_json::json!({ "type": "fill", "data": raw }),
+                source: "hl-rest-wallet-backfill".to_string(),
+                ingestion_run_id: None,
+                ingested_at: Utc::now(),
+            });
+        }
+
+        // 2. Funding payments
+        let remaining = limit.saturating_sub(records.len());
+        if remaining > 0 {
+            let funding = self.fetch_user_funding(wallet_str, resume_ms).await?;
+            for entry in funding.iter().take(remaining) {
+                let raw = serde_json::to_value(entry)?;
+                let hash = entry
+                    .hash
+                    .clone()
+                    .unwrap_or_else(|| format!("funding-{}-{}", entry.coin, entry.time));
+                records.push(RawTransaction {
+                    id: Uuid::new_v4(),
+                    network: network.clone(),
+                    tx_hash: hash,
+                    timestamp: (entry.time / 1000) as i64,
+                    block_number: None,
+                    raw_metadata: serde_json::json!({ "type": "funding", "data": raw }),
+                    source: "hl-rest-wallet-backfill".to_string(),
+                    ingestion_run_id: None,
+                    ingested_at: Utc::now(),
+                });
+            }
+        }
+
+        // 3. Non-funding ledger updates
+        let remaining = limit.saturating_sub(records.len());
+        if remaining > 0 {
+            let ledger_updates = self
+                .fetch_user_ledger_updates(wallet_str, resume_ms)
+                .await?;
+            for update in ledger_updates.iter().take(remaining) {
+                let raw = serde_json::to_value(update)?;
+                records.push(RawTransaction {
+                    id: Uuid::new_v4(),
+                    network: network.clone(),
+                    tx_hash: update.hash.clone(),
+                    timestamp: (update.time / 1000) as i64,
+                    block_number: None,
+                    raw_metadata: serde_json::json!({ "type": "ledger_update", "data": raw }),
+                    source: "hl-rest-wallet-backfill".to_string(),
+                    ingestion_run_id: None,
+                    ingested_at: Utc::now(),
+                });
+            }
+        }
+
+        info!(
+            "Hyperliquid V2 wallet backfill: collected {} records for {}",
+            records.len(),
+            wallet_str
+        );
+
+        Ok(IngestionBatch {
+            records,
+            checkpoint: None,
+            run_metadata: None,
+        })
+    }
+
+    /// Market backfill: fetch funding rate history for a coin, producing
+    /// target-agnostic `RawTransaction` records.
+    ///
+    /// Hyperliquid does not expose a `recentTrades` REST endpoint, so the
+    /// primary market-level backfill data source is `fundingHistory`. The WS
+    /// `trades` channel provides real-time market trade data for streaming.
+    async fn market_backfill(
+        &self,
+        target: &IndexTarget,
+        cursor: Option<&serde_json::Value>,
+        limit: usize,
+    ) -> anyhow::Result<IngestionBatch> {
+        let coin = target
+            .address
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("market target must have an address (coin symbol)"))?;
+
+        let start_time_ms = cursor_to_start_time_ms(cursor);
+        let network = &target.network;
+
+        // Parse filter spec for data_types if present
+        let _filter: MarketFilterSpec = match &target.filter_spec {
+            Some(v) => serde_json::from_value(v.clone())?,
+            None => MarketFilterSpec::default(),
+        };
+
+        let rates = self
+            .fetch_funding_history(coin, start_time_ms, None)
+            .await?;
+
+        let records: Vec<RawTransaction> = rates
+            .iter()
+            .take(limit)
+            .map(|rate| {
+                let raw = serde_json::to_value(rate).unwrap_or_default();
+                let hash = format!("funding-rate-{}-{}", rate.coin, rate.time);
+                RawTransaction {
+                    id: Uuid::new_v4(),
+                    network: network.clone(),
+                    tx_hash: hash,
+                    timestamp: (rate.time / 1000) as i64,
+                    block_number: None,
+                    raw_metadata: serde_json::json!({ "type": "funding_rate", "data": raw }),
+                    source: "hl-rest-market-backfill".to_string(),
+                    ingestion_run_id: None,
+                    ingested_at: Utc::now(),
+                }
+            })
+            .collect();
+
+        info!(
+            "Hyperliquid V2 market backfill: collected {} records for {}",
+            records.len(),
+            coin
+        );
+
+        Ok(IngestionBatch {
+            records,
+            checkpoint: None,
+            run_metadata: None,
+        })
+    }
 }
+
+// ---------------------------------------------------------------------------
+// Cursor helpers
+// ---------------------------------------------------------------------------
+
+/// Extract start time in milliseconds from a V2 checkpoint cursor.
+///
+/// Cursor shape: `{"last_time_ms": i64}`.
+fn cursor_to_start_time_ms(cursor: Option<&serde_json::Value>) -> i64 {
+    cursor
+        .and_then(|c| c.get("last_time_ms"))
+        .and_then(|v| v.as_i64())
+        .map(|ms| ms + 1) // advance past last seen
+        .unwrap_or(0)
+}
+
+/// Source string for V2 Hyperliquid ingestion paths.
+fn v2_source(target_kind: TargetKind, mode: &str) -> String {
+    let kind_str = match target_kind {
+        TargetKind::Wallet => "wallet",
+        TargetKind::Market => "market",
+        _ => "unknown",
+    };
+    format!("hl-ws-{kind_str}-{mode}")
+}
+
+// ---------------------------------------------------------------------------
+// V2 Connector implementation
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl spectraplex_core::connector::Connector for HyperliquidAdapter {
+    fn capabilities(&self) -> ConnectorCapabilities {
+        ConnectorCapabilities {
+            supported_target_kinds: vec![TargetKind::Wallet, TargetKind::Market],
+            supported_modes: vec![TargetMode::Backfill, TargetMode::Stream],
+            chain_family: ChainFamily::Hyperliquid,
+        }
+    }
+
+    async fn backfill(
+        &self,
+        target: &IndexTarget,
+        cursor: Option<&serde_json::Value>,
+        limit: usize,
+    ) -> anyhow::Result<IngestionBatch> {
+        if target.chain_family != ChainFamily::Hyperliquid {
+            anyhow::bail!(
+                "HyperliquidAdapter only supports Hyperliquid chain family, got {:?}",
+                target.chain_family
+            );
+        }
+
+        match target.kind {
+            TargetKind::Wallet => self.wallet_backfill(target, cursor, limit).await,
+            TargetKind::Market => self.market_backfill(target, cursor, limit).await,
+            other => anyhow::bail!(
+                "HyperliquidAdapter does not support target kind {:?}; supported: wallet, market",
+                other
+            ),
+        }
+    }
+
+    async fn stream(
+        &self,
+        target: &IndexTarget,
+        _cursor: Option<&serde_json::Value>,
+    ) -> anyhow::Result<mpsc::Receiver<RawTransaction>> {
+        if target.chain_family != ChainFamily::Hyperliquid {
+            anyhow::bail!(
+                "HyperliquidAdapter only supports Hyperliquid chain family, got {:?}",
+                target.chain_family
+            );
+        }
+
+        match target.kind {
+            TargetKind::Wallet => {
+                let wallet_str = target
+                    .address
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("wallet target must have an address"))?;
+
+                let (tx, rx) = mpsc::channel(256);
+                let ws_client = match &self.ws_url {
+                    Some(url) => HyperliquidWsClient::with_url(url),
+                    None => HyperliquidWsClient::new(),
+                };
+                let wallet = wallet_str.to_string();
+                let network = target.network.clone();
+                let source = v2_source(target.kind, "stream");
+
+                tokio::spawn(async move {
+                    let result = ws_client
+                        .subscribe_user(&wallet, |msg| {
+                            if let Some(data) = &msg.data {
+                                let channel = msg.channel.as_deref().unwrap_or("unknown");
+                                let event_type = match channel {
+                                    "userFills" => "fill",
+                                    "userFundings" => "funding",
+                                    "userNonFundingLedgerUpdates" => "ledger_update",
+                                    _ => "unknown",
+                                };
+
+                                let raw_tx = RawTransaction {
+                                    id: Uuid::new_v4(),
+                                    network: network.clone(),
+                                    tx_hash: format!("ws-{}-{}", channel, Uuid::new_v4()),
+                                    timestamp: Utc::now().timestamp(),
+                                    block_number: None,
+                                    raw_metadata: serde_json::json!({
+                                        "type": event_type,
+                                        "data": data,
+                                    }),
+                                    source: source.clone(),
+                                    ingestion_run_id: None,
+                                    ingested_at: Utc::now(),
+                                };
+
+                                // Best-effort send; if receiver is dropped we
+                                // will detect it when subscribe_user returns.
+                                let _ = tx.try_send(raw_tx);
+                            }
+                        })
+                        .await;
+
+                    if let Err(e) = result {
+                        tracing::error!("Hyperliquid wallet WS stream error: {}", e);
+                    }
+                });
+
+                Ok(rx)
+            }
+            TargetKind::Market => {
+                let coin = target
+                    .address
+                    .as_deref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("market target must have an address (coin symbol)")
+                    })?;
+
+                let (tx, rx) = mpsc::channel(256);
+                let ws_client = match &self.ws_url {
+                    Some(url) => HyperliquidWsClient::with_url(url),
+                    None => HyperliquidWsClient::new(),
+                };
+                let coin_owned = coin.to_string();
+                let network = target.network.clone();
+                let source = v2_source(target.kind, "stream");
+
+                tokio::spawn(async move {
+                    let result = ws_client
+                        .subscribe_trades(&coin_owned, |msg| {
+                            if let Some(data) = &msg.data {
+                                let raw_tx = RawTransaction {
+                                    id: Uuid::new_v4(),
+                                    network: network.clone(),
+                                    tx_hash: format!("ws-trades-{}", Uuid::new_v4()),
+                                    timestamp: Utc::now().timestamp(),
+                                    block_number: None,
+                                    raw_metadata: serde_json::json!({
+                                        "type": "trade",
+                                        "data": data,
+                                    }),
+                                    source: source.clone(),
+                                    ingestion_run_id: None,
+                                    ingested_at: Utc::now(),
+                                };
+                                let _ = tx.try_send(raw_tx);
+                            }
+                        })
+                        .await;
+
+                    if let Err(e) = result {
+                        tracing::error!("Hyperliquid market WS stream error: {}", e);
+                    }
+                });
+
+                Ok(rx)
+            }
+            other => anyhow::bail!(
+                "HyperliquidAdapter does not support streaming for target kind {:?}; supported: wallet, market",
+                other
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// V1 Legacy ChainIngestor implementation (preserved for backward compat)
+// ---------------------------------------------------------------------------
 
 #[async_trait::async_trait]
 impl ChainIngestor for HyperliquidAdapter {
@@ -245,6 +675,7 @@ impl ChainIngestor for HyperliquidAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spectraplex_core::connector::Connector;
 
     fn sample_fills_json() -> &'static str {
         r#"[
@@ -292,6 +723,23 @@ mod tests {
         ]"#
     }
 
+    fn sample_funding_history_json() -> &'static str {
+        r#"[
+            {
+                "coin": "ETH",
+                "fundingRate": "0.0001",
+                "premium": "0.00005",
+                "time": 1700000000000
+            },
+            {
+                "coin": "ETH",
+                "fundingRate": "0.00012",
+                "premium": "0.00006",
+                "time": 1700003600000
+            }
+        ]"#
+    }
+
     #[test]
     fn test_deserialize_fills() {
         let fills: Vec<HlFill> = serde_json::from_str(sample_fills_json()).unwrap();
@@ -320,6 +768,436 @@ mod tests {
         assert_eq!(updates[0].hash, "0xledger123");
         assert_eq!(updates[0].delta["type"], "deposit");
     }
+
+    #[test]
+    fn test_deserialize_funding_history() {
+        let rates: Vec<HlFundingRate> =
+            serde_json::from_str(sample_funding_history_json()).unwrap();
+        assert_eq!(rates.len(), 2);
+        assert_eq!(rates[0].coin, "ETH");
+        assert_eq!(rates[0].funding_rate, "0.0001");
+        assert_eq!(rates[0].premium, "0.00005");
+        assert_eq!(rates[1].time, 1700003600000);
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 Connector capability tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_capabilities_target_kinds() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        assert_eq!(caps.chain_family, ChainFamily::Hyperliquid);
+        assert!(caps.supports_target_kind(TargetKind::Wallet));
+        assert!(caps.supports_target_kind(TargetKind::Market));
+        assert!(!caps.supports_target_kind(TargetKind::Contract));
+        assert!(!caps.supports_target_kind(TargetKind::Program));
+        assert!(!caps.supports_target_kind(TargetKind::Account));
+        assert!(!caps.supports_target_kind(TargetKind::TopicFilter));
+        assert!(!caps.supports_target_kind(TargetKind::Pool));
+        assert!(!caps.supports_target_kind(TargetKind::Protocol));
+    }
+
+    #[test]
+    fn test_capabilities_modes() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        assert!(caps.supports_mode(TargetMode::Backfill));
+        assert!(caps.supports_mode(TargetMode::Stream));
+    }
+
+    #[test]
+    fn test_capabilities_can_service_wallet() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        let target = make_target(
+            TargetKind::Wallet,
+            ChainFamily::Hyperliquid,
+            Some("0xabc"),
+            None,
+        );
+        assert!(caps.can_service(&target));
+    }
+
+    #[test]
+    fn test_capabilities_can_service_market() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        let target = make_target(
+            TargetKind::Market,
+            ChainFamily::Hyperliquid,
+            Some("ETH"),
+            None,
+        );
+        assert!(caps.can_service(&target));
+    }
+
+    #[test]
+    fn test_capabilities_rejects_wrong_chain_family() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        let target = make_target(TargetKind::Wallet, ChainFamily::Evm, Some("0xabc"), None);
+        assert!(!caps.can_service(&target));
+    }
+
+    #[test]
+    fn test_capabilities_rejects_unsupported_kind() {
+        let adapter = HyperliquidAdapter::new();
+        let caps = adapter.capabilities();
+        let target = make_target(
+            TargetKind::Contract,
+            ChainFamily::Hyperliquid,
+            Some("0xabc"),
+            None,
+        );
+        assert!(!caps.can_service(&target));
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 backfill error handling tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_backfill_rejects_wrong_chain_family() {
+        let adapter = HyperliquidAdapter::new();
+        let target = make_target(TargetKind::Wallet, ChainFamily::Evm, Some("0xabc"), None);
+        let result = adapter.backfill(&target, None, 10).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("only supports Hyperliquid"));
+    }
+
+    #[tokio::test]
+    async fn test_backfill_rejects_unsupported_target_kind() {
+        let adapter = HyperliquidAdapter::new();
+        let target = make_target(
+            TargetKind::Contract,
+            ChainFamily::Hyperliquid,
+            Some("0xabc"),
+            None,
+        );
+        let result = adapter.backfill(&target, None, 10).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("does not support target kind"));
+        assert!(err_msg.contains("Contract"));
+    }
+
+    #[tokio::test]
+    async fn test_backfill_rejects_program_target() {
+        let adapter = HyperliquidAdapter::new();
+        let target = make_target(
+            TargetKind::Program,
+            ChainFamily::Hyperliquid,
+            Some("abc"),
+            None,
+        );
+        let result = adapter.backfill(&target, None, 10).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support target kind"));
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 wallet backfill with mock server
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_v2_wallet_backfill_with_mock_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut stream = stream;
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let response_body = if request.contains("userFills") {
+                        r#"[{"coin":"BTC","px":"40000.0","sz":"0.1","side":"A","time":1700000000000,"hash":"0xtest1"}]"#
+                    } else if request.contains("userFunding") {
+                        r#"[{"time":1700000000000,"coin":"BTC","usdc":"1.23"}]"#
+                    } else if request.contains("userNonFundingLedgerUpdates") {
+                        r#"[{"time":1700000000000,"hash":"0xledger1","delta":{"type":"deposit","usdc":"5000.0"}}]"#
+                    } else {
+                        "[]"
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+
+        let adapter = HyperliquidAdapter::with_base_url(&base_url);
+        let target = make_target(
+            TargetKind::Wallet,
+            ChainFamily::Hyperliquid,
+            Some("0x1234567890abcdef1234567890abcdef12345678"),
+            None,
+        );
+
+        let batch = adapter.backfill(&target, None, 100).await.unwrap();
+        assert_eq!(batch.records.len(), 3);
+
+        // Verify all records are RawTransaction with no wallet_address/user_id
+        for record in &batch.records {
+            let json = serde_json::to_string(record).unwrap();
+            assert!(!json.contains("wallet_address"));
+            assert!(!json.contains("user_id"));
+            assert_eq!(record.network, "hypercore-mainnet");
+            assert_eq!(record.source, "hl-rest-wallet-backfill");
+        }
+
+        // Verify record types
+        assert_eq!(batch.records[0].raw_metadata["type"], "fill");
+        assert_eq!(batch.records[0].tx_hash, "0xtest1");
+        assert_eq!(batch.records[1].raw_metadata["type"], "funding");
+        assert_eq!(batch.records[2].raw_metadata["type"], "ledger_update");
+
+        server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 wallet backfill with cursor/checkpoint resume
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_v2_wallet_backfill_with_cursor_resume() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut stream = stream;
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let response_body = if request.contains("userFills") {
+                        r#"[{"coin":"BTC","px":"40000.0","sz":"0.1","side":"A","time":1700000000000,"hash":"0xold"}]"#
+                    } else {
+                        "[]"
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+
+        let adapter = HyperliquidAdapter::with_base_url(&base_url);
+        let target = make_target(
+            TargetKind::Wallet,
+            ChainFamily::Hyperliquid,
+            Some("0x1234567890abcdef1234567890abcdef12345678"),
+            None,
+        );
+
+        // Cursor at the same time as the mock fill (1700000000000ms)
+        // cursor_to_start_time_ms adds 1, so resume_ms = 1700000000001 > fill time
+        let cursor = serde_json::json!({ "last_time_ms": 1700000000000_i64 });
+        let batch = adapter.backfill(&target, Some(&cursor), 100).await.unwrap();
+
+        // Fill should be filtered out
+        assert_eq!(batch.records.len(), 0);
+
+        server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 market backfill with mock server
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_v2_market_backfill_with_mock_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut stream = stream;
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let response_body = if request.contains("fundingHistory") {
+                        r#"[{"coin":"ETH","fundingRate":"0.0001","premium":"0.00005","time":1700000000000},{"coin":"ETH","fundingRate":"0.00012","premium":"0.00006","time":1700003600000}]"#
+                    } else {
+                        "[]"
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+
+        let adapter = HyperliquidAdapter::with_base_url(&base_url);
+        let target = make_target(
+            TargetKind::Market,
+            ChainFamily::Hyperliquid,
+            Some("ETH"),
+            None,
+        );
+
+        let batch = adapter.backfill(&target, None, 100).await.unwrap();
+        assert_eq!(batch.records.len(), 2);
+
+        // Verify records are target-agnostic
+        for record in &batch.records {
+            let json = serde_json::to_string(record).unwrap();
+            assert!(!json.contains("wallet_address"));
+            assert!(!json.contains("user_id"));
+            assert_eq!(record.network, "hypercore-mainnet");
+            assert_eq!(record.source, "hl-rest-market-backfill");
+            assert_eq!(record.raw_metadata["type"], "funding_rate");
+            assert_eq!(record.block_number, None);
+        }
+
+        // Verify data content
+        assert_eq!(
+            batch.records[0].raw_metadata["data"]["fundingRate"],
+            "0.0001"
+        );
+        assert!(batch.records[0].tx_hash.starts_with("funding-rate-ETH-"));
+
+        server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 market backfill with limit
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_v2_market_backfill_respects_limit() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut stream = stream;
+                    let mut buf = vec![0u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let response_body = if request.contains("fundingHistory") {
+                        r#"[{"coin":"ETH","fundingRate":"0.0001","premium":"0.00005","time":1700000000000},{"coin":"ETH","fundingRate":"0.00012","premium":"0.00006","time":1700003600000}]"#
+                    } else {
+                        "[]"
+                    };
+
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+        });
+
+        let adapter = HyperliquidAdapter::with_base_url(&base_url);
+        let target = make_target(
+            TargetKind::Market,
+            ChainFamily::Hyperliquid,
+            Some("ETH"),
+            None,
+        );
+
+        // Limit to 1 record
+        let batch = adapter.backfill(&target, None, 1).await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+
+        server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 stream error tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_stream_rejects_wrong_chain_family() {
+        let adapter = HyperliquidAdapter::new();
+        let target = make_target(TargetKind::Wallet, ChainFamily::Evm, Some("0xabc"), None);
+        let result = adapter.stream(&target, None).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("only supports Hyperliquid"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_rejects_unsupported_target_kind() {
+        let adapter = HyperliquidAdapter::new();
+        let target = make_target(
+            TargetKind::Contract,
+            ChainFamily::Hyperliquid,
+            Some("0xabc"),
+            None,
+        );
+        let result = adapter.stream(&target, None).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not support streaming"));
+    }
+
+    // -----------------------------------------------------------------------
+    // V1 Legacy ChainIngestor tests (preserved byte-identical behavior)
+    // -----------------------------------------------------------------------
 
     #[tokio::test]
     async fn test_fetch_history_with_mock_server() {
@@ -485,7 +1363,11 @@ mod tests {
             .timeout(Duration::from_millis(200))
             .build()
             .unwrap();
-        let adapter = HyperliquidAdapter { client, base_url };
+        let adapter = HyperliquidAdapter {
+            client,
+            base_url,
+            ws_url: None,
+        };
 
         let result = adapter.fetch_user_fills("0xtest").await;
         assert!(result.is_err());
@@ -499,5 +1381,95 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // Cursor / checkpoint helpers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cursor_to_start_time_ms_none() {
+        assert_eq!(cursor_to_start_time_ms(None), 0);
+    }
+
+    #[test]
+    fn test_cursor_to_start_time_ms_with_value() {
+        let cursor = serde_json::json!({ "last_time_ms": 1700000000000_i64 });
+        // Should advance by 1ms past last seen
+        assert_eq!(cursor_to_start_time_ms(Some(&cursor)), 1700000000001);
+    }
+
+    #[test]
+    fn test_cursor_to_start_time_ms_missing_key() {
+        let cursor = serde_json::json!({ "other_key": 123 });
+        assert_eq!(cursor_to_start_time_ms(Some(&cursor)), 0);
+    }
+
+    #[test]
+    fn test_v2_source_strings() {
+        assert_eq!(
+            v2_source(TargetKind::Wallet, "stream"),
+            "hl-ws-wallet-stream"
+        );
+        assert_eq!(
+            v2_source(TargetKind::Market, "stream"),
+            "hl-ws-market-stream"
+        );
+        assert_eq!(
+            v2_source(TargetKind::Wallet, "backfill"),
+            "hl-ws-wallet-backfill"
+        );
+        assert_eq!(
+            v2_source(TargetKind::Contract, "stream"),
+            "hl-ws-unknown-stream"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RawTransaction output verification
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_raw_transaction_has_no_wallet_or_user_fields() {
+        let rt = RawTransaction {
+            id: Uuid::new_v4(),
+            network: "hypercore-mainnet".to_string(),
+            tx_hash: "0xtest".to_string(),
+            timestamp: 1700000000,
+            block_number: None,
+            raw_metadata: serde_json::json!({"type": "fill"}),
+            source: "hl-rest-wallet-backfill".to_string(),
+            ingestion_run_id: None,
+            ingested_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&rt).unwrap();
+        assert!(!json.contains("wallet_address"));
+        assert!(!json.contains("user_id"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    fn make_target(
+        kind: TargetKind,
+        chain_family: ChainFamily,
+        address: Option<&str>,
+        filter_spec: Option<serde_json::Value>,
+    ) -> IndexTarget {
+        let now = Utc::now();
+        IndexTarget {
+            id: Uuid::new_v4(),
+            kind,
+            network: "hypercore-mainnet".to_string(),
+            chain_family,
+            address: address.map(|s| s.to_string()),
+            filter_spec,
+            mode: TargetMode::Both,
+            label: None,
+            owner_id: None,
+            created_at: now,
+            updated_at: now,
+        }
     }
 }

--- a/adapters/src/hyperliquid_ws.rs
+++ b/adapters/src/hyperliquid_ws.rs
@@ -21,6 +21,8 @@ enum WsSubType<'a> {
     UserFundings { user: &'a str },
     #[serde(rename = "userNonFundingLedgerUpdates")]
     UserLedgerUpdates { user: &'a str },
+    #[serde(rename = "trades")]
+    Trades { coin: &'a str },
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -105,5 +107,119 @@ impl HyperliquidWsClient {
         let _ = write.send(Message::Close(None)).await;
 
         Ok(())
+    }
+
+    /// Subscribe to market trades for a specific coin.
+    ///
+    /// Uses the Hyperliquid WS `trades` channel which emits real-time
+    /// trade events for the given coin. Calls `on_message` for each
+    /// incoming message. Returns when the connection is closed or an
+    /// error occurs.
+    pub async fn subscribe_trades<F>(&self, coin: &str, mut on_message: F) -> anyhow::Result<()>
+    where
+        F: FnMut(WsMessage) + Send,
+    {
+        let (ws_stream, _) = connect_async(&self.url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        let sub = WsSubscription {
+            method: "subscribe",
+            subscription: WsSubType::Trades { coin },
+        };
+        let msg = serde_json::to_string(&sub)?;
+        write.send(Message::Text(msg)).await?;
+
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => match serde_json::from_str::<WsMessage>(&text) {
+                    Ok(ws_msg) => on_message(ws_msg),
+                    Err(e) => warn!(error = %e, "Failed to parse WebSocket trade message"),
+                },
+                Ok(Message::Ping(data)) => {
+                    write.send(Message::Pong(data)).await?;
+                }
+                Ok(Message::Close(_)) => break,
+                Err(e) => {
+                    error!(error = %e, "WebSocket error in trades stream");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let _ = write.send(Message::Close(None)).await;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trades_subscription_serialization() {
+        let sub = WsSubscription {
+            method: "subscribe",
+            subscription: WsSubType::Trades { coin: "SOL" },
+        };
+        let json = serde_json::to_string(&sub).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["method"], "subscribe");
+        assert_eq!(parsed["subscription"]["type"], "trades");
+        assert_eq!(parsed["subscription"]["coin"], "SOL");
+    }
+
+    #[test]
+    fn test_user_fills_subscription_serialization() {
+        let sub = WsSubscription {
+            method: "subscribe",
+            subscription: WsSubType::UserFills { user: "0xabc" },
+        };
+        let json = serde_json::to_string(&sub).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["method"], "subscribe");
+        assert_eq!(parsed["subscription"]["type"], "userFills");
+        assert_eq!(parsed["subscription"]["user"], "0xabc");
+    }
+
+    #[test]
+    fn test_user_fundings_subscription_serialization() {
+        let sub = WsSubscription {
+            method: "subscribe",
+            subscription: WsSubType::UserFundings { user: "0xdef" },
+        };
+        let json = serde_json::to_string(&sub).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["subscription"]["type"], "userFundings");
+    }
+
+    #[test]
+    fn test_user_ledger_updates_subscription_serialization() {
+        let sub = WsSubscription {
+            method: "subscribe",
+            subscription: WsSubType::UserLedgerUpdates { user: "0xghi" },
+        };
+        let json = serde_json::to_string(&sub).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed["subscription"]["type"],
+            "userNonFundingLedgerUpdates"
+        );
+    }
+
+    #[test]
+    fn test_ws_message_deserialization() {
+        let json = r#"{"channel":"trades","data":[{"coin":"ETH","side":"B","px":"3500.0","sz":"1.0","time":1700000000000}]}"#;
+        let msg: WsMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.channel.as_deref(), Some("trades"));
+        assert!(msg.data.is_some());
+    }
+
+    #[test]
+    fn test_ws_message_deserialization_subscription_response() {
+        let json = r#"{"channel":"subscriptionResponse","data":{"method":"subscribe","subscription":{"type":"trades","coin":"SOL"}}}"#;
+        let msg: WsMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.channel.as_deref(), Some("subscriptionResponse"));
     }
 }


### PR DESCRIPTION
## Summary

Phase 2, Work Packet 5: Implement V2 Connector trait for Hyperliquid adapters with wallet and market target kinds.

- **V2 Connector implementation** for `HyperliquidAdapter` declaring Wallet + Market target kinds, Backfill + Stream modes, and Hyperliquid chain family
- **Wallet backfill** produces target-agnostic `RawTransaction` records from existing REST methods (fills, funding, ledger updates)
- **Market backfill** uses new `fundingHistory` REST endpoint
- **Stream mode** spawns WS background tasks for both target types using `subscribe_user` (wallet) and `subscribe_trades` (market)
- **New `WsSubType::Trades`** variant added to `HyperliquidWsClient` with correct serialization
- **Legacy `ChainIngestor`** preserved byte-identical to main
- Unsupported targets return clear errors

## Validation

All 10 validation points pass:
- V2 Connector correctly declares Wallet+Market target kinds, Backfill+Stream modes, Hyperliquid chain family
- Wallet backfill produces target-agnostic RawTransaction records from fills, funding, and ledger updates
- Market backfill uses fundingHistory REST endpoint
- Stream spawns WS background tasks for both target types
- WsSubType::Trades variant added with correct serialization
- Legacy ChainIngestor is byte-identical to main
- Unsupported targets return clear errors
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (minus known flaky semaphore test)

## Test plan

- [ ] Review V2 Connector trait implementation for HyperliquidAdapter
- [ ] Verify wallet backfill produces correct RawTransaction records
- [ ] Verify market backfill uses fundingHistory endpoint correctly
- [ ] Verify WS stream spawning for wallet and market targets
- [ ] Confirm legacy ChainIngestor is unchanged
- [ ] CI passes (fmt, clippy, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)