### PR TITLE
P4-W5: Compatibility pass — verify wallet API, reorganize docs, add surface tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,18 @@ The API server runs on `127.0.0.1:3000` and requires `DATABASE_URL` to be set.
 
 All `/v1/*` endpoints require authentication via `Authorization: Bearer <API_KEY>` header. The API key is configured server-side via `SPECTRAPLEX_API_KEY`. If no API key is configured, all requests are rejected (fail-closed).
 
+### Which API Should I Use?
+
+Spectraplex exposes two complementary API surfaces:
+
+- **Wallet-scoped endpoints** (`/v1/transactions/:wallet`, `/v1/ledger/:wallet`, etc.) provide familiar, wallet-centric access to raw and normalized data. These endpoints are **stable** and will continue to be maintained for backward compatibility. They are well suited for tax, portfolio, and forensics use cases where the primary query axis is a single wallet address.
+
+- **Dataset endpoints** (`/v1/datasets/...`, `/v1/export/dataset`, etc.) are the **preferred forward path** for new consumers. They offer flexible, target-agnostic querying across Silver datasets, support richer filtering (by target, network, and time range), and integrate cleanly with ETL and data warehouse pipelines. New integrations should prefer dataset endpoints unless the use case is strictly single-wallet.
+
+Both API surfaces share the same authentication and authorization model, and both remain fully supported.
+
+### Ingestion and Job Control
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/health` | Health check, returns `"OK"` (no auth required) |
@@ -228,15 +240,42 @@ All `/v1/*` endpoints require authentication via `Authorization: Bearer <API_KEY
 | `POST` | `/v1/ingest/batch` | Trigger batch ingestion for multiple wallets (max 50) |
 | `POST` | `/v1/normalize` | Trigger async normalization for a wallet (returns job ID) |
 | `GET` | `/v1/jobs/:job_id` | Poll job status (pending/running/completed/failed) |
+| `POST` | `/v1/stream/start` | Start real-time Solana gRPC streaming (returns stream ID) |
+| `POST` | `/v1/stream/:stream_id/stop` | Stop an active stream |
+| `GET` | `/v1/streams` | List all active streams with stats |
+
+The ingest and normalize endpoints accept an optional `callback_url` field. When provided, the server will POST a JSON payload to that URL when the job completes or fails. Only HTTP(S) URLs targeting public addresses are accepted.
+
+### Wallet-Scoped Query Endpoints (Stable)
+
+These endpoints query data by wallet address. They are stable and maintained for backward compatibility.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
 | `GET` | `/v1/transactions/:wallet` | Get raw transactions by wallet (paginated) |
 | `GET` | `/v1/transactions/:wallet/:tx_hash` | Get a single transaction by hash |
 | `GET` | `/v1/ledger/:wallet` | Get normalized ledger entries by wallet (paginated) |
 | `GET` | `/v1/export/:wallet` | Export ledger entries as CSV or JSON |
 | `GET` | `/v1/balances/:wallet` | Get current asset balances (aggregated from ledger) |
 | `GET` | `/v1/stats/:wallet` | Get wallet statistics (tx count, chains, date range) |
-| `POST` | `/v1/stream/start` | Start real-time Solana gRPC streaming (returns stream ID) |
-| `POST` | `/v1/stream/:stream_id/stop` | Stop an active stream |
-| `GET` | `/v1/streams` | List all active streams with stats |
+
+All wallet endpoints validate the address format and return structured JSON errors.
+
+Query endpoints support `?limit=N&offset=N` parameters (default limit: 50, max: 1000).
+
+The transactions, ledger, and export endpoints support date range filtering via `?from=<unix_ts>&to=<unix_ts>` query parameters (both optional).
+
+### Dataset Query and Export Endpoints (Preferred)
+
+These endpoints are the preferred forward path for new consumers. They provide flexible, target-agnostic querying across Silver datasets and integrate with ETL workflows.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/v1/targets` | Register an index target (wallet, contract, program, etc.) |
+| `GET` | `/v1/targets` | List all registered index targets |
+| `GET` | `/v1/targets/:target_id` | Get a specific index target by ID |
+| `GET` | `/v1/networks` | List all known networks |
+| `GET` | `/v1/networks/:network_id` | Get a specific network by ID |
 | `GET` | `/v1/datasets` | List all Silver datasets with latest version info |
 | `GET` | `/v1/datasets/:name/versions` | List version history for a dataset |
 | `GET` | `/v1/datasets/:name/records` | Query dataset records with filters (paginated) |
@@ -246,15 +285,7 @@ All `/v1/*` endpoints require authentication via `Authorization: Bearer <API_KEY
 | `GET` | `/v1/export/jobs/:job_id` | Poll export job status |
 | `GET` | `/v1/export/jobs/:job_id/download` | Download completed export data |
 
-All wallet endpoints validate the address format and return structured JSON errors.
-
-Query endpoints support `?limit=N&offset=N` parameters (default limit: 50, max: 1000).
-
-The transactions, ledger, and export endpoints support date range filtering via `?from=<unix_ts>&to=<unix_ts>` query parameters (both optional).
-
 The dataset records endpoint supports filtering via `?target_id=<UUID>&network=<id>&time_start=<unix_ts>&time_end=<unix_ts>&limit=N&offset=N` query parameters (all optional). Queryable datasets: `token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`.
-
-The ingest and normalize endpoints accept an optional `callback_url` field. When provided, the server will POST a JSON payload to that URL when the job completes or fails. Only HTTP(S) URLs targeting public addresses are accepted.
 
 ### POST /v1/ingest
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -5877,4 +5877,365 @@ mod tests {
         assert_eq!(json["versions"].as_array().unwrap().len(), 0);
         assert_eq!(json["completeness"].as_array().unwrap().len(), 0);
     }
+
+    // ── Compatibility verification tests ──────────────────────────────
+    //
+    // These tests verify that all wallet-scoped and dataset-centric API
+    // endpoints are routed, return expected response shapes, and share
+    // the same authentication/authorization behavior.
+
+    /// Helper: send a GET request without auth and assert 401.
+    async fn assert_get_requires_auth(app: Router, uri: &str) {
+        let req = axum::http::Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "GET {} should require auth",
+            uri
+        );
+    }
+
+    /// Helper: send a POST request without auth and assert 401.
+    async fn assert_post_requires_auth(app: Router, uri: &str) {
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "POST {} should require auth",
+            uri
+        );
+    }
+
+    /// Helper: send an authenticated GET and assert it does NOT return 401 or 404.
+    async fn assert_get_routed(app: Router, uri: &str) {
+        let req = axum::http::Request::builder()
+            .uri(uri)
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        // The route must exist (not 404 from router-level mismatch) and must
+        // have passed auth (not 401). DB-dependent endpoints will return 500
+        // because the test DB is not real, which is expected.
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "GET {} should be routed (got 404)",
+            uri
+        );
+        assert_ne!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "GET {} should pass auth (got 401)",
+            uri
+        );
+    }
+
+    /// Helper: send an authenticated POST and assert it does NOT return 401 or 404.
+    async fn assert_post_routed(app: Router, uri: &str, body: &str) {
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "POST {} should be routed (got 404)",
+            uri
+        );
+        assert_ne!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "POST {} should pass auth (got 401)",
+            uri
+        );
+    }
+
+    // ── Wallet endpoint routing verification ──────────────────────────
+
+    #[tokio::test]
+    async fn compat_wallet_transactions_routed() {
+        assert_get_routed(test_router(), "/v1/transactions/SomeWallet123").await;
+    }
+
+    #[tokio::test]
+    async fn compat_wallet_single_transaction_routed() {
+        assert_get_routed(test_router(), "/v1/transactions/SomeWallet123/0xdeadbeef").await;
+    }
+
+    #[tokio::test]
+    async fn compat_wallet_ledger_routed() {
+        assert_get_routed(test_router(), "/v1/ledger/SomeWallet123").await;
+    }
+
+    #[tokio::test]
+    async fn compat_wallet_export_routed() {
+        assert_get_routed(test_router(), "/v1/export/SomeWallet123").await;
+    }
+
+    #[tokio::test]
+    async fn compat_wallet_balances_routed() {
+        assert_get_routed(test_router(), "/v1/balances/SomeWallet123").await;
+    }
+
+    #[tokio::test]
+    async fn compat_wallet_stats_routed() {
+        assert_get_routed(test_router(), "/v1/stats/SomeWallet123").await;
+    }
+
+    // ── Dataset endpoint routing verification ─────────────────────────
+
+    #[tokio::test]
+    async fn compat_datasets_list_routed() {
+        assert_get_routed(test_router(), "/v1/datasets").await;
+    }
+
+    #[tokio::test]
+    async fn compat_datasets_versions_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/token_transfers/versions").await;
+    }
+
+    #[tokio::test]
+    async fn compat_datasets_records_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/token_transfers/records").await;
+    }
+
+    #[tokio::test]
+    async fn compat_datasets_completeness_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/token_transfers/completeness").await;
+    }
+
+    #[tokio::test]
+    async fn compat_datasets_status_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/token_transfers/status").await;
+    }
+
+    #[tokio::test]
+    async fn compat_export_dataset_routed() {
+        assert_post_routed(
+            test_router(),
+            "/v1/export/dataset",
+            r#"{"dataset":"token_transfers","format":"jsonl"}"#,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn compat_export_job_status_routed() {
+        let job_id = Uuid::new_v4();
+        // Export job not found returns 404 from handler logic, but the route
+        // exists and auth passes. Use the status endpoint which returns 404
+        // for missing jobs — we check only that auth is not the blocker.
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri(format!("/v1/export/jobs/{}", job_id))
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // 404 here is from the handler (job not found), not from the router.
+        // Auth passed (not 401).
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn compat_export_job_download_routed() {
+        let job_id = Uuid::new_v4();
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri(format!("/v1/export/jobs/{}/download", job_id))
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn compat_targets_list_routed() {
+        assert_get_routed(test_router(), "/v1/targets").await;
+    }
+
+    #[tokio::test]
+    async fn compat_targets_get_routed() {
+        let id = Uuid::new_v4();
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri(format!("/v1/targets/{}", id))
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn compat_networks_list_routed() {
+        assert_get_routed(test_router(), "/v1/networks").await;
+    }
+
+    #[tokio::test]
+    async fn compat_networks_get_routed() {
+        assert_get_routed(test_router(), "/v1/networks/solana-mainnet").await;
+    }
+
+    // ── Ingestion/job control endpoint routing verification ───────────
+
+    #[tokio::test]
+    async fn compat_ingest_routed() {
+        assert_post_routed(
+            test_router(),
+            "/v1/ingest",
+            r#"{"chain":"solana","wallet":"SomeWallet123"}"#,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn compat_ingest_batch_routed() {
+        assert_post_routed(
+            test_router(),
+            "/v1/ingest/batch",
+            r#"{"wallets":[{"chain":"solana","wallet":"SomeWallet123"}]}"#,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn compat_normalize_routed() {
+        assert_post_routed(
+            test_router(),
+            "/v1/normalize",
+            r#"{"wallet":"SomeWallet123"}"#,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn compat_stream_start_routed() {
+        assert_post_routed(test_router(), "/v1/stream/start", r#"{"chain":"solana"}"#).await;
+    }
+
+    #[tokio::test]
+    async fn compat_streams_list_routed() {
+        assert_get_routed(test_router(), "/v1/streams").await;
+    }
+
+    // ── Shared auth behavior across both API surfaces ─────────────────
+
+    #[tokio::test]
+    async fn compat_wallet_endpoints_require_auth() {
+        let wallet_gets = vec![
+            "/v1/transactions/SomeWallet123",
+            "/v1/transactions/SomeWallet123/0xdeadbeef",
+            "/v1/ledger/SomeWallet123",
+            "/v1/export/SomeWallet123",
+            "/v1/balances/SomeWallet123",
+            "/v1/stats/SomeWallet123",
+        ];
+        for uri in wallet_gets {
+            assert_get_requires_auth(test_router(), uri).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn compat_dataset_endpoints_require_auth() {
+        let dataset_gets = vec![
+            "/v1/datasets",
+            "/v1/datasets/token_transfers/versions",
+            "/v1/datasets/token_transfers/records",
+            "/v1/datasets/token_transfers/completeness",
+            "/v1/datasets/token_transfers/status",
+            "/v1/targets",
+            "/v1/networks",
+        ];
+        for uri in dataset_gets {
+            assert_get_requires_auth(test_router(), uri).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn compat_dataset_post_endpoints_require_auth() {
+        let dataset_posts = vec!["/v1/export/dataset", "/v1/targets"];
+        for uri in dataset_posts {
+            assert_post_requires_auth(test_router(), uri).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn compat_ingestion_endpoints_require_auth() {
+        let ingestion_posts = vec!["/v1/ingest", "/v1/ingest/batch", "/v1/normalize"];
+        for uri in ingestion_posts {
+            assert_post_requires_auth(test_router(), uri).await;
+        }
+    }
+
+    // ── Response shape verification ───────────────────────────────────
+
+    #[tokio::test]
+    async fn compat_wallet_endpoints_return_json_errors() {
+        // Wallet endpoints should return JSON error bodies for invalid wallets
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/transactions/bad%20wallet")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("error").is_some(),
+            "wallet error should be JSON with 'error' field"
+        );
+    }
+
+    #[tokio::test]
+    async fn compat_dataset_endpoints_return_json_errors() {
+        // Invalid dataset name should return JSON error
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/v1/datasets/nonexistent_dataset/records")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // Should be 400 for unknown dataset, not 404 from missing route
+        assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("error").is_some(),
+            "dataset error should be JSON with 'error' field"
+        );
+    }
+
+    #[tokio::test]
+    async fn compat_health_does_not_require_auth() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
 }


### PR DESCRIPTION
## Summary

Phase 4, Work Packet 5: Compatibility pass ensuring wallet-focused API paths still function after Phase 3–4 changes, with documentation reorganized to prefer the dataset-centric API as the forward path.

- **README.md**: Reorganized API reference into three subsections (Ingestion & Job Control, Wallet-Scoped Stable, Dataset Preferred) with API philosophy guidance. Documented 5 previously unlisted target/network endpoints.
- **api/src/main.rs**: Added 30 compatibility tests verifying all wallet and dataset endpoints are routed, return expected response shapes, and share authentication.

## Validation

| Check | Result |
|-------|--------|
| `cargo fmt --all --check` | ✅ Pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ Pass |
| `cargo test --workspace` | ✅ 810 tests, 0 failures |
| All 27 API endpoints in README match routes in `api/src/main.rs` | ✅ Verified |
| README.md ↔ CLAUDE.md API surface sync | ✅ In sync |
| 30 compatibility tests cover routing, auth, response shapes | ✅ Pass |

**Note:** CLAUDE.md is gitignored and not tracked in the repository, so it does not appear in the PR diff. The on-disk copy was updated to match the README reorganization.

## Test plan

- [ ] Review README.md API subsection reorganization and philosophy guidance
- [ ] Review 30 new compatibility tests in `api/src/main.rs`
- [ ] Confirm all wallet-scoped endpoints remain unchanged and accessible
- [ ] Confirm dataset-centric endpoints are correctly documented
- [ ] Verify CI passes (fmt, clippy, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)