### PR TITLE
feat: Hyperliquid reusable Silver datasets (P3-W4)

### DIFF
--- a/adapters/src/hyperliquid_parser.rs
+++ b/adapters/src/hyperliquid_parser.rs
@@ -174,7 +174,8 @@ fn parse_ledger_update(
 
 use chrono::Utc;
 use spectraplex_core::materializer::{
-    DatasetDescriptor, DatasetName, Materializer, NativeBalanceDelta, TokenTransfer,
+    DatasetDescriptor, DatasetName, HlFillRecord, HlFundingPayment, HlPositionChange, Materializer,
+    NativeBalanceDelta, TokenTransfer,
 };
 use spectraplex_core::v2::ChainFamily;
 use uuid::Uuid;
@@ -424,6 +425,305 @@ impl Materializer for HyperliquidNativeBalanceDeltaMaterializer {
             name: self.dataset_name(),
             description:
                 "Hyperliquid native balance deltas: USDC balance changes from fills and funding"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HlFillRecord extraction (P3-W4)
+// ---------------------------------------------------------------------------
+
+/// Extract a normalized Hyperliquid fill record from raw transaction metadata.
+///
+/// Produces a fill record from "fill"-type Bronze raw_transactions.
+pub fn extract_hl_fill_records(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<HlFillRecord> {
+    let entry_type = raw_metadata["type"].as_str().unwrap_or("unknown");
+
+    if entry_type != "fill" {
+        return vec![];
+    }
+
+    let data = &raw_metadata["data"];
+    let fill: HlFill = match serde_json::from_value(data.clone()) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
+    let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
+    let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
+
+    let closed_pnl = fill
+        .closed_pnl
+        .as_deref()
+        .and_then(|s| BigDecimal::from_str(s).ok());
+    let fee = fill
+        .fee
+        .as_deref()
+        .and_then(|s| BigDecimal::from_str(s).ok());
+
+    vec![HlFillRecord {
+        id: Uuid::new_v4(),
+        raw_transaction_id: raw_tx_id,
+        network: network.to_string(),
+        coin: fill.coin,
+        side: fill.side,
+        price,
+        size,
+        direction: fill.dir,
+        closed_pnl,
+        fee,
+        fee_token: fill.fee_token,
+        fill_time: fill.time as i64,
+        order_id: fill.oid.map(|v| v as i64),
+        trade_id: fill.tid.map(|v| v as i64),
+        dataset_version_id: None,
+        created_at: Utc::now(),
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// HlFundingPayment extraction (P3-W4)
+// ---------------------------------------------------------------------------
+
+/// Extract a normalized Hyperliquid funding payment from raw transaction metadata.
+///
+/// Produces a funding payment record from "funding"-type Bronze raw_transactions.
+pub fn extract_hl_funding_payments(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<HlFundingPayment> {
+    let entry_type = raw_metadata["type"].as_str().unwrap_or("unknown");
+
+    if entry_type != "funding" {
+        return vec![];
+    }
+
+    let data = &raw_metadata["data"];
+    let funding: HlFundingEntry = match serde_json::from_value(data.clone()) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
+    let amount = BigDecimal::from_str(&funding.usdc).unwrap_or_default();
+    let funding_rate = funding
+        .funding_rate
+        .as_deref()
+        .and_then(|s| BigDecimal::from_str(s).ok());
+
+    vec![HlFundingPayment {
+        id: Uuid::new_v4(),
+        raw_transaction_id: raw_tx_id,
+        network: network.to_string(),
+        coin: funding.coin,
+        amount,
+        funding_rate,
+        payment_time: funding.time as i64,
+        dataset_version_id: None,
+        created_at: Utc::now(),
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// HlPositionChange extraction (P3-W4)
+// ---------------------------------------------------------------------------
+
+/// Extract a normalized Hyperliquid position change from raw transaction metadata.
+///
+/// Position changes are derived from fills (and liquidations). Each fill that
+/// opens, increases, or closes a position produces a position change record.
+pub fn extract_hl_position_changes(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<HlPositionChange> {
+    let entry_type = raw_metadata["type"].as_str().unwrap_or("unknown");
+
+    match entry_type {
+        "fill" => extract_position_change_from_fill(raw_tx_id, network, raw_metadata),
+        "ledger_update" => {
+            extract_position_change_from_liquidation(raw_tx_id, network, raw_metadata)
+        }
+        _ => vec![],
+    }
+}
+
+fn extract_position_change_from_fill(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<HlPositionChange> {
+    let data = &raw_metadata["data"];
+    let fill: HlFill = match serde_json::from_value(data.clone()) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
+    let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
+    let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
+
+    // Determine signed size_delta: buy = positive, sell = negative
+    let size_delta = if fill.side == "B" { size } else { -size };
+
+    vec![HlPositionChange {
+        id: Uuid::new_v4(),
+        raw_transaction_id: raw_tx_id,
+        network: network.to_string(),
+        coin: fill.coin,
+        side: fill.side,
+        size_delta,
+        price,
+        direction: fill.dir,
+        source_event: "fill".to_string(),
+        dataset_version_id: None,
+        created_at: Utc::now(),
+    }]
+}
+
+fn extract_position_change_from_liquidation(
+    raw_tx_id: Option<Uuid>,
+    network: &str,
+    raw_metadata: &serde_json::Value,
+) -> Vec<HlPositionChange> {
+    let data = &raw_metadata["data"];
+    let delta = &data["delta"];
+    let delta_type = delta["type"].as_str().unwrap_or("unknown");
+
+    if delta_type != "liquidation" {
+        return vec![];
+    }
+
+    // Liquidation events may contain leveraged position info
+    let coin = delta["coin"].as_str().unwrap_or("UNKNOWN");
+    let size_str = delta["sz"].as_str().unwrap_or("0");
+    let price_str = delta["px"].as_str().unwrap_or("0");
+    let side = delta["side"].as_str().unwrap_or("A");
+
+    let size = BigDecimal::from_str(size_str).unwrap_or_default();
+    let price = BigDecimal::from_str(price_str).unwrap_or_default();
+
+    if size == BigDecimal::from(0) {
+        return vec![];
+    }
+
+    // Liquidation closes a position, so size_delta is opposite to position side
+    let size_delta = if side == "B" { size } else { -size };
+
+    vec![HlPositionChange {
+        id: Uuid::new_v4(),
+        raw_transaction_id: raw_tx_id,
+        network: network.to_string(),
+        coin: coin.to_string(),
+        side: side.to_string(),
+        size_delta,
+        price,
+        direction: Some("Liquidation".to_string()),
+        source_event: "liquidation".to_string(),
+        dataset_version_id: None,
+        created_at: Utc::now(),
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// Materializer implementations (P3-W4)
+// ---------------------------------------------------------------------------
+
+/// Materializer for Hyperliquid fill records.
+pub struct HlFillMaterializer;
+
+impl Materializer for HlFillMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::HlFills
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:hl_fill_records_v1_a1b2c3d4"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Hyperliquid
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Hyperliquid fill records: normalized trade executions with price, size, fees, and PnL"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Hyperliquid funding payments.
+pub struct HlFundingPaymentMaterializer;
+
+impl Materializer for HlFundingPaymentMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::HlFunding
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:hl_funding_payments_v1_e5f6g7h8"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Hyperliquid
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Hyperliquid funding payments: periodic funding rate payments received or paid"
+                    .to_string(),
+            source_bronze_tables: vec!["raw_transactions".to_string()],
+            chain_families: vec![self.chain_family()],
+        }
+    }
+}
+
+/// Materializer for Hyperliquid position changes.
+pub struct HlPositionChangeMaterializer;
+
+impl Materializer for HlPositionChangeMaterializer {
+    fn dataset_name(&self) -> DatasetName {
+        DatasetName::Positions
+    }
+
+    fn parser_version(&self) -> i32 {
+        1
+    }
+
+    fn parser_hash(&self) -> &str {
+        "sha256:hl_position_changes_v1_i9j0k1l2"
+    }
+
+    fn chain_family(&self) -> ChainFamily {
+        ChainFamily::Hyperliquid
+    }
+
+    fn descriptor(&self) -> DatasetDescriptor {
+        DatasetDescriptor {
+            name: self.dataset_name(),
+            description:
+                "Hyperliquid position changes: state changes derived from fills and liquidations"
                     .to_string(),
             source_bronze_tables: vec!["raw_transactions".to_string()],
             chain_families: vec![self.chain_family()],
@@ -777,6 +1077,361 @@ mod tests {
         assert!(
             deltas.is_empty(),
             "ledger_update does not produce native balance deltas"
+        );
+    }
+
+    // -- HlFillRecord extraction tests (P3-W4) --
+
+    #[test]
+    fn test_extract_hl_fill_record_buy() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "ETH",
+                "px": "3500.0",
+                "sz": "2.0",
+                "side": "B",
+                "time": 1700000000000u64,
+                "hash": "0xfill1",
+                "fee": "3.50",
+                "feeToken": "USDC",
+                "closedPnl": "0.0",
+                "dir": "Open Long",
+                "oid": 12345,
+                "tid": 67890
+            }
+        });
+
+        let fills = extract_hl_fill_records(Some(Uuid::new_v4()), "hypercore-mainnet", &metadata);
+
+        assert_eq!(fills.len(), 1);
+        let f = &fills[0];
+        assert_eq!(f.coin, "ETH");
+        assert_eq!(f.side, "B");
+        assert_eq!(f.price, BigDecimal::from_str("3500.0").unwrap());
+        assert_eq!(f.size, BigDecimal::from_str("2.0").unwrap());
+        assert_eq!(f.direction, Some("Open Long".to_string()));
+        assert_eq!(f.fee, Some(BigDecimal::from_str("3.50").unwrap()));
+        assert_eq!(f.fee_token, Some("USDC".to_string()));
+        assert_eq!(f.fill_time, 1700000000000);
+        assert_eq!(f.order_id, Some(12345));
+        assert_eq!(f.trade_id, Some(67890));
+        assert_eq!(f.network, "hypercore-mainnet");
+    }
+
+    #[test]
+    fn test_extract_hl_fill_record_sell_with_pnl() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "BTC",
+                "px": "42000.0",
+                "sz": "0.5",
+                "side": "A",
+                "time": 1700000000000u64,
+                "hash": "0xfill2",
+                "fee": "10.50",
+                "feeToken": "USDC",
+                "closedPnl": "500.0",
+                "dir": "Close Long"
+            }
+        });
+
+        let fills = extract_hl_fill_records(None, "hypercore-mainnet", &metadata);
+
+        assert_eq!(fills.len(), 1);
+        let f = &fills[0];
+        assert_eq!(f.coin, "BTC");
+        assert_eq!(f.side, "A");
+        assert_eq!(f.closed_pnl, Some(BigDecimal::from_str("500.0").unwrap()));
+        assert_eq!(f.direction, Some("Close Long".to_string()));
+    }
+
+    #[test]
+    fn test_extract_hl_fill_record_funding_returns_none() {
+        let metadata = serde_json::json!({
+            "type": "funding",
+            "data": {
+                "time": 1700000000000u64,
+                "coin": "ETH",
+                "usdc": "-2.50",
+                "fundingRate": "0.0001"
+            }
+        });
+
+        let fills = extract_hl_fill_records(None, "hypercore-mainnet", &metadata);
+        assert!(
+            fills.is_empty(),
+            "funding events should not produce fill records"
+        );
+    }
+
+    // -- HlFundingPayment extraction tests (P3-W4) --
+
+    #[test]
+    fn test_extract_hl_funding_payment() {
+        let metadata = serde_json::json!({
+            "type": "funding",
+            "data": {
+                "time": 1700000000000u64,
+                "coin": "ETH",
+                "usdc": "-2.50",
+                "fundingRate": "0.0001"
+            }
+        });
+
+        let payments =
+            extract_hl_funding_payments(Some(Uuid::new_v4()), "hypercore-mainnet", &metadata);
+
+        assert_eq!(payments.len(), 1);
+        let p = &payments[0];
+        assert_eq!(p.coin, "ETH");
+        assert_eq!(p.amount, BigDecimal::from_str("-2.50").unwrap());
+        assert_eq!(
+            p.funding_rate,
+            Some(BigDecimal::from_str("0.0001").unwrap())
+        );
+        assert_eq!(p.payment_time, 1700000000000);
+        assert_eq!(p.network, "hypercore-mainnet");
+    }
+
+    #[test]
+    fn test_extract_hl_funding_payment_positive() {
+        let metadata = serde_json::json!({
+            "type": "funding",
+            "data": {
+                "time": 1700000001000u64,
+                "coin": "BTC",
+                "usdc": "5.00",
+                "fundingRate": "-0.0002"
+            }
+        });
+
+        let payments = extract_hl_funding_payments(None, "hypercore-mainnet", &metadata);
+
+        assert_eq!(payments.len(), 1);
+        let p = &payments[0];
+        assert_eq!(p.coin, "BTC");
+        assert_eq!(p.amount, BigDecimal::from_str("5.00").unwrap());
+    }
+
+    #[test]
+    fn test_extract_hl_funding_payment_fill_returns_none() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "ETH",
+                "px": "3500.0",
+                "sz": "2.0",
+                "side": "B",
+                "time": 1700000000000u64,
+                "hash": "0xfill1"
+            }
+        });
+
+        let payments = extract_hl_funding_payments(None, "hypercore-mainnet", &metadata);
+        assert!(
+            payments.is_empty(),
+            "fills should not produce funding payments"
+        );
+    }
+
+    // -- HlPositionChange extraction tests (P3-W4) --
+
+    #[test]
+    fn test_extract_hl_position_change_from_fill_buy() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "ETH",
+                "px": "3500.0",
+                "sz": "2.0",
+                "side": "B",
+                "time": 1700000000000u64,
+                "hash": "0xfill1",
+                "dir": "Open Long"
+            }
+        });
+
+        let changes =
+            extract_hl_position_changes(Some(Uuid::new_v4()), "hypercore-mainnet", &metadata);
+
+        assert_eq!(changes.len(), 1);
+        let c = &changes[0];
+        assert_eq!(c.coin, "ETH");
+        assert_eq!(c.side, "B");
+        assert_eq!(c.size_delta, BigDecimal::from_str("2.0").unwrap());
+        assert_eq!(c.price, BigDecimal::from_str("3500.0").unwrap());
+        assert_eq!(c.direction, Some("Open Long".to_string()));
+        assert_eq!(c.source_event, "fill");
+    }
+
+    #[test]
+    fn test_extract_hl_position_change_from_fill_sell() {
+        let metadata = serde_json::json!({
+            "type": "fill",
+            "data": {
+                "coin": "BTC",
+                "px": "42000.0",
+                "sz": "0.5",
+                "side": "A",
+                "time": 1700000000000u64,
+                "hash": "0xfill2",
+                "dir": "Close Long"
+            }
+        });
+
+        let changes = extract_hl_position_changes(None, "hypercore-mainnet", &metadata);
+
+        assert_eq!(changes.len(), 1);
+        let c = &changes[0];
+        assert_eq!(c.coin, "BTC");
+        assert_eq!(c.side, "A");
+        assert_eq!(c.size_delta, BigDecimal::from_str("-0.5").unwrap());
+        assert_eq!(c.direction, Some("Close Long".to_string()));
+        assert_eq!(c.source_event, "fill");
+    }
+
+    #[test]
+    fn test_extract_hl_position_change_from_liquidation() {
+        let metadata = serde_json::json!({
+            "type": "ledger_update",
+            "data": {
+                "time": 1700000000000u64,
+                "hash": "0xliq1",
+                "delta": {
+                    "type": "liquidation",
+                    "coin": "ETH",
+                    "sz": "5.0",
+                    "px": "3000.0",
+                    "side": "A"
+                }
+            }
+        });
+
+        let changes =
+            extract_hl_position_changes(Some(Uuid::new_v4()), "hypercore-mainnet", &metadata);
+
+        assert_eq!(changes.len(), 1);
+        let c = &changes[0];
+        assert_eq!(c.coin, "ETH");
+        assert_eq!(c.side, "A");
+        assert_eq!(c.size_delta, BigDecimal::from_str("-5.0").unwrap());
+        assert_eq!(c.direction, Some("Liquidation".to_string()));
+        assert_eq!(c.source_event, "liquidation");
+    }
+
+    #[test]
+    fn test_extract_hl_position_change_from_deposit_returns_none() {
+        let metadata = serde_json::json!({
+            "type": "ledger_update",
+            "data": {
+                "time": 1700000000000u64,
+                "hash": "0xdep1",
+                "delta": { "type": "deposit", "usdc": "10000.0" }
+            }
+        });
+
+        let changes = extract_hl_position_changes(None, "hypercore-mainnet", &metadata);
+        assert!(
+            changes.is_empty(),
+            "deposits should not produce position changes"
+        );
+    }
+
+    #[test]
+    fn test_extract_hl_position_change_from_funding_returns_none() {
+        let metadata = serde_json::json!({
+            "type": "funding",
+            "data": {
+                "time": 1700000000000u64,
+                "coin": "ETH",
+                "usdc": "-2.50",
+                "fundingRate": "0.0001"
+            }
+        });
+
+        let changes = extract_hl_position_changes(None, "hypercore-mainnet", &metadata);
+        assert!(
+            changes.is_empty(),
+            "funding events should not produce position changes"
+        );
+    }
+
+    // -- P3-W4 Materializer contract tests --
+
+    #[test]
+    fn hl_fill_materializer_contract() {
+        let m = HlFillMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::HlFills);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Hyperliquid);
+        assert!(!m.parser_hash().is_empty());
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::HlFills);
+        assert_eq!(desc.chain_families, vec![ChainFamily::Hyperliquid]);
+    }
+
+    #[test]
+    fn hl_funding_payment_materializer_contract() {
+        let m = HlFundingPaymentMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::HlFunding);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Hyperliquid);
+        assert!(!m.parser_hash().is_empty());
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::HlFunding);
+    }
+
+    #[test]
+    fn hl_position_change_materializer_contract() {
+        let m = HlPositionChangeMaterializer;
+        assert_eq!(m.dataset_name(), DatasetName::Positions);
+        assert_eq!(m.parser_version(), 1);
+        assert_eq!(m.chain_family(), ChainFamily::Hyperliquid);
+        assert!(!m.parser_hash().is_empty());
+        let desc = m.descriptor();
+        assert!(desc.validate().is_ok());
+        assert_eq!(desc.name, DatasetName::Positions);
+    }
+
+    #[test]
+    fn hl_all_p3w4_materializers_have_distinct_hashes() {
+        use std::collections::HashSet;
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            Box::new(HlFillMaterializer),
+            Box::new(HlFundingPaymentMaterializer),
+            Box::new(HlPositionChangeMaterializer),
+        ];
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            3,
+            "all 3 P3-W4 materializers must have distinct hashes"
+        );
+    }
+
+    #[test]
+    fn hl_all_materializers_have_distinct_hashes_across_all_hl() {
+        use std::collections::HashSet;
+        let materializers: Vec<Box<dyn Materializer>> = vec![
+            // P3-W1 / existing
+            Box::new(HyperliquidLedgerMaterializer),
+            // P3-W2
+            Box::new(HyperliquidTokenTransferMaterializer),
+            Box::new(HyperliquidNativeBalanceDeltaMaterializer),
+            // P3-W4
+            Box::new(HlFillMaterializer),
+            Box::new(HlFundingPaymentMaterializer),
+            Box::new(HlPositionChangeMaterializer),
+        ];
+        let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
+        assert_eq!(
+            hashes.len(),
+            6,
+            "all 6 HL materializers must have distinct hashes"
         );
     }
 }

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -212,13 +212,17 @@ mod tests {
             // Decoded event materializers (P3-W3)
             Box::new(evm_parser::EvmDecodedEventMaterializer),
             Box::new(solana_parser::SolanaDecodedEventMaterializer),
+            // Hyperliquid Silver dataset materializers (P3-W4)
+            Box::new(hyperliquid_parser::HlFillMaterializer),
+            Box::new(hyperliquid_parser::HlFundingPaymentMaterializer),
+            Box::new(hyperliquid_parser::HlPositionChangeMaterializer),
         ];
 
         let hashes: HashSet<&str> = materializers.iter().map(|m| m.parser_hash()).collect();
         assert_eq!(
             hashes.len(),
             materializers.len(),
-            "all 10 materializers must have globally distinct parser_hash values"
+            "all 13 materializers must have globally distinct parser_hash values"
         );
     }
 
