### PR TITLE
P3-W2: Transfer and balance-delta datasets

### DIFF
--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -258,11 +258,97 @@ fn negate(val: BigDecimal) -> BigDecimal {
 }
 
 // ---------------------------------------------------------------------------
-// Materializer implementation
+// Token Transfer extraction (P3-W2)
 // ---------------------------------------------------------------------------
 
-use spectraplex_core::materializer::{DatasetDescriptor, DatasetName, Materializer};
+use chrono::Utc;
+use spectraplex_core::materializer::{DatasetDescriptor, DatasetName, Materializer, TokenTransfer};
 use spectraplex_core::v2::ChainFamily;
+use uuid::Uuid;
+
+/// Extract ERC-20 token transfers from an EVM raw transaction.
+///
+/// Decodes Transfer(address,address,uint256) events from raw log topics/data.
+/// Does not filter by wallet — emits all transfers found in the transaction.
+pub fn extract_evm_token_transfers(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<TokenTransfer> {
+    let mut transfers = Vec::new();
+
+    let topics = match raw_metadata.get("topics").and_then(|t| t.as_array()) {
+        Some(t) => t,
+        None => return vec![],
+    };
+
+    let topic0 = match topics.first().and_then(|t| t.as_str()) {
+        Some(t) => t,
+        None => return vec![],
+    };
+
+    if topic0 != ERC20_TRANSFER_TOPIC || topics.len() < 3 {
+        return vec![];
+    }
+
+    let from = topic_to_address(topics[1].as_str().unwrap_or_default());
+    let to = topic_to_address(topics[2].as_str().unwrap_or_default());
+
+    let data_hex = raw_metadata
+        .get("data")
+        .and_then(|d| d.as_str())
+        .unwrap_or("0x0");
+    let amount_bd = hex_to_bigdecimal(data_hex);
+
+    let token_address = raw_metadata
+        .get("address")
+        .and_then(|a| a.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let decimals = token_decimals(&token_address);
+    let symbol = token_symbol(&token_address);
+    let normalized = normalize_bigdecimal(amount_bd, decimals);
+
+    transfers.push(TokenTransfer {
+        id: Uuid::new_v4(),
+        raw_transaction_id: raw_tx_id,
+        network: network.to_string(),
+        token_address,
+        token_symbol: Some(symbol),
+        from_address: from,
+        to_address: to,
+        amount: normalized,
+        decimals: decimals as i32,
+        dataset_version_id: None,
+        created_at: Utc::now(),
+    });
+
+    transfers
+}
+
+// ---------------------------------------------------------------------------
+// EVM Native Balance Delta: DEFERRED
+// ---------------------------------------------------------------------------
+//
+// EVM native balance deltas require trace API (debug_traceTransaction or
+// trace_transaction) data which is not yet stored in Bronze raw_transactions.
+// The current Bronze model stores log-level data and transaction-level
+// metadata (value, gas_used, effective_gas_price), but this is insufficient
+// to compute accurate native balance deltas for all accounts in a transaction:
+//
+// - The "value" field only captures the direct ETH transfer.
+// - Internal transactions (contract-to-contract ETH transfers) are not
+//   visible without trace data.
+// - Gas refunds and self-destructs also affect balances.
+//
+// When Bronze gains trace API support (e.g. raw_evm_traces table), this
+// materializer should be implemented. Until then, DatasetName::NativeBalanceDeltas
+// is not supported for EVM chain family.
+
+// ---------------------------------------------------------------------------
+// Materializer implementations
+// ---------------------------------------------------------------------------
 
 /// Materializer wrapper for the EVM ledger parser.
 pub struct EvmLedgerMaterializer;
@@ -289,6 +375,38 @@ impl Materializer for EvmLedgerMaterializer {
             name: self.dataset_name(),
             description:
                 "EVM ledger entries: ERC-20 transfers, native ETH value transfers, and gas fees"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for EVM token transfers (ERC-20 Transfer events).
+pub struct EvmTokenTransferMaterializer;
+
+impl Materializer for EvmTokenTransferMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::TokenTransfers
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:evm_token_transfers_v1_a1c5e7b9"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Evm
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "EVM token transfers: ERC-20 Transfer events decoded from raw log topics and data"
                     .to_string(),
             source_bronze_tables: vec!["raw_transactions".to_string()],
             chain_families: vec![self.chain_family()],
@@ -587,6 +705,89 @@ mod tests {
         assert!(desc.validate().is_ok());
         assert_eq!(desc.name, DatasetName::LedgerEntries);
         assert_eq!(desc.chain_families, vec![ChainFamily::Evm]);
+    }
+
+    #[test]
+    fn evm_token_transfer_materializer_contract() {
+        let m = EvmTokenTransferMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::TokenTransfers);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Evm);
+        assert!(!m.parser_hash().is_empty());
+        assert_ne!(
+            m.parser_hash(),
+            EvmLedgerMaterializer.parser_hash(),
+            "distinct from ledger materializer"
+        );
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::TokenTransfers);
+    }
+
+    #[test]
+    fn evm_all_materializers_have_distinct_hashes() {
+        use std::collections::HashSet;
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(EvmLedgerMaterializer),
+            Box::new(EvmTokenTransferMaterializer),
+        ];
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            2,
+            "all EVM materializers must have distinct hashes"
+        );
+    }
+
+    #[test]
+    fn test_extract_evm_token_transfer_erc20() {
+        let from_padded = format!(
+            "0x000000000000000000000000{}",
+            "1111111111111111111111111111111111111111"
+        );
+        let to_padded = format!(
+            "0x000000000000000000000000{}",
+            "2222222222222222222222222222222222222222"
+        );
+        let metadata = json!({
+            "topics": [
+                ERC20_TRANSFER_TOPIC,
+                from_padded,
+                to_padded,
+            ],
+            "data": "0x0000000000000000000000000000000000000000000000000000000005f5e100", // 100_000_000
+            "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+        });
+
+        let transfers =
+            extract_evm_token_transfers(Some(Uuid::new_v4()), "ethereum-mainnet", &metadata);
+
+        assert_eq!(transfers.len(), 1);
+        let t = &transfers[0];
+        assert_eq!(t.from_address, "0x1111111111111111111111111111111111111111");
+        assert_eq!(t.to_address, "0x2222222222222222222222222222222222222222");
+        assert_eq!(t.token_symbol, Some("USDC".to_string()));
+        assert_eq!(t.decimals, 6);
+        assert_eq!(t.network, "ethereum-mainnet");
+        // 100_000_000 / 10^6 = 100
+        assert_eq!(t.amount, BigDecimal::from(100));
+    }
+
+    #[test]
+    fn test_extract_evm_token_transfer_no_topics() {
+        let metadata = json!({});
+        let transfers = extract_evm_token_transfers(None, "ethereum-mainnet", &metadata);
+        assert!(transfers.is_empty());
+    }
+
+    #[test]
+    fn test_extract_evm_token_transfer_non_transfer_topic() {
+        let metadata = json!({
+            "topics": ["0xabcdef"],
+            "data": "0x0",
+        });
+        let transfers = extract_evm_token_transfers(None, "ethereum-mainnet", &metadata);
+        assert!(transfers.is_empty());
     }
 
     #[test]

--- a/adapters/src/hyperliquid_parser.rs
+++ b/adapters/src/hyperliquid_parser.rs
@@ -169,11 +169,173 @@ fn parse_ledger_update(
 }
 
 // ---------------------------------------------------------------------------
-// Materializer implementation
+// Token Transfer extraction (P3-W2)
 // ---------------------------------------------------------------------------
 
-use spectraplex_core::materializer::{DatasetDescriptor, DatasetName, Materializer};
+use chrono::Utc;
+use spectraplex_core::materializer::{
+    DatasetDescriptor, DatasetName, Materializer, NativeBalanceDelta, TokenTransfer,
+};
 use spectraplex_core::v2::ChainFamily;
+use uuid::Uuid;
+
+/// Extract Hyperliquid token transfers from a raw transaction.
+///
+/// Deposits and withdrawals are modeled as USDC transfers between an external
+/// source/destination and the user's Hyperliquid account.
+pub fn extract_hyperliquid_token_transfers(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    wallet_address: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<TokenTransfer> {
+    let entry_type = raw_metadata["type"].as_str().unwrap_or("unknown");
+
+    match entry_type {
+        "ledger_update" => {
+            let data = &raw_metadata["data"];
+            let delta = &data["delta"];
+            let delta_type = delta["type"].as_str().unwrap_or("unknown");
+
+            match delta_type {
+                "deposit" => {
+                    let usdc = delta["usdc"].as_str().unwrap_or("0");
+                    let amount = BigDecimal::from_str(usdc).unwrap_or_default();
+                    if amount == BigDecimal::from(0) {
+                        return vec![];
+                    }
+                    vec![TokenTransfer {
+                        id: Uuid::new_v4(),
+                        raw_transaction_id: raw_tx_id,
+                        network: network.to_string(),
+                        token_address: "USDC".to_string(),
+                        token_symbol: Some("USDC".to_string()),
+                        from_address: "external".to_string(),
+                        to_address: wallet_address.to_string(),
+                        amount,
+                        decimals: 6,
+                        dataset_version_id: None,
+                        created_at: Utc::now(),
+                    }]
+                }
+                "withdraw" => {
+                    let usdc = delta["usdc"].as_str().unwrap_or("0");
+                    let amount = BigDecimal::from_str(usdc).unwrap_or_default().abs();
+                    if amount == BigDecimal::from(0) {
+                        return vec![];
+                    }
+                    vec![TokenTransfer {
+                        id: Uuid::new_v4(),
+                        raw_transaction_id: raw_tx_id,
+                        network: network.to_string(),
+                        token_address: "USDC".to_string(),
+                        token_symbol: Some("USDC".to_string()),
+                        from_address: wallet_address.to_string(),
+                        to_address: "external".to_string(),
+                        amount,
+                        decimals: 6,
+                        dataset_version_id: None,
+                        created_at: Utc::now(),
+                    }]
+                }
+                _ => vec![],
+            }
+        }
+        _ => vec![],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native Balance Delta extraction (P3-W2)
+// ---------------------------------------------------------------------------
+
+/// Extract Hyperliquid native balance deltas from a raw transaction.
+///
+/// On Hyperliquid, the "native" token is USDC (the settlement currency).
+/// Balance deltas are extracted from fill and funding events as changes to the
+/// account's USDC balance.
+pub fn extract_hyperliquid_native_balance_deltas(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    wallet_address: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<NativeBalanceDelta> {
+    let entry_type = raw_metadata["type"].as_str().unwrap_or("unknown");
+
+    match entry_type {
+        "fill" => {
+            let data = &raw_metadata["data"];
+            let fill: HlFill = match serde_json::from_value(data.clone()) {
+                Ok(f) => f,
+                Err(_) => return vec![],
+            };
+
+            // Fee and closed PnL represent USDC balance changes
+            let fee = fill
+                .fee
+                .as_deref()
+                .and_then(|f| BigDecimal::from_str(f).ok())
+                .unwrap_or_default();
+            let pnl = fill
+                .closed_pnl
+                .as_deref()
+                .and_then(|p| BigDecimal::from_str(p).ok())
+                .unwrap_or_default();
+
+            // Total USDC delta from this fill = -fee + closed_pnl
+            let delta = &pnl - &fee.abs();
+
+            if delta == BigDecimal::from(0) {
+                return vec![];
+            }
+
+            vec![NativeBalanceDelta {
+                id: Uuid::new_v4(),
+                raw_transaction_id: raw_tx_id,
+                network: network.to_string(),
+                account_address: wallet_address.to_string(),
+                native_token: "USDC".to_string(),
+                pre_balance: BigDecimal::from(0), // Not available from fill data
+                post_balance: BigDecimal::from(0), // Not available from fill data
+                delta,
+                is_fee_payer: true, // The user always pays fees on HL
+                dataset_version_id: None,
+                created_at: Utc::now(),
+            }]
+        }
+        "funding" => {
+            let data = &raw_metadata["data"];
+            let funding: HlFundingEntry = match serde_json::from_value(data.clone()) {
+                Ok(f) => f,
+                Err(_) => return vec![],
+            };
+
+            let delta = BigDecimal::from_str(&funding.usdc).unwrap_or_default();
+            if delta == BigDecimal::from(0) {
+                return vec![];
+            }
+
+            vec![NativeBalanceDelta {
+                id: Uuid::new_v4(),
+                raw_transaction_id: raw_tx_id,
+                network: network.to_string(),
+                account_address: wallet_address.to_string(),
+                native_token: "USDC".to_string(),
+                pre_balance: BigDecimal::from(0),
+                post_balance: BigDecimal::from(0),
+                delta,
+                is_fee_payer: false,
+                dataset_version_id: None,
+                created_at: Utc::now(),
+            }]
+        }
+        _ => vec![],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Materializer implementations
+// ---------------------------------------------------------------------------
 
 /// Materializer wrapper for the Hyperliquid ledger parser.
 pub struct HyperliquidLedgerMaterializer;
@@ -200,6 +362,68 @@ impl Materializer for HyperliquidLedgerMaterializer {
             name: self.dataset_name(),
             description:
                 "Hyperliquid ledger entries: fills, funding payments, deposits, and withdrawals"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Hyperliquid token transfers (deposits/withdrawals).
+pub struct HyperliquidTokenTransferMaterializer;
+
+impl Materializer for HyperliquidTokenTransferMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::TokenTransfers
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:hl_token_transfers_v1_e7f2a4d8"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Hyperliquid
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description: "Hyperliquid token transfers: USDC deposits and withdrawals".to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Hyperliquid native balance deltas.
+pub struct HyperliquidNativeBalanceDeltaMaterializer;
+
+impl Materializer for HyperliquidNativeBalanceDeltaMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::NativeBalanceDeltas
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:hl_native_deltas_v1_f3d6c9a2"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Hyperliquid
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Hyperliquid native balance deltas: USDC balance changes from fills and funding"
                     .to_string(),
             source_bronze_tables: vec!["raw_transactions".to_string()],
             chain_families: vec![self.chain_family()],
@@ -362,5 +586,197 @@ mod tests {
         assert!(desc.validate().is_ok());
         assert_eq!(desc.name, DatasetName::LedgerEntries);
         assert_eq!(desc.chain_families, vec![ChainFamily::Hyperliquid]);
+    }
+
+    #[test]
+    fn hyperliquid_token_transfer_materializer_contract() {
+        let m = HyperliquidTokenTransferMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::TokenTransfers);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Hyperliquid);
+        assert!(!m.parser_hash().is_empty());
+        assert_ne!(m.parser_hash(), HyperliquidLedgerMaterializer.parser_hash());
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::TokenTransfers);
+    }
+
+    #[test]
+    fn hyperliquid_native_balance_delta_materializer_contract() {
+        let m = HyperliquidNativeBalanceDeltaMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::NativeBalanceDeltas);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Hyperliquid);
+        assert!(!m.parser_hash().is_empty());
+        assert_ne!(m.parser_hash(), HyperliquidLedgerMaterializer.parser_hash());
+        assert_ne!(
+            m.parser_hash(),
+            HyperliquidTokenTransferMaterializer.parser_hash()
+        );
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::NativeBalanceDeltas);
+    }
+
+    #[test]
+    fn hyperliquid_all_materializers_have_distinct_hashes() {
+        use std::collections::HashSet;
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(HyperliquidLedgerMaterializer),
+            Box::new(HyperliquidTokenTransferMaterializer),
+            Box::new(HyperliquidNativeBalanceDeltaMaterializer),
+        ];
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            3,
+            "all 3 HL materializers must have distinct hashes"
+        );
+    }
+
+    #[test]
+    fn test_extract_hl_token_transfer_deposit() {
+        let metadata = serde_json::json!({
+            "type": "ledger_update",
+            "data": {
+                "time": 1700000000000u64,
+                "hash": "0xdep1",
+                "delta": { "type": "deposit", "usdc": "10000.0" }
+            }
+        });
+
+        let transfers = extract_hyperliquid_token_transfers(
+            Some(Uuid::new_v4()),
+            "hypercore-mainnet",
+            "0xtest",
+            &metadata,
+        );
+
+        assert_eq!(transfers.len(), 1);
+        let t = &transfers[0];
+        assert_eq!(t.from_address, "external");
+        assert_eq!(t.to_address, "0xtest");
+        assert_eq!(t.token_symbol, Some("USDC".to_string()));
+        assert_eq!(t.amount, BigDecimal::from_str("10000.0").unwrap());
+    }
+
+    #[test]
+    fn test_extract_hl_token_transfer_withdrawal() {
+        let metadata = serde_json::json!({
+            "type": "ledger_update",
+            "data": {
+                "time": 1700000000000u64,
+                "hash": "0xwith1",
+                "delta": { "type": "withdraw", "usdc": "5000.0" }
+            }
+        });
+
+        let transfers =
+            extract_hyperliquid_token_transfers(None, "hypercore-mainnet", "0xuser", &metadata);
+
+        assert_eq!(transfers.len(), 1);
+        let t = &transfers[0];
+        assert_eq!(t.from_address, "0xuser");
+        assert_eq!(t.to_address, "external");
+        assert_eq!(t.amount, BigDecimal::from_str("5000.0").unwrap());
+    }
+
+    #[test]
+    fn test_extract_hl_token_transfer_fill_returns_none() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "ETH",
+                "px": "3500.0",
+                "sz": "2.0",
+                "side": "B",
+                "time": 1700000000000u64,
+                "hash": "0xfill1",
+            }
+        });
+
+        let transfers =
+            extract_hyperliquid_token_transfers(None, "hypercore-mainnet", "0xtest", &metadata);
+        assert!(transfers.is_empty(), "fills are not token transfers");
+    }
+
+    #[test]
+    fn test_extract_hl_native_delta_fill() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "ETH",
+                "px": "3500.0",
+                "sz": "2.0",
+                "side": "B",
+                "time": 1700000000000u64,
+                "hash": "0xfill1",
+                "fee": "3.50",
+                "feeToken": "USDC",
+                "closedPnl": "100.0"
+            }
+        });
+
+        let deltas = extract_hyperliquid_native_balance_deltas(
+            Some(Uuid::new_v4()),
+            "hypercore-mainnet",
+            "0xuser",
+            &metadata,
+        );
+
+        assert_eq!(deltas.len(), 1);
+        let d = &deltas[0];
+        assert_eq!(d.account_address, "0xuser");
+        assert_eq!(d.native_token, "USDC");
+        // delta = pnl - |fee| = 100.0 - 3.50 = 96.50
+        assert_eq!(d.delta, BigDecimal::from_str("96.50").unwrap());
+        assert!(d.is_fee_payer);
+    }
+
+    #[test]
+    fn test_extract_hl_native_delta_funding() {
+        let metadata = serde_json::json!({
+            "type": "funding",
+            "data": {
+                "time": 1700000000000u64,
+                "coin": "ETH",
+                "usdc": "-2.50",
+                "fundingRate": "0.0001"
+            }
+        });
+
+        let deltas = extract_hyperliquid_native_balance_deltas(
+            None,
+            "hypercore-mainnet",
+            "0xuser",
+            &metadata,
+        );
+
+        assert_eq!(deltas.len(), 1);
+        let d = &deltas[0];
+        assert_eq!(d.delta, BigDecimal::from_str("-2.50").unwrap());
+        assert!(!d.is_fee_payer);
+    }
+
+    #[test]
+    fn test_extract_hl_native_delta_unknown_type() {
+        let metadata = serde_json::json!({
+            "type": "ledger_update",
+            "data": {
+                "time": 1700000000000u64,
+                "delta": { "type": "deposit", "usdc": "100.0" }
+            }
+        });
+
+        let deltas = extract_hyperliquid_native_balance_deltas(
+            None,
+            "hypercore-mainnet",
+            "0xuser",
+            &metadata,
+        );
+        assert!(
+            deltas.is_empty(),
+            "ledger_update does not produce native balance deltas"
+        );
     }
 }

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -130,4 +130,97 @@ mod tests {
             assert_eq!(desc.name, m.dataset_name());
         }
     }
+
+    // -- P3-W2: Token Transfer and Native Balance Delta materializer tests --
+
+    #[test]
+    fn all_token_transfer_materializers_produce_correct_dataset() {
+        use spectraplex_core::materializer::{DatasetName, Materializer};
+
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(solana_parser::SolanaTokenTransferMaterializer),
+            Box::new(evm_parser::EvmTokenTransferMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidTokenTransferMaterializer),
+        ];
+
+        for m in &materializers {
+            assert_eq!(
+                m.dataset_name(),
+                DatasetName::TokenTransfers,
+                "token transfer materializer for {:?} should produce token_transfers",
+                m.chain_family()
+            );
+        }
+    }
+
+    #[test]
+    fn all_native_balance_delta_materializers_produce_correct_dataset() {
+        use spectraplex_core::materializer::{DatasetName, Materializer};
+
+        // EVM native balance deltas are deferred — only Solana and Hyperliquid
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(solana_parser::SolanaNativeBalanceDeltaMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidNativeBalanceDeltaMaterializer),
+        ];
+
+        for m in &materializers {
+            assert_eq!(
+                m.dataset_name(),
+                DatasetName::NativeBalanceDeltas,
+                "native balance delta materializer for {:?} should produce native_balance_deltas",
+                m.chain_family()
+            );
+        }
+    }
+
+    #[test]
+    fn all_p3w2_materializers_have_globally_distinct_hashes() {
+        use spectraplex_core::materializer::Materializer;
+        use std::collections::HashSet;
+
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            // Ledger materializers (existing)
+            Box::new(solana_parser::SolanaLedgerMaterializer),
+            Box::new(evm_parser::EvmLedgerMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidLedgerMaterializer),
+            // Token transfer materializers (P3-W2)
+            Box::new(solana_parser::SolanaTokenTransferMaterializer),
+            Box::new(evm_parser::EvmTokenTransferMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidTokenTransferMaterializer),
+            // Native balance delta materializers (P3-W2, EVM deferred)
+            Box::new(solana_parser::SolanaNativeBalanceDeltaMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidNativeBalanceDeltaMaterializer),
+        ];
+
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            materializers.len(),
+            "all 8 materializers must have globally distinct parser_hash values"
+        );
+    }
+
+    #[test]
+    fn all_p3w2_materializer_descriptors_are_valid() {
+        use spectraplex_core::materializer::Materializer;
+
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(solana_parser::SolanaTokenTransferMaterializer),
+            Box::new(evm_parser::EvmTokenTransferMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidTokenTransferMaterializer),
+            Box::new(solana_parser::SolanaNativeBalanceDeltaMaterializer),
+            Box::new(hyperliquid_parser::HyperliquidNativeBalanceDeltaMaterializer),
+        ];
+
+        for m in &materializers {
+            let desc = m.descriptor();
+            assert!(
+                desc.validate().is_ok(),
+                "descriptor for {:?} / {:?} should be valid",
+                m.chain_family(),
+                m.dataset_name()
+            );
+            assert_eq!(desc.name, m.dataset_name());
+        }
+    }
 }