@@ -234,6 +238,10 @@ mod tests {
             Box::new(hyperliquid_parser::HyperliquidNativeBalanceDeltaMaterializer),
             Box::new(evm_parser::EvmDecodedEventMaterializer),
             Box::new(solana_parser::SolanaDecodedEventMaterializer),
+            // P3-W4 materializers
+            Box::new(hyperliquid_parser::HlFillMaterializer),
+            Box::new(hyperliquid_parser::HlFundingPaymentMaterializer),
+            Box::new(hyperliquid_parser::HlPositionChangeMaterializer),
         ];
 
         for m in &materializers {

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -4,7 +4,10 @@
 //! `Repository` value they already hold for V1 wallet-scoped queries.
 
 use chrono::{DateTime, Utc};
-use spectraplex_core::materializer::{DecodedEvent, NativeBalanceDelta, TokenTransfer};
+use spectraplex_core::materializer::{
+    DecodedEvent, HlFillRecord, HlFundingPayment, HlPositionChange, NativeBalanceDelta,
+    TokenTransfer,
+};
 use spectraplex_core::v2::{
     ChainFamily, Checkpoint, DatasetVersion, DatasetVersionStatus, IndexTarget, IngestionRun,
     Network, RawTransaction, TargetKind, TargetMatch, TargetMode,
@@ -633,6 +636,229 @@ pub fn build_decoded_event_insert(
 }
 
 // ---------------------------------------------------------------------------
+// Row-mapping helpers for Silver tables (P3-W4)
+// ---------------------------------------------------------------------------
+
+fn row_to_hl_fill_record(row: &sqlx::postgres::PgRow) -> anyhow::Result<HlFillRecord> {
+    Ok(HlFillRecord {
+        id: row.try_get("id")?,
+        raw_transaction_id: row.try_get("raw_transaction_id")?,
+        network: row.try_get("network")?,
+        coin: row.try_get("coin")?,
+        side: row.try_get("side")?,
+        price: row.try_get("price")?,
+        size: row.try_get("size")?,
+        direction: row.try_get("direction")?,
+        closed_pnl: row.try_get("closed_pnl")?,
+        fee: row.try_get("fee")?,
+        fee_token: row.try_get("fee_token")?,
+        fill_time: row.try_get("fill_time")?,
+        order_id: row.try_get("order_id")?,
+        trade_id: row.try_get("trade_id")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_hl_funding_payment(row: &sqlx::postgres::PgRow) -> anyhow::Result<HlFundingPayment> {
+    Ok(HlFundingPayment {
+        id: row.try_get("id")?,
+        raw_transaction_id: row.try_get("raw_transaction_id")?,
+        network: row.try_get("network")?,
+        coin: row.try_get("coin")?,
+        amount: row.try_get("amount")?,
+        funding_rate: row.try_get("funding_rate")?,
+        payment_time: row.try_get("payment_time")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_hl_position_change(row: &sqlx::postgres::PgRow) -> anyhow::Result<HlPositionChange> {
+    Ok(HlPositionChange {
+        id: row.try_get("id")?,
+        raw_transaction_id: row.try_get("raw_transaction_id")?,
+        network: row.try_get("network")?,
+        coin: row.try_get("coin")?,
+        side: row.try_get("side")?,
+        size_delta: row.try_get("size_delta")?,
+        price: row.try_get("price")?,
+        direction: row.try_get("direction")?,
+        source_event: row.try_get("source_event")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Query builders for Silver tables (P3-W4)
+// ---------------------------------------------------------------------------
+
+/// Build a batch INSERT for `hl_fill_records` with ON CONFLICT DO NOTHING.
+pub fn build_hl_fill_record_insert(
+    fills: &[HlFillRecord],
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let mut query = String::from(
+        "INSERT INTO hl_fill_records \
+         (id, raw_transaction_id, network, coin, side, price, size, direction, closed_pnl, fee, fee_token, fill_time, order_id, trade_id, dataset_version_id, created_at) \
+         VALUES ",
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    for (i, f) in fills.iter().enumerate() {
+        let base = i * 16;
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!(
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5,
+            base + 6,
+            base + 7,
+            base + 8,
+            base + 9,
+            base + 10,
+            base + 11,
+            base + 12,
+            base + 13,
+            base + 14,
+            base + 15,
+            base + 16,
+        ));
+        use sqlx::Arguments;
+        args.add(f.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.raw_transaction_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.network).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.coin).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.side).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.price).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.size).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.direction).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.closed_pnl)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.fee).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&f.fee_token).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.fill_time).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.order_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.trade_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.dataset_version_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(f.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    query.push_str(
+        " ON CONFLICT (raw_transaction_id, coin, fill_time, side) \
+         WHERE raw_transaction_id IS NOT NULL DO NOTHING",
+    );
+    Ok((query, args))
+}
+
+/// Build a batch INSERT for `hl_funding_payments` with ON CONFLICT DO NOTHING.
+pub fn build_hl_funding_payment_insert(
+    payments: &[HlFundingPayment],
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let mut query = String::from(
+        "INSERT INTO hl_funding_payments \
+         (id, raw_transaction_id, network, coin, amount, funding_rate, payment_time, dataset_version_id, created_at) \
+         VALUES ",
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    for (i, p) in payments.iter().enumerate() {
+        let base = i * 9;
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!(
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5,
+            base + 6,
+            base + 7,
+            base + 8,
+            base + 9,
+        ));
+        use sqlx::Arguments;
+        args.add(p.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(p.raw_transaction_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&p.network).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&p.coin).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&p.amount).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&p.funding_rate)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(p.payment_time)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(p.dataset_version_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(p.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    query.push_str(
+        " ON CONFLICT (raw_transaction_id, coin, payment_time) \
+         WHERE raw_transaction_id IS NOT NULL DO NOTHING",
+    );
+    Ok((query, args))
+}
+
+/// Build a batch INSERT for `hl_position_changes` with ON CONFLICT DO NOTHING.
+pub fn build_hl_position_change_insert(
+    changes: &[HlPositionChange],
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let mut query = String::from(
+        "INSERT INTO hl_position_changes \
+         (id, raw_transaction_id, network, coin, side, size_delta, price, direction, source_event, dataset_version_id, created_at) \
+         VALUES ",
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    for (i, c) in changes.iter().enumerate() {
+        let base = i * 11;
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!(
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            base + 1,
+            base + 2,
+            base + 3,
+            base + 4,
+            base + 5,
+            base + 6,
+            base + 7,
+            base + 8,
+            base + 9,
+            base + 10,
+            base + 11,
+        ));
+        use sqlx::Arguments;
+        args.add(c.id).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(c.raw_transaction_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.network).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.coin).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.side).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.size_delta)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.price).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.direction).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(&c.source_event)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(c.dataset_version_id)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(c.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    query.push_str(
+        " ON CONFLICT (raw_transaction_id, coin, side, source_event) \
+         WHERE raw_transaction_id IS NOT NULL DO NOTHING",
+    );
+    Ok((query, args))
+}
+
+// ---------------------------------------------------------------------------
 // V2 Repository impl
 // ---------------------------------------------------------------------------
 
@@ -1219,6 +1445,165 @@ impl Repository {
         .await?;
         rows.iter().map(row_to_decoded_event).collect()
     }
+
+    // -----------------------------------------------------------------------
+    // HlFillRecords (P3-W4)
+    // -----------------------------------------------------------------------
+
+    /// Bulk insert Hyperliquid fill records.
+    pub async fn save_hl_fill_records(&self, fills: &[HlFillRecord]) -> anyhow::Result<()> {
+        for chunk in fills.chunks(Self::V2_BATCH_SIZE) {
+            let (query, args) = build_hl_fill_record_insert(chunk)?;
+            sqlx::query_with(&query, args).execute(self.pool()).await?;
+        }
+        Ok(())
+    }
+
+    /// Query Hyperliquid fill records by coin.
+    pub async fn get_hl_fill_records_by_coin(
+        &self,
+        coin: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<HlFillRecord>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, side, price, size, direction, \
+             closed_pnl, fee, fee_token, fill_time, order_id, trade_id, dataset_version_id, created_at \
+             FROM hl_fill_records \
+             WHERE coin = $1 \
+             ORDER BY fill_time DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(coin)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_fill_record).collect()
+    }
+
+    /// Query Hyperliquid fill records by raw transaction ID.
+    pub async fn get_hl_fill_records_by_raw_tx(
+        &self,
+        raw_tx_id: Uuid,
+    ) -> anyhow::Result<Vec<HlFillRecord>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, side, price, size, direction, \
+             closed_pnl, fee, fee_token, fill_time, order_id, trade_id, dataset_version_id, created_at \
+             FROM hl_fill_records WHERE raw_transaction_id = $1 ORDER BY fill_time",
+        )
+        .bind(raw_tx_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_fill_record).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // HlFundingPayments (P3-W4)
+    // -----------------------------------------------------------------------
+
+    /// Bulk insert Hyperliquid funding payment records.
+    pub async fn save_hl_funding_payments(
+        &self,
+        payments: &[HlFundingPayment],
+    ) -> anyhow::Result<()> {
+        for chunk in payments.chunks(Self::V2_BATCH_SIZE) {
+            let (query, args) = build_hl_funding_payment_insert(chunk)?;
+            sqlx::query_with(&query, args).execute(self.pool()).await?;
+        }
+        Ok(())
+    }
+
+    /// Query Hyperliquid funding payments by coin.
+    pub async fn get_hl_funding_payments_by_coin(
+        &self,
+        coin: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<HlFundingPayment>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, amount, funding_rate, \
+             payment_time, dataset_version_id, created_at \
+             FROM hl_funding_payments \
+             WHERE coin = $1 \
+             ORDER BY payment_time DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(coin)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_funding_payment).collect()
+    }
+
+    /// Query Hyperliquid funding payments by raw transaction ID.
+    pub async fn get_hl_funding_payments_by_raw_tx(
+        &self,
+        raw_tx_id: Uuid,
+    ) -> anyhow::Result<Vec<HlFundingPayment>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, amount, funding_rate, \
+             payment_time, dataset_version_id, created_at \
+             FROM hl_funding_payments WHERE raw_transaction_id = $1 ORDER BY payment_time",
+        )
+        .bind(raw_tx_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_funding_payment).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // HlPositionChanges (P3-W4)
+    // -----------------------------------------------------------------------
+
+    /// Bulk insert Hyperliquid position change records.
+    pub async fn save_hl_position_changes(
+        &self,
+        changes: &[HlPositionChange],
+    ) -> anyhow::Result<()> {
+        for chunk in changes.chunks(Self::V2_BATCH_SIZE) {
+            let (query, args) = build_hl_position_change_insert(chunk)?;
+            sqlx::query_with(&query, args).execute(self.pool()).await?;
+        }
+        Ok(())
+    }
+
+    /// Query Hyperliquid position changes by coin.
+    pub async fn get_hl_position_changes_by_coin(
+        &self,
+        coin: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<HlPositionChange>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, side, size_delta, price, \
+             direction, source_event, dataset_version_id, created_at \
+             FROM hl_position_changes \
+             WHERE coin = $1 \
+             ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(coin)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_position_change).collect()
+    }
+
+    /// Query Hyperliquid position changes by raw transaction ID.
+    pub async fn get_hl_position_changes_by_raw_tx(
+        &self,
+        raw_tx_id: Uuid,
+    ) -> anyhow::Result<Vec<HlPositionChange>> {
+        let rows = sqlx::query(
+            "SELECT id, raw_transaction_id, network, coin, side, size_delta, price, \
+             direction, source_event, dataset_version_id, created_at \
+             FROM hl_position_changes WHERE raw_transaction_id = $1 ORDER BY created_at",
+        )
+        .bind(raw_tx_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_hl_position_change).collect()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1743,6 +2128,242 @@ mod tests {
         fn _assert_send<F: std::future::Future + Send>(_: F) {}
         fn _check(repo: &Repository) {
             _assert_send(repo.get_decoded_events_by_contract("0xabc", 10, 0));
+        }
+        let _ = _check;
+    }
+
+    // -- hl_fill_record batch insert (P3-W4) --
+
+    fn make_hl_fill_record() -> HlFillRecord {
+        use bigdecimal::BigDecimal;
+        HlFillRecord {
+            id: Uuid::new_v4(),
+            raw_transaction_id: Some(Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            side: "B".to_string(),
+            price: BigDecimal::from(3500),
+            size: BigDecimal::from(2),
+            direction: Some("Open Long".to_string()),
+            closed_pnl: Some(BigDecimal::from(0)),
+            fee: Some(BigDecimal::from(3)),
+            fee_token: Some("USDC".to_string()),
+            fill_time: 1700000000000,
+            order_id: Some(12345),
+            trade_id: Some(67890),
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn make_hl_funding_payment() -> HlFundingPayment {
+        use bigdecimal::BigDecimal;
+        HlFundingPayment {
+            id: Uuid::new_v4(),
+            raw_transaction_id: Some(Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            amount: BigDecimal::from(-3),
+            funding_rate: Some(BigDecimal::from(1)),
+            payment_time: 1700000000000,
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn make_hl_position_change() -> HlPositionChange {
+        use bigdecimal::BigDecimal;
+        HlPositionChange {
+            id: Uuid::new_v4(),
+            raw_transaction_id: Some(Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            side: "B".to_string(),
+            size_delta: BigDecimal::from(2),
+            price: BigDecimal::from(3500),
+            direction: Some("Open Long".to_string()),
+            source_event: "fill".to_string(),
+            dataset_version_id: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn hl_fill_record_insert_single() {
+        let fill = make_hl_fill_record();
+        let (query, _) = build_hl_fill_record_insert(&[fill]).unwrap();
+
+        assert!(query.starts_with("INSERT INTO hl_fill_records"));
+        assert!(query
+            .contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"));
+        assert!(query.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn hl_fill_record_insert_multiple() {
+        let fills: Vec<_> = (0..3).map(|_| make_hl_fill_record()).collect();
+        let (query, _) = build_hl_fill_record_insert(&fills).unwrap();
+
+        assert!(query
+            .contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"));
+        assert!(query.contains(
+            "($17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32)"
+        ));
+    }
+
+    #[test]
+    fn hl_fill_record_insert_param_count() {
+        let fills: Vec<_> = (0..5).map(|_| make_hl_fill_record()).collect();
+        let (query, _) = build_hl_fill_record_insert(&fills).unwrap();
+        // 5 rows * 16 params = 80 => highest param is $80
+        assert!(query.contains("$80"));
+        assert!(!query.contains("$81"));
+    }
+
+    #[test]
+    fn hl_fill_record_insert_dedup_clause() {
+        let fill = make_hl_fill_record();
+        let (query, _) = build_hl_fill_record_insert(&[fill]).unwrap();
+
+        assert!(query.contains("ON CONFLICT (raw_transaction_id, coin, fill_time, side)"));
+        assert!(query.contains("WHERE raw_transaction_id IS NOT NULL"));
+        assert!(query.contains("DO NOTHING"));
+    }
+
+    // -- hl_funding_payment batch insert (P3-W4) --
+
+    #[test]
+    fn hl_funding_payment_insert_single() {
+        let payment = make_hl_funding_payment();
+        let (query, _) = build_hl_funding_payment_insert(&[payment]).unwrap();
+
+        assert!(query.starts_with("INSERT INTO hl_funding_payments"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9)"));
+        assert!(query.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn hl_funding_payment_insert_multiple() {
+        let payments: Vec<_> = (0..3).map(|_| make_hl_funding_payment()).collect();
+        let (query, _) = build_hl_funding_payment_insert(&payments).unwrap();
+
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9)"));
+        assert!(query.contains("($10, $11, $12, $13, $14, $15, $16, $17, $18)"));
+        assert!(query.contains("($19, $20, $21, $22, $23, $24, $25, $26, $27)"));
+    }
+
+    #[test]
+    fn hl_funding_payment_insert_param_count() {
+        let payments: Vec<_> = (0..5).map(|_| make_hl_funding_payment()).collect();
+        let (query, _) = build_hl_funding_payment_insert(&payments).unwrap();
+        // 5 rows * 9 params = 45 => highest param is $45
+        assert!(query.contains("$45"));
+        assert!(!query.contains("$46"));
+    }
+
+    #[test]
+    fn hl_funding_payment_insert_dedup_clause() {
+        let payment = make_hl_funding_payment();
+        let (query, _) = build_hl_funding_payment_insert(&[payment]).unwrap();
+
+        assert!(query.contains("ON CONFLICT (raw_transaction_id, coin, payment_time)"));
+        assert!(query.contains("WHERE raw_transaction_id IS NOT NULL"));
+        assert!(query.contains("DO NOTHING"));
+    }
+
+    // -- hl_position_change batch insert (P3-W4) --
+
+    #[test]
+    fn hl_position_change_insert_single() {
+        let change = make_hl_position_change();
+        let (query, _) = build_hl_position_change_insert(&[change]).unwrap();
+
+        assert!(query.starts_with("INSERT INTO hl_position_changes"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn hl_position_change_insert_multiple() {
+        let changes: Vec<_> = (0..3).map(|_| make_hl_position_change()).collect();
+        let (query, _) = build_hl_position_change_insert(&changes).unwrap();
+
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("($12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)"));
+        assert!(query.contains("($23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)"));
+    }
+
+    #[test]
+    fn hl_position_change_insert_param_count() {
+        let changes: Vec<_> = (0..5).map(|_| make_hl_position_change()).collect();
+        let (query, _) = build_hl_position_change_insert(&changes).unwrap();
+        // 5 rows * 11 params = 55 => highest param is $55
+        assert!(query.contains("$55"));
+        assert!(!query.contains("$56"));
+    }
+
+    #[test]
+    fn hl_position_change_insert_dedup_clause() {
+        let change = make_hl_position_change();
+        let (query, _) = build_hl_position_change_insert(&[change]).unwrap();
+
+        assert!(query.contains("ON CONFLICT (raw_transaction_id, coin, side, source_event)"));
+        assert!(query.contains("WHERE raw_transaction_id IS NOT NULL"));
+        assert!(query.contains("DO NOTHING"));
+    }
+
+    // -- Repository method signatures (P3-W4) --
+
+    #[test]
+    fn repo_save_hl_fill_records_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.save_hl_fill_records(&[]));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_get_hl_fill_records_by_coin_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.get_hl_fill_records_by_coin("ETH", 10, 0));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_save_hl_funding_payments_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.save_hl_funding_payments(&[]));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_get_hl_funding_payments_by_coin_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.get_hl_funding_payments_by_coin("ETH", 10, 0));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_save_hl_position_changes_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.save_hl_position_changes(&[]));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn repo_get_hl_position_changes_by_coin_is_send() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            _assert_send(repo.get_hl_position_changes_by_coin("ETH", 10, 0));
         }
         let _ = _check;
     }

--- a/core/src/materializer.rs
+++ b/core/src/materializer.rs
@@ -263,6 +263,96 @@ pub struct NativeBalanceDelta {
     pub created_at: DateTime<Utc>,
 }
 
+/// Normalized Hyperliquid fill record.
+///
+/// Each record represents a single fill (trade execution) on Hyperliquid,
+/// extracted from Bronze raw_transactions metadata. Not wallet-specific —
+/// any account's fills can be represented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlFillRecord {
+    pub id: Uuid,
+    /// FK to raw_transactions; nullable during transition.
+    pub raw_transaction_id: Option<Uuid>,
+    pub network: String,
+    /// The traded asset (e.g. "ETH", "BTC").
+    pub coin: String,
+    /// Trade side: "B" (buy) or "A"/"S" (sell).
+    pub side: String,
+    /// Execution price as a decimal string.
+    pub price: BigDecimal,
+    /// Fill size (quantity).
+    pub size: BigDecimal,
+    /// Trade direction (e.g. "Open Long", "Close Short").
+    pub direction: Option<String>,
+    /// Realized PnL from closing a position.
+    pub closed_pnl: Option<BigDecimal>,
+    /// Fee charged for this fill.
+    pub fee: Option<BigDecimal>,
+    /// Token used to pay the fee (typically "USDC").
+    pub fee_token: Option<String>,
+    /// Timestamp of the fill (milliseconds since epoch).
+    pub fill_time: i64,
+    /// Hyperliquid order ID.
+    pub order_id: Option<i64>,
+    /// Hyperliquid trade ID.
+    pub trade_id: Option<i64>,
+    /// FK to dataset_versions; nullable during transition.
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Normalized Hyperliquid funding payment record.
+///
+/// Each record represents a single funding payment received or paid on
+/// Hyperliquid. Not wallet-specific — any account's funding payments
+/// can be represented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlFundingPayment {
+    pub id: Uuid,
+    /// FK to raw_transactions; nullable during transition.
+    pub raw_transaction_id: Option<Uuid>,
+    pub network: String,
+    /// The asset the funding rate applies to (e.g. "ETH").
+    pub coin: String,
+    /// USDC amount: positive = received, negative = paid.
+    pub amount: BigDecimal,
+    /// The funding rate applied.
+    pub funding_rate: Option<BigDecimal>,
+    /// Timestamp of the funding payment (milliseconds since epoch).
+    pub payment_time: i64,
+    /// FK to dataset_versions; nullable during transition.
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Normalized Hyperliquid position change record.
+///
+/// Each record represents a position state change derived from fills,
+/// liquidations, or other events. Not wallet-specific — any account's
+/// position changes can be represented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlPositionChange {
+    pub id: Uuid,
+    /// FK to raw_transactions; nullable during transition.
+    pub raw_transaction_id: Option<Uuid>,
+    pub network: String,
+    /// The asset whose position changed (e.g. "ETH").
+    pub coin: String,
+    /// Trade side that caused the change: "B" (buy) or "A"/"S" (sell).
+    pub side: String,
+    /// Size delta from this event (signed: positive = increase, negative = decrease).
+    pub size_delta: BigDecimal,
+    /// Execution price of the triggering event.
+    pub price: BigDecimal,
+    /// Direction of the position change (e.g. "Open Long", "Close Short").
+    pub direction: Option<String>,
+    /// Source event type: "fill", "liquidation".
+    pub source_event: String,
+    /// FK to dataset_versions; nullable during transition.
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -673,5 +763,177 @@ mod tests {
             created_at: chrono::Utc::now(),
         };
         assert_eq!(nbd.delta, BigDecimal::from(0));
+    }
+
+    // -- HlFillRecord tests (P3-W4) --
+
+    #[test]
+    fn hl_fill_record_serde_roundtrip() {
+        use bigdecimal::BigDecimal;
+        use std::str::FromStr;
+
+        let fill = HlFillRecord {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: Some(uuid::Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            side: "B".to_string(),
+            price: BigDecimal::from_str("3500.0").unwrap(),
+            size: BigDecimal::from_str("2.0").unwrap(),
+            direction: Some("Open Long".to_string()),
+            closed_pnl: Some(BigDecimal::from(0)),
+            fee: Some(BigDecimal::from_str("3.50").unwrap()),
+            fee_token: Some("USDC".to_string()),
+            fill_time: 1700000000000,
+            order_id: Some(12345),
+            trade_id: Some(67890),
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&fill).unwrap();
+        let back: HlFillRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.network, "hypercore-mainnet");
+        assert_eq!(back.coin, "ETH");
+        assert_eq!(back.side, "B");
+        assert_eq!(back.price, BigDecimal::from_str("3500.0").unwrap());
+        assert_eq!(back.size, BigDecimal::from_str("2.0").unwrap());
+        assert_eq!(back.direction, Some("Open Long".to_string()));
+        assert_eq!(back.fill_time, 1700000000000);
+    }
+
+    #[test]
+    fn hl_fill_record_no_wallet_specific_fields() {
+        let fill = HlFillRecord {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "hypercore-mainnet".to_string(),
+            coin: "BTC".to_string(),
+            side: "A".to_string(),
+            price: BigDecimal::from(42000),
+            size: BigDecimal::from(1),
+            direction: None,
+            closed_pnl: None,
+            fee: None,
+            fee_token: None,
+            fill_time: 1700000000000,
+            order_id: None,
+            trade_id: None,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&fill).unwrap();
+        assert!(
+            !json.contains("wallet_address"),
+            "HlFillRecord must not have wallet_address"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "HlFillRecord must not have user_id"
+        );
+    }
+
+    // -- HlFundingPayment tests (P3-W4) --
+
+    #[test]
+    fn hl_funding_payment_serde_roundtrip() {
+        use bigdecimal::BigDecimal;
+        use std::str::FromStr;
+
+        let fp = HlFundingPayment {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: Some(uuid::Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            amount: BigDecimal::from_str("-2.50").unwrap(),
+            funding_rate: Some(BigDecimal::from_str("0.0001").unwrap()),
+            payment_time: 1700000000000,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&fp).unwrap();
+        let back: HlFundingPayment = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.network, "hypercore-mainnet");
+        assert_eq!(back.coin, "ETH");
+        assert_eq!(back.amount, BigDecimal::from_str("-2.50").unwrap());
+        assert_eq!(back.payment_time, 1700000000000);
+    }
+
+    #[test]
+    fn hl_funding_payment_no_wallet_specific_fields() {
+        let fp = HlFundingPayment {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "hypercore-mainnet".to_string(),
+            coin: "BTC".to_string(),
+            amount: BigDecimal::from(5),
+            funding_rate: None,
+            payment_time: 1700000000000,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&fp).unwrap();
+        assert!(
+            !json.contains("wallet_address"),
+            "HlFundingPayment must not have wallet_address"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "HlFundingPayment must not have user_id"
+        );
+    }
+
+    // -- HlPositionChange tests (P3-W4) --
+
+    #[test]
+    fn hl_position_change_serde_roundtrip() {
+        use bigdecimal::BigDecimal;
+        use std::str::FromStr;
+
+        let pc = HlPositionChange {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: Some(uuid::Uuid::new_v4()),
+            network: "hypercore-mainnet".to_string(),
+            coin: "ETH".to_string(),
+            side: "B".to_string(),
+            size_delta: BigDecimal::from_str("2.0").unwrap(),
+            price: BigDecimal::from_str("3500.0").unwrap(),
+            direction: Some("Open Long".to_string()),
+            source_event: "fill".to_string(),
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&pc).unwrap();
+        let back: HlPositionChange = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.network, "hypercore-mainnet");
+        assert_eq!(back.coin, "ETH");
+        assert_eq!(back.side, "B");
+        assert_eq!(back.size_delta, BigDecimal::from_str("2.0").unwrap());
+        assert_eq!(back.source_event, "fill");
+    }
+
+    #[test]
+    fn hl_position_change_no_wallet_specific_fields() {
+        let pc = HlPositionChange {
+            id: uuid::Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "hypercore-mainnet".to_string(),
+            coin: "BTC".to_string(),
+            side: "A".to_string(),
+            size_delta: BigDecimal::from(-1),
+            price: BigDecimal::from(42000),
+            direction: None,
+            source_event: "liquidation".to_string(),
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&pc).unwrap();
+        assert!(
+            !json.contains("wallet_address"),
+            "HlPositionChange must not have wallet_address"
+        );
+        assert!(
+            !json.contains("user_id"),
+            "HlPositionChange must not have user_id"
+        );
     }
 }

--- a/migrations/20260310000000_add_hl_silver_datasets.sql
+++ b/migrations/20260310000000_add_hl_silver_datasets.sql
@@ -1,0 +1,117 @@
+-- P3-W4: Hyperliquid reusable Silver datasets.
+-- Normalized fill records, funding payments, and position changes.
+--
+-- NOTE: The existing V1 extension table `hl_fills` (from 20260217000000) is
+-- left untouched. These Silver tables use UUID primary keys and reference
+-- the V2 `raw_transactions` table.
+
+-- ---------------------------------------------------------------------------
+-- 1. hl_fill_records — normalized fill (trade execution) records
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS hl_fill_records (
+    id                  UUID PRIMARY KEY,
+    raw_transaction_id  UUID REFERENCES raw_transactions(id),
+    network             TEXT NOT NULL,
+    coin                TEXT NOT NULL,
+    side                TEXT NOT NULL,
+    price               NUMERIC NOT NULL,
+    size                NUMERIC NOT NULL,
+    direction           TEXT,
+    closed_pnl          NUMERIC,
+    fee                 NUMERIC,
+    fee_token           TEXT,
+    fill_time           BIGINT NOT NULL,
+    order_id            BIGINT,
+    trade_id            BIGINT,
+    dataset_version_id  UUID REFERENCES dataset_versions(id),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hl_fill_records_coin
+    ON hl_fill_records(coin);
+
+CREATE INDEX IF NOT EXISTS idx_hl_fill_records_raw_tx
+    ON hl_fill_records(raw_transaction_id);
+
+CREATE INDEX IF NOT EXISTS idx_hl_fill_records_network
+    ON hl_fill_records(network);
+
+CREATE INDEX IF NOT EXISTS idx_hl_fill_records_dataset_version
+    ON hl_fill_records(dataset_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_hl_fill_records_fill_time
+    ON hl_fill_records(fill_time);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_hl_fill_records_dedup
+    ON hl_fill_records(raw_transaction_id, coin, fill_time, side)
+    WHERE raw_transaction_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. hl_funding_payments — normalized funding payment records
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS hl_funding_payments (
+    id                  UUID PRIMARY KEY,
+    raw_transaction_id  UUID REFERENCES raw_transactions(id),
+    network             TEXT NOT NULL,
+    coin                TEXT NOT NULL,
+    amount              NUMERIC NOT NULL,
+    funding_rate        NUMERIC,
+    payment_time        BIGINT NOT NULL,
+    dataset_version_id  UUID REFERENCES dataset_versions(id),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hl_funding_payments_coin
+    ON hl_funding_payments(coin);
+
+CREATE INDEX IF NOT EXISTS idx_hl_funding_payments_raw_tx
+    ON hl_funding_payments(raw_transaction_id);
+
+CREATE INDEX IF NOT EXISTS idx_hl_funding_payments_network
+    ON hl_funding_payments(network);
+
+CREATE INDEX IF NOT EXISTS idx_hl_funding_payments_dataset_version
+    ON hl_funding_payments(dataset_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_hl_funding_payments_payment_time
+    ON hl_funding_payments(payment_time);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_hl_funding_payments_dedup
+    ON hl_funding_payments(raw_transaction_id, coin, payment_time)
+    WHERE raw_transaction_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. hl_position_changes — normalized position state change records
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS hl_position_changes (
+    id                  UUID PRIMARY KEY,
+    raw_transaction_id  UUID REFERENCES raw_transactions(id),
+    network             TEXT NOT NULL,
+    coin                TEXT NOT NULL,
+    side                TEXT NOT NULL,
+    size_delta          NUMERIC NOT NULL,
+    price               NUMERIC NOT NULL,
+    direction           TEXT,
+    source_event        TEXT NOT NULL,
+    dataset_version_id  UUID REFERENCES dataset_versions(id),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hl_position_changes_coin
+    ON hl_position_changes(coin);
+
+CREATE INDEX IF NOT EXISTS idx_hl_position_changes_raw_tx
+    ON hl_position_changes(raw_transaction_id);
+
+CREATE INDEX IF NOT EXISTS idx_hl_position_changes_network
+    ON hl_position_changes(network);
+
+CREATE INDEX IF NOT EXISTS idx_hl_position_changes_dataset_version
+    ON hl_position_changes(dataset_version_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_hl_position_changes_dedup
+    ON hl_position_changes(raw_transaction_id, coin, side, source_event)
+    WHERE raw_transaction_id IS NOT NULL;


### PR DESCRIPTION
## Summary

**Phase 3 — Expand Silver Into Reusable Datasets**
**Work Packet P3-W4: Hyperliquid reusable datasets**

Adds first-class Silver datasets for Hyperliquid fills, funding payments, and position changes, following the established P3-W2/P3-W3 Silver dataset pattern.

### What's included

- **3 new Silver structs** in `core/`: `HlFillRecord`, `HlFundingPayment`, `HlPositionChange` — no wallet_address/user_id fields, consistent with target-agnostic design
- **Migration** (`20260310000000_add_hl_silver_datasets.sql`): creates `hl_fill_records`, `hl_funding_payments`, `hl_position_changes` tables with `IF NOT EXISTS` guards and nullable FKs
- **3 extraction functions** in `adapters/hyperliquid_parser.rs`: extract structured Silver data from Bronze `raw_transactions` metadata
- **3 new materializers**: `HlFillMaterializer`, `HlFundingPaymentMaterializer`, `HlPositionChangeMaterializer` with unique parser hashes (total materializer count: 13, all globally distinct)
- **Repository methods** in `adapters/v2_repo.rs`: bulk insert and query methods for all three dataset types
- **Comprehensive unit tests** covering extraction, serialization, and edge cases

### Design decisions

- Existing `hl_fills` extension table is untouched — the new `hl_fill_records` table serves the Silver dataset layer
- Nullable FKs allow independent Silver materialization without requiring prior Bronze ingestion order
- Parser hashes are globally distinct across all 13 materializers

### Validation

All 634 tests pass (0 failures), `cargo fmt` and `cargo clippy` clean.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 634 tests, 0 failures
- [x] Verify 3 new Silver structs have no wallet_address/user_id fields
- [x] Verify 13 materializers with globally distinct parser hashes
- [x] Verify migration uses IF NOT EXISTS and nullable FKs
- [x] Verify existing hl_fills/blocks/evm_logs extension tables untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)