--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -176,11 +176,176 @@ fn spl_token_symbol(mint: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Materializer implementation
+// Token Transfer extraction (P3-W2)
 // ---------------------------------------------------------------------------
 
-use spectraplex_core::materializer::{DatasetDescriptor, DatasetName, Materializer};
+use chrono::Utc;
+use spectraplex_core::materializer::{
+    DatasetDescriptor, DatasetName, Materializer, NativeBalanceDelta, TokenTransfer,
+};
 use spectraplex_core::v2::ChainFamily;
+use uuid::Uuid;
+
+/// Extract SPL token transfers from a Solana raw transaction.
+///
+/// Uses pre/post token balance arrays from the transaction metadata to compute
+/// deltas for each token account owner. Emits one `TokenTransfer` per non-zero
+/// delta, with the owner as either from_address or to_address depending on sign.
+pub fn extract_solana_token_transfers(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<TokenTransfer> {
+    let sol_tx: EncodedConfirmedTransactionWithStatusMeta =
+        match serde_json::from_value(raw_metadata.clone()) {
+            Ok(tx) => tx,
+            Err(_) => return vec![],
+        };
+
+    let meta = match &sol_tx.transaction.meta {
+        Some(m) => m,
+        None => return vec![],
+    };
+
+    if meta.err.is_some() {
+        return vec![];
+    }
+
+    let mut transfers = Vec::new();
+
+    if let OptionSerializer::Some(pre_token_balances) = &meta.pre_token_balances {
+        if let OptionSerializer::Some(post_token_balances) = &meta.post_token_balances {
+            for post in post_token_balances {
+                let owner = match &post.owner {
+                    OptionSerializer::Some(o) => o.clone(),
+                    _ => continue,
+                };
+
+                let mint = post.mint.clone();
+                let decimals = post.ui_token_amount.decimals as u32;
+
+                let pre_raw = pre_token_balances
+                    .iter()
+                    .find(|p| p.account_index == post.account_index)
+                    .and_then(|p| p.ui_token_amount.amount.parse::<i128>().ok())
+                    .unwrap_or(0);
+
+                let post_raw = post.ui_token_amount.amount.parse::<i128>().unwrap_or(0);
+                let delta_raw = post_raw - pre_raw;
+
+                if delta_raw == 0 {
+                    continue;
+                }
+
+                let amount = token_raw_to_decimal(delta_raw.unsigned_abs() as i128, decimals);
+                let symbol = spl_token_symbol(&mint);
+
+                let (from, to) = if delta_raw > 0 {
+                    // Incoming: unknown sender -> owner
+                    ("unknown".to_string(), owner)
+                } else {
+                    // Outgoing: owner -> unknown receiver
+                    (owner, "unknown".to_string())
+                };
+
+                transfers.push(TokenTransfer {
+                    id: Uuid::new_v4(),
+                    raw_transaction_id: raw_tx_id,
+                    network: network.to_string(),
+                    token_address: mint,
+                    token_symbol: Some(symbol),
+                    from_address: from,
+                    to_address: to,
+                    amount,
+                    decimals: decimals as i32,
+                    dataset_version_id: None,
+                    created_at: Utc::now(),
+                });
+            }
+        }
+    }
+
+    transfers
+}
+
+// ---------------------------------------------------------------------------
+// Native Balance Delta extraction (P3-W2)
+// ---------------------------------------------------------------------------
+
+/// Extract SOL native balance deltas from a Solana raw transaction.
+///
+/// Uses pre/post balance arrays and the account keys from the transaction.
+/// Flags the first signer (index 0) as the fee payer.
+pub fn extract_solana_native_balance_deltas(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<NativeBalanceDelta> {
+    let sol_tx: EncodedConfirmedTransactionWithStatusMeta =
+        match serde_json::from_value(raw_metadata.clone()) {
+            Ok(tx) => tx,
+            Err(_) => return vec![],
+        };
+
+    let meta = match &sol_tx.transaction.meta {
+        Some(m) => m,
+        None => return vec![],
+    };
+
+    if meta.err.is_some() {
+        return vec![];
+    }
+
+    let account_keys: Vec<String> =
+        if let solana_transaction_status::EncodedTransaction::Json(ui_tx) =
+            &sol_tx.transaction.transaction
+        {
+            match &ui_tx.message {
+                solana_transaction_status::UiMessage::Parsed(msg) => {
+                    msg.account_keys.iter().map(|k| k.pubkey.clone()).collect()
+                }
+                solana_transaction_status::UiMessage::Raw(msg) => msg.account_keys.clone(),
+            }
+        } else {
+            return vec![];
+        };
+
+    let mut deltas = Vec::new();
+
+    for (idx, account) in account_keys.iter().enumerate() {
+        let pre = meta.pre_balances.get(idx).copied().unwrap_or(0) as i128;
+        let post = meta.post_balances.get(idx).copied().unwrap_or(0) as i128;
+        let change = post - pre;
+
+        if change == 0 {
+            continue;
+        }
+
+        let pre_sol = lamports_to_sol(pre);
+        let post_sol = lamports_to_sol(post);
+        let delta_sol = lamports_to_sol(change);
+
+        deltas.push(NativeBalanceDelta {
+            id: Uuid::new_v4(),
+            raw_transaction_id: raw_tx_id,
+            network: network.to_string(),
+            account_address: account.clone(),
+            native_token: "SOL".to_string(),
+            pre_balance: pre_sol,
+            post_balance: post_sol,
+            delta: delta_sol,
+            is_fee_payer: idx == 0,
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        });
+    }
+
+    deltas
+}
+
+// ---------------------------------------------------------------------------
+// Materializer implementations
+// ---------------------------------------------------------------------------
 
 /// Materializer wrapper for the Solana ledger parser.
 pub struct SolanaLedgerMaterializer;
@@ -207,6 +372,70 @@ impl Materializer for SolanaLedgerMaterializer {
             name: self.dataset_name(),
             description:
                 "Solana ledger entries: SOL balance changes, SPL token transfers, and fees"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Solana token transfers.
+pub struct SolanaTokenTransferMaterializer;
+
+impl Materializer for SolanaTokenTransferMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::TokenTransfers
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:solana_token_transfers_v1_d4e9f1a7"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Solana
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Solana token transfers: SPL token movements extracted from pre/post token balances"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Solana native balance deltas.
+pub struct SolanaNativeBalanceDeltaMaterializer;
+
+impl Materializer for SolanaNativeBalanceDeltaMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::NativeBalanceDeltas
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:solana_native_deltas_v1_b2c3a8f6"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Solana
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Solana native balance deltas: SOL balance changes per account with fee payer flag"
                     .to_string(),
             source_bronze_tables: vec!["raw_transactions".to_string()],
             chain_families: vec![self.chain_family()],
@@ -282,5 +511,61 @@ mod tests {
         assert!(desc.validate().is_ok());
         assert_eq!(desc.name, DatasetName::LedgerEntries);
         assert_eq!(desc.chain_families, vec![ChainFamily::Solana]);
+    }
+
+    #[test]
+    fn solana_token_transfer_materializer_contract() {
+        let m = SolanaTokenTransferMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::TokenTransfers);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Solana);
+        assert!(!m.parser_hash().is_empty());
+        assert_ne!(
+            m.parser_hash(),
+            SolanaLedgerMaterializer.parser_hash(),
+            "distinct from ledger materializer"
+        );
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::TokenTransfers);
+    }
+
+    #[test]
+    fn solana_native_balance_delta_materializer_contract() {
+        let m = SolanaNativeBalanceDeltaMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::NativeBalanceDeltas);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Solana);
+        assert!(!m.parser_hash().is_empty());
+        assert_ne!(
+            m.parser_hash(),
+            SolanaLedgerMaterializer.parser_hash(),
+            "distinct from ledger materializer"
+        );
+        assert_ne!(
+            m.parser_hash(),
+            SolanaTokenTransferMaterializer.parser_hash(),
+            "distinct from token transfer materializer"
+        );
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::NativeBalanceDeltas);
+    }
+
+    #[test]
+    fn solana_all_materializers_have_distinct_hashes() {
+        use std::collections::HashSet;
+
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(SolanaLedgerMaterializer),
+            Box::new(SolanaTokenTransferMaterializer),
+            Box::new(SolanaNativeBalanceDeltaMaterializer),
+        ];
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            3,
+            "all 3 Solana materializers must have distinct hashes"
+        );
     }
 }

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -4,6 +4,7 @@
 //! `Repository` value they already hold for V1 wallet-scoped queries.
 
 use chrono::{DateTime, Utc};
+use spectraplex_core::materializer::{NativeBalanceDelta, TokenTransfer};
 use spectraplex_core::v2::{
     ChainFamily, Checkpoint, DatasetVersion, DatasetVersionStatus, IndexTarget, IngestionRun,
     Network, RawTransaction, TargetKind, TargetMatch, TargetMode,
@@ -395,6 +396,159 @@ pub fn build_dataset_version_insert(
     args.add(&dv.notes).map_err(|e| anyhow::anyhow!("{e}"))?;
     args.add(dataset_version_status_to_sql(&dv.status))
         .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok((query, args))
+}
+
+// ---------------------------------------------------------------------------
+// Row-mapping helpers for Silver tables (P3-W2)
+// ---------------------------------------------------------------------------
+
+fn row_to_token_transfer(row: &sqlx::postgres::PgRow) -> anyhow::Result<TokenTransfer> {
+    use bigdecimal::BigDecimal;
+    Ok(TokenTransfer {
+        id: row.try_get("id")?,
+        raw_transaction_id: row.try_get("raw_transaction_id")?,
+        network: row.try_get("network")?,
+        token_address: row.try_get("token_address")?,
+        token_symbol: row.try_get("token_symbol")?,
+        from_address: row.try_get("from_address")?,
+        to_address: row.try_get("to_address")?,
+        amount: row.try_get::<BigDecimal, _>("amount")?,
+        decimals: row.try_get("decimals")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_native_balance_delta(row: &sqlx::postgres::PgRow) -> anyhow::Result<NativeBalanceDelta> {
+    use bigdecimal::BigDecimal;
+    Ok(NativeBalanceDelta {
+        id: row.try_get("id")?,
+        raw_transaction_id: row.try_get("raw_transaction_id")?,
+        network: row.try_get("network")?,
+        account_address: row.try_get("account_address")?,
+        native_token: row.try_get("native_token")?,
+        pre_balance: row.try_get::<BigDecimal, _>("pre_balance")?,
+        post_balance: row.try_get::<BigDecimal, _>("post_balance")?,
+        delta: row.try_get::<BigDecimal, _>("delta")?,
+        is_fee_payer: row.try_get("is_fee_payer")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Query builders for Silver tables (P3-W2)
+// ---------------------------------------------------------------------------
+
+/// Build a batch INSERT for `token_transfers` with ON CONFLICT DO NOTHING.
+pub fn build_token_transfer_insert(
+    transfers: &[TokenTransfer],
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let mut query = String::from(
+        "INSERT INTO token_transfers \
+         (id, raw_transaction_id, network, token_address, token_symbol, from_address, to_address, amount, decimals, dataset_version_id, created_at) \
+         VALUES ",
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    for (i, t) in transfers.iter().enumerate() {
+        let base = i * 11;
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!(
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5,
+            base + 6,
+            base + 7,
+            base + 8,
+            base + 9,
+            base + 10,
+            base + 11,
+        ));
+        use sqlx::Arguments;
+        args.add(t.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(t.raw_transaction_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.network).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.token_address)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.token_symbol)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.from_address)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.to_address)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&t.amount).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(t.decimals).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(t.dataset_version_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(t.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    query.push_str(
+        " ON CONFLICT (raw_transaction_id, from_address, to_address, token_address, amount) \
+         WHERE raw_transaction_id IS NOT NULL DO NOTHING",
+    );
+    Ok((query, args))
+}
+
+/// Build a batch INSERT for `native_balance_deltas` with ON CONFLICT DO NOTHING.
+pub fn build_native_balance_delta_insert(
+    deltas: &[NativeBalanceDelta],
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let mut query = String::from(
+        "INSERT INTO native_balance_deltas \
+         (id, raw_transaction_id, network, account_address, native_token, pre_balance, post_balance, delta, is_fee_payer, dataset_version_id, created_at) \
+         VALUES ",
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    for (i, d) in deltas.iter().enumerate() {
+        let base = i * 11;
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!(
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5,
+            base + 6,
+            base + 7,
+            base + 8,
+            base + 9,
+            base + 10,
+            base + 11,
+        ));
+        use sqlx::Arguments;
+        args.add(d.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(d.raw_transaction_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.network).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.account_address)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.native_token)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.pre_balance)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.post_balance)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&d.delta).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(d.is_fee_payer)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(d.dataset_version_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(d.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    query.push_str(
+        " ON CONFLICT (raw_transaction_id, account_address) \
+         WHERE raw_transaction_id IS NOT NULL DO NOTHING",
+    );
     Ok((query, args))
 }
 
@@ -829,6 +983,111 @@ impl Repository {
         let count: i64 = row.try_get("cnt")?;
         Ok(count)
     }
+
+    // -----------------------------------------------------------------------
+    // TokenTransfers (P3-W2)
+    // -----------------------------------------------------------------------
+
+    /// Bulk insert token transfer records.
+    pub async fn save_token_transfers(&self, transfers: &[TokenTransfer]) -> anyhow::Result<()> {
+        for chunk in transfers.chunks(Self::V2_BATCH_SIZE) {
+            let (query, args) = build_token_transfer_insert(chunk)?;
+            sqlx::query_with(&query, args).execute(self.pool()).await?;
+        }
+        Ok(())
+    }
+
+    /// Query token transfers by address (from or to).
+    pub async fn get_token_transfers_by_address(
+        &self,
+        address: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<TokenTransfer>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, token_address, token_symbol, \
+             from_address, to_address, amount, decimals, dataset_version_id, created_at \
+             FROM token_transfers \
+             WHERE from_address = $1 OR to_address = $1 \
+             ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(address)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_token_transfer).collect()
+    }
+
+    /// Query token transfers by raw transaction ID.
+    pub async fn get_token_transfers_by_raw_tx(
+        &self,
+        raw_tx_id: Uuid,
+    ) -> anyhow::Result<Vec<TokenTransfer>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, token_address, token_symbol, \
+             from_address, to_address, amount, decimals, dataset_version_id, created_at \
+             FROM token_transfers WHERE raw_transaction_id = $1 ORDER BY created_at",
+        )
+        .bind(raw_tx_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_token_transfer).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // NativeBalanceDeltas (P3-W2)
+    // -----------------------------------------------------------------------
+
+    /// Bulk insert native balance delta records.
+    pub async fn save_native_balance_deltas(
+        &self,
+        deltas: &[NativeBalanceDelta],
+    ) -> anyhow::Result<()> {
+        for chunk in deltas.chunks(Self::V2_BATCH_SIZE) {
+            let (query, args) = build_native_balance_delta_insert(chunk)?;
+            sqlx::query_with(&query, args).execute(self.pool()).await?;
+        }
+        Ok(())
+    }
+
+    /// Query native balance deltas by account address.
+    pub async fn get_native_balance_deltas_by_account(
+        &self,
+        account_address: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<NativeBalanceDelta>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, account_address, native_token, \
+             pre_balance, post_balance, delta, is_fee_payer, dataset_version_id, created_at \
+             FROM native_balance_deltas \
+             WHERE account_address = $1 \
+             ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(account_address)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_native_balance_delta).collect()
+    }
+
+    /// Query native balance deltas by raw transaction ID.
+    pub async fn get_native_balance_deltas_by_raw_tx(
+        &self,
+        raw_tx_id: Uuid,
+    ) -> anyhow::Result<Vec<NativeBalanceDelta>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, account_address, native_token, \
+             pre_balance, post_balance, delta, is_fee_payer, dataset_version_id, created_at \
+             FROM native_balance_deltas WHERE raw_transaction_id = $1 ORDER BY created_at",
+        )
+        .bind(raw_tx_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_native_balance_delta).collect()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,5 +1400,138 @@ mod tests {
     #[test]
     fn v2_batch_size_matches_v1() {
         assert_eq!(Repository::V2_BATCH_SIZE, 500);
+    }
+
+    // -- token_transfer batch insert (P3-W2) --
+
+    fn make_token_transfer() -> TokenTransfer {
+        use bigdecimal::BigDecimal;
+        TokenTransfer {
+            id: Uuid::new_v4(),
+            raw_transaction_id: Some(Uuid::new_v4()),
+            network: "ethereum-mainnet".to_string(),
+            token_address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+            token_symbol: Some("USDC".to_string()),
+            from_address: "0x1111111111111111111111111111111111111111".to_string(),
+            to_address: "0x2222222222222222222222222222222222222222".to_string(),
+            amount: BigDecimal::from(100),
+            decimals: 6,
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn make_native_balance_delta() -> NativeBalanceDelta {
+        use bigdecimal::BigDecimal;
+        NativeBalanceDelta {
+            id: Uuid::new_v4(),
+            raw_transaction_id: Some(Uuid::new_v4()),
+            network: "solana-mainnet".to_string(),
+            account_address: "DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy".to_string(),
+            native_token: "SOL".to_string(),
+            pre_balance: BigDecimal::from(10),
+            post_balance: BigDecimal::from(9),
+            delta: BigDecimal::from(-1),
+            is_fee_payer: true,
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn token_transfer_insert_single() {
+        let tt = make_token_transfer();
+        let (query, _) = build_token_transfer_insert(&[tt]).unwrap();
+
+        assert!(query.starts_with("INSERT INTO token_transfers"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn token_transfer_insert_multiple() {
+        let transfers: Vec<_> = (0..3).map(|_| make_token_transfer()).collect();
+        let (query, _) = build_token_transfer_insert(&transfers).unwrap();
+
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("($12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)"));
+        assert!(query.contains("($23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)"));
+    }
+
+    #[test]
+    fn token_transfer_insert_param_count() {
+        let transfers: Vec<_> = (0..5).map(|_| make_token_transfer()).collect();
+        let (query, _) = build_token_transfer_insert(&transfers).unwrap();
+        // 5 rows * 11 params = 55 => highest param is $55
+        assert!(query.contains("$55"));
+        assert!(!query.contains("$56"));
+    }
+
+    // -- native_balance_delta batch insert (P3-W2) --
+
+    #[test]
+    fn native_balance_delta_insert_single() {
+        let nbd = make_native_balance_delta();
+        let (query, _) = build_native_balance_delta_insert(&[nbd]).unwrap();
+
+        assert!(query.starts_with("INSERT INTO native_balance_deltas"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn native_balance_delta_insert_multiple() {
+        let deltas: Vec<_> = (0..3).map(|_| make_native_balance_delta()).collect();
+        let (query, _) = build_native_balance_delta_insert(&deltas).unwrap();
+
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("($12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)"));
+    }
+
+    #[test]
+    fn native_balance_delta_insert_param_count() {
+        let deltas: Vec<_> = (0..5).map(|_| make_native_balance_delta()).collect();
+        let (query, _) = build_native_balance_delta_insert(&deltas).unwrap();
+        // 5 rows * 11 params = 55 => highest param is $55
+        assert!(query.contains("$55"));
+        assert!(!query.contains("$56"));
+    }
+
+    // -- Repository method signatures (P3-W2) --
+
+    #[test]
+    fn repo_save_token_transfers_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.save_token_transfers(&[]));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_get_token_transfers_by_address_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.get_token_transfers_by_address("0x1", 10, 0));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_save_native_balance_deltas_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.save_native_balance_deltas(&[]));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_get_native_balance_deltas_by_account_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.get_native_balance_deltas_by_account("addr", 10, 0));
+        }
+        let _ = _check;
     }
 }

--- a/core/src/materializer.rs
+++ b/core/src/materializer.rs
@@ -1,11 +1,14 @@
 //! Dataset registry, Materializer trait, and regeneration types.
 //!
 //! This module defines canonical dataset identifiers, the `Materializer` trait
-//! for parser/materializer version tracking, and the types needed for
-//! Bronze-to-Silver regeneration.
+//! for parser/materializer version tracking, the types needed for
+//! Bronze-to-Silver regeneration, and Silver dataset record structs.
 
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString};
+use uuid::Uuid;
 
 use crate::v2::ChainFamily;
 
@@ -170,6 +173,66 @@ pub struct RegenerationRequest {
     pub reason: String,
     /// Whether to supersede the current version.
     pub supersede_current: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Silver Dataset Records
+// ---------------------------------------------------------------------------
+
+/// Normalized token transfer record across all chains.
+///
+/// Each record represents a single token movement extracted from Bronze data.
+/// Addresses are generic (not wallet-specific) to support contract, program,
+/// and protocol target types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenTransfer {
+    pub id: Uuid,
+    /// FK to raw_transactions; nullable during transition.
+    pub raw_transaction_id: Option<Uuid>,
+    pub network: String,
+    /// Token contract/mint address (e.g. SPL mint, ERC-20 contract).
+    pub token_address: String,
+    /// Human-readable symbol if resolvable; otherwise the token address.
+    pub token_symbol: Option<String>,
+    /// Sender address.
+    pub from_address: String,
+    /// Receiver address.
+    pub to_address: String,
+    /// Transfer amount (positive = movement from sender to receiver).
+    pub amount: BigDecimal,
+    /// Token decimals used for normalization.
+    pub decimals: i32,
+    /// FK to dataset_versions; nullable during transition.
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Native currency balance delta per account per transaction.
+///
+/// Each record represents the change in native token balance for a single
+/// account in a single transaction. Not wallet-specific — any account
+/// involved in a transaction can have a delta.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NativeBalanceDelta {
+    pub id: Uuid,
+    /// FK to raw_transactions; nullable during transition.
+    pub raw_transaction_id: Option<Uuid>,
+    pub network: String,
+    /// The account whose balance changed.
+    pub account_address: String,
+    /// Native token symbol (e.g. "SOL", "ETH", "USDC" for Hyperliquid).
+    pub native_token: String,
+    /// Balance before the transaction.
+    pub pre_balance: BigDecimal,
+    /// Balance after the transaction.
+    pub post_balance: BigDecimal,
+    /// Computed delta (post_balance - pre_balance).
+    pub delta: BigDecimal,
+    /// Whether this account was the fee payer for the transaction.
+    pub is_fee_payer: bool,
+    /// FK to dataset_versions; nullable during transition.
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
 }
 
 // ---------------------------------------------------------------------------
@@ -393,5 +456,131 @@ mod tests {
         let desc = m.descriptor();
         assert!(desc.validate().is_ok());
         assert_eq!(desc.name, m.dataset_name());
+    }
+
+    // -- TokenTransfer tests --
+
+    #[test]
+    fn token_transfer_serde_roundtrip() {
+        use bigdecimal::BigDecimal;
+        use std::str::FromStr;
+
+        let tt = TokenTransfer {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: Some(uuid::Uuid::new_v4()),
+            network: "solana-mainnet".to_string(),
+            token_address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            token_symbol: Some("USDC".to_string()),
+            from_address: "DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy".to_string(),
+            to_address: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
+            amount: BigDecimal::from_str("1000.50").unwrap(),
+            decimals: 6,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&tt).unwrap();
+        let back: TokenTransfer = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.network, "solana-mainnet");
+        assert_eq!(back.token_symbol, Some("USDC".to_string()));
+        assert_eq!(back.decimals, 6);
+        assert_eq!(back.amount, BigDecimal::from_str("1000.50").unwrap());
+    }
+
+    #[test]
+    fn token_transfer_no_wallet_specific_fields() {
+        let tt = TokenTransfer {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "ethereum-mainnet".to_string(),
+            token_address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+            token_symbol: Some("USDC".to_string()),
+            from_address: "0x1111111111111111111111111111111111111111".to_string(),
+            to_address: "0x2222222222222222222222222222222222222222".to_string(),
+            amount: BigDecimal::from(100),
+            decimals: 6,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&tt).unwrap();
+        assert!(
+            !json.contains("wallet_address"),
+            "TokenTransfer must not have wallet_address"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "TokenTransfer must not have user_id"
+        );
+    }
+
+    // -- NativeBalanceDelta tests --
+
+    #[test]
+    fn native_balance_delta_serde_roundtrip() {
+        use bigdecimal::BigDecimal;
+        use std::str::FromStr;
+
+        let nbd = NativeBalanceDelta {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: Some(uuid::Uuid::new_v4()),
+            network: "solana-mainnet".to_string(),
+            account_address: "DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy".to_string(),
+            native_token: "SOL".to_string(),
+            pre_balance: BigDecimal::from_str("10.5").unwrap(),
+            post_balance: BigDecimal::from_str("9.5").unwrap(),
+            delta: BigDecimal::from_str("-1.0").unwrap(),
+            is_fee_payer: true,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&nbd).unwrap();
+        let back: NativeBalanceDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.network, "solana-mainnet");
+        assert_eq!(back.native_token, "SOL");
+        assert!(back.is_fee_payer);
+        assert_eq!(back.delta, BigDecimal::from_str("-1.0").unwrap());
+    }
+
+    #[test]
+    fn native_balance_delta_no_wallet_specific_fields() {
+        let nbd = NativeBalanceDelta {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "ethereum-mainnet".to_string(),
+            account_address: "0x1111111111111111111111111111111111111111".to_string(),
+            native_token: "ETH".to_string(),
+            pre_balance: BigDecimal::from(100),
+            post_balance: BigDecimal::from(99),
+            delta: BigDecimal::from(-1),
+            is_fee_payer: false,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&nbd).unwrap();
+        assert!(
+            !json.contains("wallet_address"),
+            "NativeBalanceDelta must not have wallet_address"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "NativeBalanceDelta must not have user_id"
+        );
+    }
+
+    #[test]
+    fn native_balance_delta_zero_delta() {
+        let nbd = NativeBalanceDelta {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "solana-mainnet".to_string(),
+            account_address: "some_address".to_string(),
+            native_token: "SOL".to_string(),
+            pre_balance: BigDecimal::from(5),
+            post_balance: BigDecimal::from(5),
+            delta: BigDecimal::from(0),
+            is_fee_payer: false,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        assert_eq!(nbd.delta, BigDecimal::from(0));
     }
 }

--- a/docs/phase3/p3-w2-transfer-balance-delta-handoff.md
+++ b/docs/phase3/p3-w2-transfer-balance-delta-handoff.md
@@ -1,0 +1,117 @@
+# P3-W2: Transfer and Balance-Delta Datasets — Handoff
+
+## Summary
+
+This packet adds two new Silver datasets — `token_transfers` and `native_balance_deltas` — along with Materializer implementations for each supported chain family and repository methods for persistence and query.
+
+## Schema
+
+### token_transfers
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | UUID PK | |
+| raw_transaction_id | UUID FK → raw_transactions | Nullable during transition |
+| network | TEXT NOT NULL | Generic chain identifier |
+| token_address | TEXT NOT NULL | Mint (Solana) or contract (EVM) or symbol (HL) |
+| token_symbol | TEXT | Human-readable if resolvable |
+| from_address | TEXT NOT NULL | Sender address (generic, not wallet-specific) |
+| to_address | TEXT NOT NULL | Receiver address (generic, not wallet-specific) |
+| amount | NUMERIC NOT NULL | Normalized by decimals |
+| decimals | INT NOT NULL | Token decimal places |
+| dataset_version_id | UUID FK → dataset_versions | Nullable during transition |
+| created_at | TIMESTAMPTZ NOT NULL | Default NOW() |
+
+**Indexes:** from_address, to_address, raw_transaction_id, network, dataset_version_id.
+**Dedup:** Unique on (raw_transaction_id, from_address, to_address, token_address, amount) WHERE raw_transaction_id IS NOT NULL.
+
+### native_balance_deltas
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | UUID PK | |
+| raw_transaction_id | UUID FK → raw_transactions | Nullable during transition |
+| network | TEXT NOT NULL | Generic chain identifier |
+| account_address | TEXT NOT NULL | Account whose balance changed |
+| native_token | TEXT NOT NULL | e.g. "SOL", "ETH", "USDC" |
+| pre_balance | NUMERIC NOT NULL | Balance before tx |
+| post_balance | NUMERIC NOT NULL | Balance after tx |
+| delta | NUMERIC NOT NULL | post - pre |
+| is_fee_payer | BOOLEAN NOT NULL | True if account paid tx fees |
+| dataset_version_id | UUID FK → dataset_versions | Nullable during transition |
+| created_at | TIMESTAMPTZ NOT NULL | Default NOW() |
+
+**Indexes:** account_address, raw_transaction_id, network, dataset_version_id.
+**Dedup:** Unique on (raw_transaction_id, account_address) WHERE raw_transaction_id IS NOT NULL.
+
+## Materializer Implementations
+
+| Dataset | Chain Family | Struct | Parser Hash | Notes |
+|---------|-------------|--------|-------------|-------|
+| TokenTransfers | Solana | `SolanaTokenTransferMaterializer` | `sha256:solana_token_transfers_v1_d4e9f1a7` | Extracts SPL token movements from pre/post token balances |
+| TokenTransfers | EVM | `EvmTokenTransferMaterializer` | `sha256:evm_token_transfers_v1_a1c5e7b9` | Decodes ERC-20 Transfer events from log topics/data |
+| TokenTransfers | Hyperliquid | `HyperliquidTokenTransferMaterializer` | `sha256:hl_token_transfers_v1_e7f2a4d8` | Models deposits/withdrawals as USDC transfers |
+| NativeBalanceDeltas | Solana | `SolanaNativeBalanceDeltaMaterializer` | `sha256:solana_native_deltas_v1_b2c3a8f6` | Extracts SOL balance changes per account; flags fee payer |
+| NativeBalanceDeltas | Hyperliquid | `HyperliquidNativeBalanceDeltaMaterializer` | `sha256:hl_native_deltas_v1_f3d6c9a2` | USDC balance changes from fills and funding |
+
+All 8 materializers (3 ledger + 5 new) have globally distinct parser_hash values and valid descriptors.
+
+## Parser Extraction Functions
+
+| Function | Chain | Input | Output |
+|----------|-------|-------|--------|
+| `extract_solana_token_transfers()` | Solana | raw_metadata (EncodedConfirmedTransactionWithStatusMeta) | Vec<TokenTransfer> |
+| `extract_solana_native_balance_deltas()` | Solana | raw_metadata (EncodedConfirmedTransactionWithStatusMeta) | Vec<NativeBalanceDelta> |
+| `extract_evm_token_transfers()` | EVM | raw_metadata (log with topics/data/address) | Vec<TokenTransfer> |
+| `extract_hyperliquid_token_transfers()` | Hyperliquid | raw_metadata (ledger_update with deposit/withdraw delta) | Vec<TokenTransfer> |
+| `extract_hyperliquid_native_balance_deltas()` | Hyperliquid | raw_metadata (fill/funding) | Vec<NativeBalanceDelta> |
+
+## Repository Methods
+
+| Method | Table | Operation |
+|--------|-------|-----------|
+| `save_token_transfers()` | token_transfers | Bulk insert (chunked by V2_BATCH_SIZE=500) |
+| `get_token_transfers_by_address()` | token_transfers | Query by from_address OR to_address with LIMIT/OFFSET |
+| `get_token_transfers_by_raw_tx()` | token_transfers | Query by raw_transaction_id |
+| `save_native_balance_deltas()` | native_balance_deltas | Bulk insert (chunked by V2_BATCH_SIZE=500) |
+| `get_native_balance_deltas_by_account()` | native_balance_deltas | Query by account_address with LIMIT/OFFSET |
+| `get_native_balance_deltas_by_raw_tx()` | native_balance_deltas | Query by raw_transaction_id |
+
+## Deferred Decisions
+
+### EVM Native Balance Deltas — Deferred
+
+EVM native balance deltas require trace API data (`debug_traceTransaction` or `trace_transaction`) which is not yet stored in Bronze `raw_transactions`. The current Bronze model stores log-level data and transaction-level metadata (value, gas_used, effective_gas_price), but this is insufficient for accurate native balance deltas across all accounts because:
+
+- The `value` field only captures the direct ETH transfer between from/to.
+- Internal transactions (contract-to-contract ETH transfers) are invisible without traces.
+- Gas refunds and self-destructs also affect balances.
+
+**Resolution path:** When Bronze gains trace API support (e.g. a `raw_evm_traces` table), implement `EvmNativeBalanceDeltaMaterializer`. The `DatasetName::NativeBalanceDeltas` enum variant and table already exist; only the materializer and extraction function are missing for EVM.
+
+## Design Choices
+
+1. **Generic addresses, not wallet-specific.** Both tables use `from_address`/`to_address` and `account_address` — never `wallet_address` or `user_id`. This supports contract, program, and protocol target types.
+
+2. **Nullable FKs for transition safety.** `raw_transaction_id` and `dataset_version_id` are nullable so records can be created before full Bronze/versioning integration is complete.
+
+3. **Dedup indexes use WHERE NOT NULL guards.** Records without a raw_transaction_id skip the uniqueness constraint, allowing flexibility during the transition period.
+
+4. **Hyperliquid native token is USDC.** On Hyperliquid, the settlement currency is USDC, so `native_token` is "USDC" rather than a gas token. Pre/post balances are zero when absolute values are unavailable from fill/funding data — only the delta is populated.
+
+## Downstream Packet Dependencies
+
+- **P3-W3 (Event and instruction datasets):** Can proceed independently; uses the same Materializer trait and migration patterns.
+- **P3-W5 (Ledger as derived materialization):** Can now consume token_transfers and native_balance_deltas as inputs instead of re-deriving from Bronze.
+- **P3-W6 (Completeness metadata):** Should track completeness for token_transfers and native_balance_deltas alongside other datasets.
+- **P4-W1 (Dataset query API):** These new Silver tables are ready for dataset-oriented query endpoints.
+
+## Test Coverage
+
+- 574 tests pass (36 new tests added across core, adapters, and integration)
+- Domain struct serde roundtrips and no-wallet-field assertions
+- Materializer trait contract verification for all 5 new materializers
+- Globally distinct parser_hash validation across all 8 materializers
+- Query builder correctness (param counts, ON CONFLICT clauses)
+- Repository method Send-ability checks
+- Extraction function edge cases (empty data, non-matching types, zero amounts)

--- a/migrations/20260309100000_add_token_transfers.sql
+++ b/migrations/20260309100000_add_token_transfers.sql
@@ -1,0 +1,49 @@
+-- P3-W2: Token transfers Silver dataset.
+-- Normalized token transfer records across all chains.
+
+-- ---------------------------------------------------------------------------
+-- 1. Create token_transfers table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS token_transfers (
+    id                  UUID PRIMARY KEY,
+    raw_transaction_id  UUID REFERENCES raw_transactions(id),
+    network             TEXT NOT NULL,
+    token_address       TEXT NOT NULL,
+    token_symbol        TEXT,
+    from_address        TEXT NOT NULL,
+    to_address          TEXT NOT NULL,
+    amount              NUMERIC NOT NULL,
+    decimals            INT NOT NULL,
+    dataset_version_id  UUID REFERENCES dataset_versions(id),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Indexes for common query patterns
+-- ---------------------------------------------------------------------------
+
+-- Lookup by either address involved in a transfer (generic, not wallet-specific).
+CREATE INDEX IF NOT EXISTS idx_token_transfers_from_address
+    ON token_transfers(from_address);
+
+CREATE INDEX IF NOT EXISTS idx_token_transfers_to_address
+    ON token_transfers(to_address);
+
+-- Lookup by raw transaction for provenance tracking.
+CREATE INDEX IF NOT EXISTS idx_token_transfers_raw_tx
+    ON token_transfers(raw_transaction_id);
+
+-- Lookup by network for chain-scoped queries.
+CREATE INDEX IF NOT EXISTS idx_token_transfers_network
+    ON token_transfers(network);
+
+-- Lookup by dataset version for version-scoped queries.
+CREATE INDEX IF NOT EXISTS idx_token_transfers_dataset_version
+    ON token_transfers(dataset_version_id);
+
+-- Uniqueness: one transfer record per raw transaction + from + to + token.
+-- This prevents duplicate materialization of the same transfer.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_token_transfers_dedup
+    ON token_transfers(raw_transaction_id, from_address, to_address, token_address, amount)
+    WHERE raw_transaction_id IS NOT NULL;

--- a/migrations/20260309100001_add_native_balance_deltas.sql
+++ b/migrations/20260309100001_add_native_balance_deltas.sql
@@ -1,0 +1,46 @@
+-- P3-W2: Native balance deltas Silver dataset.
+-- Native currency balance changes per account per transaction.
+
+-- ---------------------------------------------------------------------------
+-- 1. Create native_balance_deltas table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS native_balance_deltas (
+    id                  UUID PRIMARY KEY,
+    raw_transaction_id  UUID REFERENCES raw_transactions(id),
+    network             TEXT NOT NULL,
+    account_address     TEXT NOT NULL,
+    native_token        TEXT NOT NULL,
+    pre_balance         NUMERIC NOT NULL,
+    post_balance        NUMERIC NOT NULL,
+    delta               NUMERIC NOT NULL,
+    is_fee_payer        BOOLEAN NOT NULL DEFAULT FALSE,
+    dataset_version_id  UUID REFERENCES dataset_versions(id),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Indexes for common query patterns
+-- ---------------------------------------------------------------------------
+
+-- Lookup by account address (generic, not wallet-specific).
+CREATE INDEX IF NOT EXISTS idx_native_balance_deltas_account
+    ON native_balance_deltas(account_address);
+
+-- Lookup by raw transaction for provenance tracking.
+CREATE INDEX IF NOT EXISTS idx_native_balance_deltas_raw_tx
+    ON native_balance_deltas(raw_transaction_id);
+
+-- Lookup by network for chain-scoped queries.
+CREATE INDEX IF NOT EXISTS idx_native_balance_deltas_network
+    ON native_balance_deltas(network);
+
+-- Lookup by dataset version for version-scoped queries.
+CREATE INDEX IF NOT EXISTS idx_native_balance_deltas_dataset_version
+    ON native_balance_deltas(dataset_version_id);
+
+-- Uniqueness: one delta record per raw transaction + account.
+-- This prevents duplicate materialization of the same balance change.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_native_balance_deltas_dedup
+    ON native_balance_deltas(raw_transaction_id, account_address)
+    WHERE raw_transaction_id IS NOT NULL;


### PR DESCRIPTION
## Summary

**Phase 3 · Work Packet 2** — Add normalized `token_transfers` and `native_balance_deltas` Silver tables with extraction, materialization, and query support for all chain families.

### What's included

- **Domain structs**: `TokenTransfer` and `NativeBalanceDelta` with full serde coverage
- **Migrations**: `token_transfers` and `native_balance_deltas` tables with `IF NOT EXISTS` guards and nullable FKs
- **Materializers**: 5 new `Materializer` implementations (8 total with globally distinct `parser_hash` values)
  - Solana token-transfer, EVM token-transfer, Hyperliquid token-transfer
  - Solana native-balance-delta, Hyperliquid native-balance-delta
- **Parser extraction**: Chain-family–specific extraction functions for Bronze → Silver
- **Repository methods**: Bulk insert and query for both new tables with parameterized queries and `ON CONFLICT` dedup
- **Tests**: 36 new tests (574 total), including serde roundtrip, materializer descriptor, and extraction coverage

### Deferred

- **EVM native balance deltas** — explicitly deferred pending trace API support in Bronze. Documented with justification and resolution path in handoff doc.

### Design notes

- No wallet-only assumptions in new Silver tables — columns use generic `address` semantics
- Tables are reusable datasets that support downstream materializations for wallets, contracts, protocols, etc.

## Tracked artifacts

- `docs/phase3/p3-w2-transfer-balance-delta-handoff.md`

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` — 574 tests pass (36 new) ✅

## Test plan

- [ ] Reviewer confirms new structs have all required fields
- [ ] Reviewer confirms migrations are idempotent (`IF NOT EXISTS`)
- [ ] Reviewer confirms all 8 materializer `parser_hash` values are globally unique
- [ ] Reviewer confirms EVM native-delta deferral is justified and documented
- [ ] CI passes all checks (fmt, clippy, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)