### PR TITLE
P5-W2: Hyperliquid Analytics Pack — Gold datasets and dashboard endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,10 @@ These endpoints are the preferred forward path for new consumers. They provide f
 | `GET` | `/v1/export/jobs/:job_id/download` | Download completed export data |
 | `GET` | `/v1/export/tax` | Export wallet_ledger as tax-software-friendly CSV |
 | `GET` | `/v1/forensics/activity` | Wallet interaction analysis (top counterparties, cross-chain summary) |
+| `GET` | `/v1/analytics/hl/trader` | Per-trader Hyperliquid PnL analytics (win rate, volume, coin breakdown) |
+| `GET` | `/v1/analytics/hl/market` | Per-coin Hyperliquid market analytics (volume, traders, PnL distribution) |
 
-The dataset records endpoint supports filtering via `?target_id=<UUID>&network=<id>&time_start=<unix_ts>&time_end=<unix_ts>&limit=N&offset=N` query parameters (all optional). Queryable datasets: `token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`, `wallet_ledger`, `balance_history`.
+The dataset records endpoint supports filtering via `?target_id=<UUID>&network=<id>&time_start=<unix_ts>&time_end=<unix_ts>&limit=N&offset=N` query parameters (all optional). Queryable datasets: `token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`, `wallet_ledger`, `balance_history`, `hl_pnl_summary`, `hl_trade_history`.
 
 ### POST /v1/ingest
 
@@ -466,7 +468,7 @@ curl -X POST http://127.0.0.1:3000/v1/export/dataset \
 # Response: {"id": "<JOB_UUID>", "state": "pending", "dataset": "token_transfers", "format": "jsonl", "record_count": null, "message": null}
 ```
 
-Creates an async export job for a dataset. Supported formats: `jsonl` (default), `csv`. Optional filters: `target_id`, `network`, `time_start`, `time_end`. Exportable datasets: `token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`, `wallet_ledger`, `balance_history`. Maximum 100,000 records per export.
+Creates an async export job for a dataset. Supported formats: `jsonl` (default), `csv`. Optional filters: `target_id`, `network`, `time_start`, `time_end`. Exportable datasets: `token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`, `wallet_ledger`, `balance_history`, `hl_pnl_summary`, `hl_trade_history`. Maximum 100,000 records per export.
 
 #### Sink delivery
 
@@ -576,15 +578,19 @@ curl -H "Authorization: Bearer <API_KEY>" \
 
 Downloads the completed export data. The response includes a `Content-Disposition` header with the filename.
 
-### Gold Datasets: wallet_ledger and balance_history
+### Gold Datasets
 
-Spectraplex includes two Gold-tier datasets materialized from Silver data:
+Spectraplex includes four Gold-tier datasets materialized from Silver data:
 
 - **`wallet_ledger`** — wallet-scoped financial records with counterparty tracking, network awareness, and nullable cost basis / proceeds fields. Derived from `token_transfers`, `native_balance_deltas`, `hl_fills`, and `hl_funding`. Queryable and exportable via the standard dataset API.
 
 - **`balance_history`** — per-wallet, per-asset running balance snapshots derived from wallet_ledger entries. Enables point-in-time balance queries for forensics and portfolio tracking.
 
-Both datasets are queryable via `/v1/datasets/{name}/records` and exportable via `/v1/export/dataset`.
+- **`hl_pnl_summary`** — per-wallet, per-coin PnL summaries aggregated from Silver `hl_fills` (closed PnL, fees) and `hl_funding` (funding payments). Includes net PnL, win/loss counts, fill count, and average trade size. Designed for trader dashboards and performance analytics.
+
+- **`hl_trade_history`** — logical trade records built by grouping Silver `hl_fills` into open→close sequences. Each record captures entry/exit price, size, realized PnL, fees, and the number of fills that composed the trade. Enables trade-by-trade performance analysis.
+
+All Gold datasets are queryable via `/v1/datasets/{name}/records` and exportable via `/v1/export/dataset`.
 
 ### GET /v1/export/tax
 
@@ -610,6 +616,28 @@ curl -H "Authorization: Bearer <API_KEY>" \
 ```
 
 Returns a forensics activity summary for wallet_ledger records: top counterparties by interaction count, cross-chain activity breakdown, and transaction type distribution. Supports `?target_id`, `?network`, `?time_start`, `?time_end` filters.
+
+### GET /v1/analytics/hl/trader
+
+```bash
+curl -H "Authorization: Bearer <API_KEY>" \
+  "http://127.0.0.1:3000/v1/analytics/hl/trader?target_id=<UUID>"
+
+# Response: {"wallet_address": "...", "total_net_pnl": "105.5", "total_volume": "50000", "total_trades": 5, "win_rate": 0.6, "coin_breakdown": [...]}
+```
+
+Returns per-trader Hyperliquid analytics computed from Gold `hl_pnl_summary` and `hl_trade_history` records: total net PnL, trading volume, win rate, and per-coin breakdown. Supports `?target_id`, `?network`, `?time_start`, `?time_end` filters.
+
+### GET /v1/analytics/hl/market
+
+```bash
+curl -H "Authorization: Bearer <API_KEY>" \
+  "http://127.0.0.1:3000/v1/analytics/hl/market"
+
+# Response: {"coins": [{"coin": "ETH", "total_volume": "100000", "unique_traders": 5, ...}], "total_volume": "100000", "total_unique_traders": 5}
+```
+
+Returns per-coin Hyperliquid market analytics: total volume, unique trader count, total trades, aggregate PnL, and average trade size per coin. Supports `?target_id`, `?network`, `?time_start`, `?time_end` filters.
 
 ## Configuration
 
@@ -718,6 +746,7 @@ All tables use UUIDs as primary keys and support idempotent batch inserts (`ON C
 - [ ] Expand Silver beyond `ledger_entries` into reusable datasets like transfers, decoded events, fills, swaps, and balance snapshots
 - [ ] Add ETL-first delivery modes such as dataset exports, sink jobs, and warehouse-friendly outputs
 - [x] Keep wallet/tax/forensics materializations first-class, but as downstream products of the broader indexing core (P5-W1: wallet_ledger, balance_history, tax export, forensics activity)
+- [x] Add Hyperliquid-specific analytics as Gold datasets proving a dashboard can consume Spectraplex outputs directly (P5-W2: hl_pnl_summary, hl_trade_history, trader and market analytics)
 
 The detailed roadmap lives in [`SPECTRAPLEX_STRATEGY_AND_EXECUTION_PLAN.md`](SPECTRAPLEX_STRATEGY_AND_EXECUTION_PLAN.md).
 

--- a/adapters/src/hl_analytics.rs
+++ b/adapters/src/hl_analytics.rs
@@ -1,0 +1,877 @@
+//! Gold-tier Hyperliquid analytics materialization and aggregation.
+//!
+//! Computes Gold datasets (hl_pnl_summary, hl_trade_history) from Silver
+//! Hyperliquid data (hl_fills, hl_funding), and builds dashboard-ready
+//! analytics responses (TraderAnalytics, MarketAnalytics).
+
+use bigdecimal::BigDecimal;
+use spectraplex_core::materializer::{
+    CoinMarketSummary, CoinPnlSummary, HlFillRecord, HlFundingPayment, HlPnlSummary,
+    HlTradeHistory, MarketAnalytics, TraderAnalytics,
+};
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+
+/// Compute PnL summary records from fills and funding payments.
+///
+/// Groups fills by (wallet_address, coin) — aggregating closed_pnl, fees,
+/// and fill count — then merges funding totals for the same keys. Returns
+/// one `HlPnlSummary` per (wallet, coin) pair.
+pub fn compute_pnl_summary(
+    wallet: &str,
+    network: &str,
+    fills: &[HlFillRecord],
+    funding: &[HlFundingPayment],
+    period_start: i64,
+    period_end: i64,
+) -> Vec<HlPnlSummary> {
+    struct CoinAgg {
+        total_closed_pnl: BigDecimal,
+        total_fees: BigDecimal,
+        total_funding: BigDecimal,
+        fill_count: i64,
+        trade_sizes: Vec<BigDecimal>,
+        win_count: i64,
+        loss_count: i64,
+    }
+
+    let mut map: HashMap<String, CoinAgg> = HashMap::new();
+
+    for fill in fills {
+        let agg = map.entry(fill.coin.clone()).or_insert_with(|| CoinAgg {
+            total_closed_pnl: BigDecimal::from(0),
+            total_fees: BigDecimal::from(0),
+            total_funding: BigDecimal::from(0),
+            fill_count: 0,
+            trade_sizes: Vec::new(),
+            win_count: 0,
+            loss_count: 0,
+        });
+        agg.fill_count += 1;
+        if let Some(ref cpnl) = fill.closed_pnl {
+            agg.total_closed_pnl += cpnl;
+            if cpnl > &BigDecimal::from(0) {
+                agg.win_count += 1;
+            } else if cpnl < &BigDecimal::from(0) {
+                agg.loss_count += 1;
+            }
+        }
+        if let Some(ref fee) = fill.fee {
+            agg.total_fees += fee;
+        }
+        agg.trade_sizes.push(fill.size.clone());
+    }
+
+    for fp in funding {
+        let agg = map.entry(fp.coin.clone()).or_insert_with(|| CoinAgg {
+            total_closed_pnl: BigDecimal::from(0),
+            total_fees: BigDecimal::from(0),
+            total_funding: BigDecimal::from(0),
+            fill_count: 0,
+            trade_sizes: Vec::new(),
+            win_count: 0,
+            loss_count: 0,
+        });
+        agg.total_funding += &fp.amount;
+    }
+
+    let now = chrono::Utc::now();
+    let mut results: Vec<HlPnlSummary> = map
+        .into_iter()
+        .map(|(coin, agg)| {
+            let trade_count = agg.win_count + agg.loss_count;
+            let avg_trade_size = if agg.trade_sizes.is_empty() {
+                BigDecimal::from(0)
+            } else {
+                let total_size: BigDecimal = agg
+                    .trade_sizes
+                    .iter()
+                    .fold(BigDecimal::from(0), |acc, s| acc + s);
+                total_size / BigDecimal::from(agg.trade_sizes.len() as i64)
+            };
+            let net_pnl = &agg.total_closed_pnl + &agg.total_funding - &agg.total_fees;
+            HlPnlSummary {
+                id: Uuid::new_v4(),
+                wallet_address: wallet.to_string(),
+                coin,
+                network: network.to_string(),
+                period_start,
+                period_end,
+                total_closed_pnl: agg.total_closed_pnl,
+                total_funding: agg.total_funding,
+                total_fees: agg.total_fees,
+                net_pnl,
+                trade_count,
+                fill_count: agg.fill_count,
+                avg_trade_size,
+                win_count: agg.win_count,
+                loss_count: agg.loss_count,
+                dataset_version_id: None,
+                created_at: now,
+            }
+        })
+        .collect();
+    results.sort_by(|a, b| a.coin.cmp(&b.coin));
+    results
+}
+
+/// Build trade history from fills by grouping into logical open/close sequences.
+///
+/// A trade begins when a fill has a direction containing "Open" and ends
+/// when a fill has a direction containing "Close". If fills cannot be
+/// grouped into explicit open/close pairs (e.g. all fills lack direction),
+/// each fill with a non-zero closed_pnl is treated as a standalone trade.
+pub fn build_trade_history(
+    wallet: &str,
+    network: &str,
+    fills: &[HlFillRecord],
+) -> Vec<HlTradeHistory> {
+    let now = chrono::Utc::now();
+
+    // Group fills by coin
+    let mut by_coin: HashMap<String, Vec<&HlFillRecord>> = HashMap::new();
+    for fill in fills {
+        by_coin.entry(fill.coin.clone()).or_default().push(fill);
+    }
+
+    let mut trades = Vec::new();
+
+    for (coin, mut coin_fills) in by_coin {
+        // Sort fills by fill_time ascending
+        coin_fills.sort_by_key(|f| f.fill_time);
+
+        let has_direction_info = coin_fills.iter().any(|f| {
+            f.direction
+                .as_deref()
+                .is_some_and(|d| d.contains("Open") || d.contains("Close"))
+        });
+
+        if has_direction_info {
+            // Group into open/close sequences
+            let mut open_fills: Vec<&HlFillRecord> = Vec::new();
+
+            for fill in &coin_fills {
+                let dir = fill.direction.as_deref().unwrap_or("");
+                if dir.contains("Open") {
+                    open_fills.push(fill);
+                } else if dir.contains("Close") && !open_fills.is_empty() {
+                    // Build trade from accumulated opens + this close
+                    let entry_price = weighted_avg_price(&open_fills);
+                    let total_size: BigDecimal = open_fills
+                        .iter()
+                        .fold(BigDecimal::from(0), |acc, f| acc + &f.size);
+                    let total_fees: BigDecimal = open_fills
+                        .iter()
+                        .chain(std::iter::once(fill))
+                        .fold(BigDecimal::from(0), |acc, f| {
+                            acc + f.fee.as_ref().unwrap_or(&BigDecimal::from(0))
+                        });
+                    let side = open_fills
+                        .first()
+                        .map(|f| f.side.clone())
+                        .unwrap_or_default();
+                    let opened_at = open_fills.first().map(|f| f.fill_time).unwrap_or(0);
+                    let num_fills = (open_fills.len() + 1) as i64;
+
+                    trades.push(HlTradeHistory {
+                        id: Uuid::new_v4(),
+                        wallet_address: wallet.to_string(),
+                        coin: coin.clone(),
+                        network: network.to_string(),
+                        side,
+                        entry_price,
+                        exit_price: fill.price.clone(),
+                        size: total_size,
+                        opened_at,
+                        closed_at: fill.fill_time,
+                        realized_pnl: fill
+                            .closed_pnl
+                            .clone()
+                            .unwrap_or_else(|| BigDecimal::from(0)),
+                        fees: total_fees,
+                        num_fills,
+                        dataset_version_id: None,
+                        created_at: now,
+                    });
+                    open_fills.clear();
+                } else if dir.contains("Close") {
+                    // Close without a preceding open — standalone trade
+                    trades.push(HlTradeHistory {
+                        id: Uuid::new_v4(),
+                        wallet_address: wallet.to_string(),
+                        coin: coin.clone(),
+                        network: network.to_string(),
+                        side: fill.side.clone(),
+                        entry_price: fill.price.clone(),
+                        exit_price: fill.price.clone(),
+                        size: fill.size.clone(),
+                        opened_at: fill.fill_time,
+                        closed_at: fill.fill_time,
+                        realized_pnl: fill
+                            .closed_pnl
+                            .clone()
+                            .unwrap_or_else(|| BigDecimal::from(0)),
+                        fees: fill.fee.clone().unwrap_or_else(|| BigDecimal::from(0)),
+                        num_fills: 1,
+                        dataset_version_id: None,
+                        created_at: now,
+                    });
+                }
+            }
+        } else {
+            // Fallback: each fill with closed_pnl becomes a standalone trade
+            for fill in &coin_fills {
+                if fill.closed_pnl.is_some() {
+                    trades.push(HlTradeHistory {
+                        id: Uuid::new_v4(),
+                        wallet_address: wallet.to_string(),
+                        coin: coin.clone(),
+                        network: network.to_string(),
+                        side: fill.side.clone(),
+                        entry_price: fill.price.clone(),
+                        exit_price: fill.price.clone(),
+                        size: fill.size.clone(),
+                        opened_at: fill.fill_time,
+                        closed_at: fill.fill_time,
+                        realized_pnl: fill
+                            .closed_pnl
+                            .clone()
+                            .unwrap_or_else(|| BigDecimal::from(0)),
+                        fees: fill.fee.clone().unwrap_or_else(|| BigDecimal::from(0)),
+                        num_fills: 1,
+                        dataset_version_id: None,
+                        created_at: now,
+                    });
+                }
+            }
+        }
+    }
+
+    trades.sort_by(|a, b| a.closed_at.cmp(&b.closed_at));
+    trades
+}
+
+/// Build per-trader analytics from PnL summaries and trade histories.
+pub fn build_trader_analytics(
+    wallet: &str,
+    pnl_summaries: &[HlPnlSummary],
+    trade_histories: &[HlTradeHistory],
+) -> TraderAnalytics {
+    let total_net_pnl = pnl_summaries
+        .iter()
+        .fold(BigDecimal::from(0), |acc, s| acc + &s.net_pnl);
+
+    let total_volume = trade_histories
+        .iter()
+        .fold(BigDecimal::from(0), |acc, t| acc + &t.size * &t.entry_price);
+
+    let total_trades = trade_histories.len() as i64;
+
+    let total_wins: i64 = pnl_summaries.iter().map(|s| s.win_count).sum();
+    let total_losses: i64 = pnl_summaries.iter().map(|s| s.loss_count).sum();
+    let total_resolved = total_wins + total_losses;
+    let win_rate = if total_resolved > 0 {
+        total_wins as f64 / total_resolved as f64
+    } else {
+        0.0
+    };
+
+    let mut coin_map: HashMap<String, (BigDecimal, BigDecimal, i64, i64, i64)> = HashMap::new();
+    for s in pnl_summaries {
+        let entry = coin_map
+            .entry(s.coin.clone())
+            .or_insert_with(|| (BigDecimal::from(0), BigDecimal::from(0), 0, 0, 0));
+        entry.0 += &s.net_pnl;
+        entry.3 += s.win_count;
+        entry.4 += s.loss_count;
+    }
+    for t in trade_histories {
+        let entry = coin_map
+            .entry(t.coin.clone())
+            .or_insert_with(|| (BigDecimal::from(0), BigDecimal::from(0), 0, 0, 0));
+        entry.1 += &t.size * &t.entry_price;
+        entry.2 += 1;
+    }
+
+    let mut coin_breakdown: Vec<CoinPnlSummary> = coin_map
+        .into_iter()
+        .map(
+            |(coin, (net_pnl, volume, trade_count, win_count, loss_count))| CoinPnlSummary {
+                coin,
+                net_pnl,
+                volume,
+                trade_count,
+                win_count,
+                loss_count,
+            },
+        )
+        .collect();
+    coin_breakdown.sort_by(|a, b| a.coin.cmp(&b.coin));
+
+    TraderAnalytics {
+        wallet_address: wallet.to_string(),
+        total_net_pnl,
+        total_volume,
+        total_trades,
+        win_rate,
+        coin_breakdown,
+    }
+}
+
+/// Build per-coin market analytics from PnL summaries and trade histories.
+pub fn build_market_analytics(
+    pnl_summaries: &[HlPnlSummary],
+    trade_histories: &[HlTradeHistory],
+) -> MarketAnalytics {
+    struct CoinAgg {
+        volume: BigDecimal,
+        traders: HashSet<String>,
+        trade_count: i64,
+        total_pnl: BigDecimal,
+        sizes: Vec<BigDecimal>,
+    }
+
+    let mut coin_map: HashMap<String, CoinAgg> = HashMap::new();
+
+    for s in pnl_summaries {
+        let entry = coin_map.entry(s.coin.clone()).or_insert_with(|| CoinAgg {
+            volume: BigDecimal::from(0),
+            traders: HashSet::new(),
+            trade_count: 0,
+            total_pnl: BigDecimal::from(0),
+            sizes: Vec::new(),
+        });
+        entry.traders.insert(s.wallet_address.clone());
+        entry.total_pnl += &s.net_pnl;
+    }
+
+    for t in trade_histories {
+        let entry = coin_map.entry(t.coin.clone()).or_insert_with(|| CoinAgg {
+            volume: BigDecimal::from(0),
+            traders: HashSet::new(),
+            trade_count: 0,
+            total_pnl: BigDecimal::from(0),
+            sizes: Vec::new(),
+        });
+        entry.volume += &t.size * &t.entry_price;
+        entry.traders.insert(t.wallet_address.clone());
+        entry.trade_count += 1;
+        entry.sizes.push(t.size.clone());
+    }
+
+    let mut all_traders: HashSet<String> = HashSet::new();
+    let mut total_volume = BigDecimal::from(0);
+
+    let mut coins: Vec<CoinMarketSummary> = coin_map
+        .into_iter()
+        .map(|(coin, agg)| {
+            for t in &agg.traders {
+                all_traders.insert(t.clone());
+            }
+            total_volume += &agg.volume;
+            let avg_trade_size = if agg.sizes.is_empty() {
+                BigDecimal::from(0)
+            } else {
+                let sum: BigDecimal = agg.sizes.iter().fold(BigDecimal::from(0), |acc, s| acc + s);
+                sum / BigDecimal::from(agg.sizes.len() as i64)
+            };
+            CoinMarketSummary {
+                coin,
+                total_volume: agg.volume,
+                unique_traders: agg.traders.len(),
+                total_trades: agg.trade_count,
+                total_pnl: agg.total_pnl,
+                avg_trade_size,
+            }
+        })
+        .collect();
+    coins.sort_by(|a, b| a.coin.cmp(&b.coin));
+
+    MarketAnalytics {
+        coins,
+        total_volume,
+        total_unique_traders: all_traders.len(),
+    }
+}
+
+/// Weighted average price of a set of fills (size-weighted).
+fn weighted_avg_price(fills: &[&HlFillRecord]) -> BigDecimal {
+    if fills.is_empty() {
+        return BigDecimal::from(0);
+    }
+    let total_size: BigDecimal = fills
+        .iter()
+        .fold(BigDecimal::from(0), |acc, f| acc + &f.size);
+    if total_size == BigDecimal::from(0) {
+        return fills[0].price.clone();
+    }
+    let weighted_sum: BigDecimal = fills
+        .iter()
+        .fold(BigDecimal::from(0), |acc, f| acc + &f.price * &f.size);
+    weighted_sum / total_size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
+
+    #[allow(clippy::too_many_arguments)]
+    fn make_fill(
+        coin: &str,
+        side: &str,
+        price: &str,
+        size: &str,
+        closed_pnl: Option<&str>,
+        fee: Option<&str>,
+        direction: Option<&str>,
+        fill_time: i64,
+    ) -> HlFillRecord {
+        HlFillRecord {
+            id: Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "hyperliquid-mainnet".to_string(),
+            coin: coin.to_string(),
+            side: side.to_string(),
+            price: BigDecimal::from_str(price).unwrap(),
+            size: BigDecimal::from_str(size).unwrap(),
+            direction: direction.map(|s| s.to_string()),
+            closed_pnl: closed_pnl.map(|s| BigDecimal::from_str(s).unwrap()),
+            fee: fee.map(|s| BigDecimal::from_str(s).unwrap()),
+            fee_token: Some("USDC".to_string()),
+            fill_time,
+            order_id: None,
+            trade_id: None,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn make_funding(coin: &str, amount: &str, payment_time: i64) -> HlFundingPayment {
+        HlFundingPayment {
+            id: Uuid::new_v4(),
+            raw_transaction_id: None,
+            network: "hyperliquid-mainnet".to_string(),
+            coin: coin.to_string(),
+            amount: BigDecimal::from_str(amount).unwrap(),
+            funding_rate: None,
+            payment_time,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn pnl_summary_aggregates_fills_and_funding() {
+        let fills = vec![
+            make_fill(
+                "ETH",
+                "B",
+                "2000",
+                "1.0",
+                Some("100"),
+                Some("2"),
+                Some("Close Long"),
+                1000,
+            ),
+            make_fill(
+                "ETH",
+                "B",
+                "2100",
+                "0.5",
+                Some("-50"),
+                Some("1"),
+                Some("Close Long"),
+                2000,
+            ),
+        ];
+        let funding = vec![
+            make_funding("ETH", "10.5", 1500),
+            make_funding("ETH", "-3.0", 2500),
+        ];
+
+        let summaries =
+            compute_pnl_summary("0xTrader", "hyperliquid-mainnet", &fills, &funding, 0, 3000);
+        assert_eq!(summaries.len(), 1);
+        let s = &summaries[0];
+        assert_eq!(s.coin, "ETH");
+        assert_eq!(s.wallet_address, "0xTrader");
+        // closed_pnl: 100 + (-50) = 50
+        assert_eq!(s.total_closed_pnl, BigDecimal::from_str("50").unwrap());
+        // funding: 10.5 + (-3.0) = 7.5
+        assert_eq!(s.total_funding, BigDecimal::from_str("7.5").unwrap());
+        // fees: 2 + 1 = 3
+        assert_eq!(s.total_fees, BigDecimal::from_str("3").unwrap());
+        // net_pnl: 50 + 7.5 - 3 = 54.5
+        assert_eq!(s.net_pnl, BigDecimal::from_str("54.5").unwrap());
+        assert_eq!(s.fill_count, 2);
+        assert_eq!(s.win_count, 1);
+        assert_eq!(s.loss_count, 1);
+    }
+
+    #[test]
+    fn pnl_summary_multiple_coins() {
+        let fills = vec![
+            make_fill(
+                "ETH",
+                "B",
+                "2000",
+                "1.0",
+                Some("100"),
+                Some("2"),
+                None,
+                1000,
+            ),
+            make_fill(
+                "BTC",
+                "A",
+                "50000",
+                "0.1",
+                Some("500"),
+                Some("5"),
+                None,
+                2000,
+            ),
+        ];
+        let summaries =
+            compute_pnl_summary("0xTrader", "hyperliquid-mainnet", &fills, &[], 0, 3000);
+        assert_eq!(summaries.len(), 2);
+        // Sorted by coin name
+        assert_eq!(summaries[0].coin, "BTC");
+        assert_eq!(summaries[1].coin, "ETH");
+    }
+
+    #[test]
+    fn pnl_summary_empty_inputs() {
+        let summaries = compute_pnl_summary("0xTrader", "hyperliquid-mainnet", &[], &[], 0, 3000);
+        assert!(summaries.is_empty());
+    }
+
+    #[test]
+    fn trade_history_groups_open_close() {
+        let fills = vec![
+            make_fill(
+                "ETH",
+                "B",
+                "2000",
+                "1.0",
+                None,
+                Some("1"),
+                Some("Open Long"),
+                1000,
+            ),
+            make_fill(
+                "ETH",
+                "B",
+                "2100",
+                "0.5",
+                None,
+                Some("0.5"),
+                Some("Open Long"),
+                2000,
+            ),
+            make_fill(
+                "ETH",
+                "A",
+                "2200",
+                "1.5",
+                Some("250"),
+                Some("1.5"),
+                Some("Close Long"),
+                3000,
+            ),
+        ];
+        let trades = build_trade_history("0xTrader", "hyperliquid-mainnet", &fills);
+        assert_eq!(trades.len(), 1);
+        let t = &trades[0];
+        assert_eq!(t.coin, "ETH");
+        assert_eq!(t.side, "B");
+        // Weighted avg entry: (2000*1.0 + 2100*0.5) / 1.5 = 3050/1.5 ≈ 2033.33...
+        assert!(t.entry_price > BigDecimal::from_str("2033").unwrap());
+        assert!(t.entry_price < BigDecimal::from_str("2034").unwrap());
+        assert_eq!(t.exit_price, BigDecimal::from_str("2200").unwrap());
+        assert_eq!(t.size, BigDecimal::from_str("1.5").unwrap());
+        assert_eq!(t.opened_at, 1000);
+        assert_eq!(t.closed_at, 3000);
+        assert_eq!(t.realized_pnl, BigDecimal::from_str("250").unwrap());
+        assert_eq!(t.num_fills, 3);
+        // total fees: 1 + 0.5 + 1.5 = 3
+        assert_eq!(t.fees, BigDecimal::from_str("3").unwrap());
+    }
+
+    #[test]
+    fn trade_history_fallback_no_directions() {
+        let fills = vec![
+            make_fill("ETH", "B", "2000", "1.0", Some("50"), Some("1"), None, 1000),
+            make_fill("ETH", "B", "2100", "0.5", None, Some("0.5"), None, 2000),
+        ];
+        let trades = build_trade_history("0xTrader", "hyperliquid-mainnet", &fills);
+        // Only fill with closed_pnl produces a trade
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].realized_pnl, BigDecimal::from_str("50").unwrap());
+    }
+
+    #[test]
+    fn trade_history_empty_fills() {
+        let trades = build_trade_history("0xTrader", "hyperliquid-mainnet", &[]);
+        assert!(trades.is_empty());
+    }
+
+    #[test]
+    fn trader_analytics_aggregation() {
+        let summaries = vec![
+            HlPnlSummary {
+                id: Uuid::new_v4(),
+                wallet_address: "0xTrader".to_string(),
+                coin: "ETH".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                period_start: 0,
+                period_end: 3000,
+                total_closed_pnl: BigDecimal::from(100),
+                total_funding: BigDecimal::from(10),
+                total_fees: BigDecimal::from(5),
+                net_pnl: BigDecimal::from(105),
+                trade_count: 3,
+                fill_count: 5,
+                avg_trade_size: BigDecimal::from(1),
+                win_count: 2,
+                loss_count: 1,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+            HlPnlSummary {
+                id: Uuid::new_v4(),
+                wallet_address: "0xTrader".to_string(),
+                coin: "BTC".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                period_start: 0,
+                period_end: 3000,
+                total_closed_pnl: BigDecimal::from(-20),
+                total_funding: BigDecimal::from(5),
+                total_fees: BigDecimal::from(2),
+                net_pnl: BigDecimal::from(-17),
+                trade_count: 1,
+                fill_count: 2,
+                avg_trade_size: BigDecimal::from_str("0.1").unwrap(),
+                win_count: 0,
+                loss_count: 1,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        ];
+
+        let trades = vec![HlTradeHistory {
+            id: Uuid::new_v4(),
+            wallet_address: "0xTrader".to_string(),
+            coin: "ETH".to_string(),
+            network: "hyperliquid-mainnet".to_string(),
+            side: "B".to_string(),
+            entry_price: BigDecimal::from(2000),
+            exit_price: BigDecimal::from(2200),
+            size: BigDecimal::from(1),
+            opened_at: 1000,
+            closed_at: 3000,
+            realized_pnl: BigDecimal::from(200),
+            fees: BigDecimal::from(3),
+            num_fills: 3,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        }];
+
+        let analytics = build_trader_analytics("0xTrader", &summaries, &trades);
+        assert_eq!(analytics.wallet_address, "0xTrader");
+        // 105 + (-17) = 88
+        assert_eq!(analytics.total_net_pnl, BigDecimal::from(88));
+        assert_eq!(analytics.total_trades, 1);
+        // win_rate = 2 / (2+1+0+1) = 2/4 = 0.5
+        assert!((analytics.win_rate - 0.5).abs() < f64::EPSILON);
+        assert_eq!(analytics.coin_breakdown.len(), 2);
+    }
+
+    #[test]
+    fn market_analytics_aggregation() {
+        let summaries = vec![
+            HlPnlSummary {
+                id: Uuid::new_v4(),
+                wallet_address: "0xAlice".to_string(),
+                coin: "ETH".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                period_start: 0,
+                period_end: 3000,
+                total_closed_pnl: BigDecimal::from(100),
+                total_funding: BigDecimal::from(0),
+                total_fees: BigDecimal::from(0),
+                net_pnl: BigDecimal::from(100),
+                trade_count: 1,
+                fill_count: 1,
+                avg_trade_size: BigDecimal::from(1),
+                win_count: 1,
+                loss_count: 0,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+            HlPnlSummary {
+                id: Uuid::new_v4(),
+                wallet_address: "0xBob".to_string(),
+                coin: "ETH".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                period_start: 0,
+                period_end: 3000,
+                total_closed_pnl: BigDecimal::from(-50),
+                total_funding: BigDecimal::from(0),
+                total_fees: BigDecimal::from(0),
+                net_pnl: BigDecimal::from(-50),
+                trade_count: 1,
+                fill_count: 1,
+                avg_trade_size: BigDecimal::from(1),
+                win_count: 0,
+                loss_count: 1,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        ];
+
+        let trades = vec![
+            HlTradeHistory {
+                id: Uuid::new_v4(),
+                wallet_address: "0xAlice".to_string(),
+                coin: "ETH".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                side: "B".to_string(),
+                entry_price: BigDecimal::from(2000),
+                exit_price: BigDecimal::from(2100),
+                size: BigDecimal::from(1),
+                opened_at: 1000,
+                closed_at: 2000,
+                realized_pnl: BigDecimal::from(100),
+                fees: BigDecimal::from(1),
+                num_fills: 2,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+            HlTradeHistory {
+                id: Uuid::new_v4(),
+                wallet_address: "0xBob".to_string(),
+                coin: "ETH".to_string(),
+                network: "hyperliquid-mainnet".to_string(),
+                side: "A".to_string(),
+                entry_price: BigDecimal::from(2100),
+                exit_price: BigDecimal::from(2050),
+                size: BigDecimal::from(2),
+                opened_at: 1500,
+                closed_at: 2500,
+                realized_pnl: BigDecimal::from(-100),
+                fees: BigDecimal::from(2),
+                num_fills: 2,
+                dataset_version_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        ];
+
+        let analytics = build_market_analytics(&summaries, &trades);
+        assert_eq!(analytics.coins.len(), 1);
+        assert_eq!(analytics.coins[0].coin, "ETH");
+        assert_eq!(analytics.total_unique_traders, 2);
+        assert_eq!(analytics.coins[0].unique_traders, 2);
+        assert_eq!(analytics.coins[0].total_trades, 2);
+        // total_pnl: 100 + (-50) = 50
+        assert_eq!(analytics.coins[0].total_pnl, BigDecimal::from(50));
+    }
+
+    #[test]
+    fn hl_pnl_summary_serde_roundtrip() {
+        let s = HlPnlSummary {
+            id: Uuid::nil(),
+            wallet_address: "0xTrader".to_string(),
+            coin: "ETH".to_string(),
+            network: "hyperliquid-mainnet".to_string(),
+            period_start: 1000,
+            period_end: 2000,
+            total_closed_pnl: BigDecimal::from(100),
+            total_funding: BigDecimal::from(10),
+            total_fees: BigDecimal::from(5),
+            net_pnl: BigDecimal::from(105),
+            trade_count: 3,
+            fill_count: 5,
+            avg_trade_size: BigDecimal::from(1),
+            win_count: 2,
+            loss_count: 1,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: HlPnlSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.coin, "ETH");
+        assert_eq!(back.net_pnl, BigDecimal::from(105));
+    }
+
+    #[test]
+    fn hl_trade_history_serde_roundtrip() {
+        let t = HlTradeHistory {
+            id: Uuid::nil(),
+            wallet_address: "0xTrader".to_string(),
+            coin: "BTC".to_string(),
+            network: "hyperliquid-mainnet".to_string(),
+            side: "B".to_string(),
+            entry_price: BigDecimal::from(50000),
+            exit_price: BigDecimal::from(51000),
+            size: BigDecimal::from_str("0.5").unwrap(),
+            opened_at: 1000,
+            closed_at: 3000,
+            realized_pnl: BigDecimal::from(500),
+            fees: BigDecimal::from(10),
+            num_fills: 3,
+            dataset_version_id: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let back: HlTradeHistory = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.coin, "BTC");
+        assert_eq!(back.realized_pnl, BigDecimal::from(500));
+        assert_eq!(back.num_fills, 3);
+    }
+
+    #[test]
+    fn trader_analytics_serde_roundtrip() {
+        let a = TraderAnalytics {
+            wallet_address: "0xTrader".to_string(),
+            total_net_pnl: BigDecimal::from(100),
+            total_volume: BigDecimal::from(50000),
+            total_trades: 5,
+            win_rate: 0.6,
+            coin_breakdown: vec![CoinPnlSummary {
+                coin: "ETH".to_string(),
+                net_pnl: BigDecimal::from(100),
+                volume: BigDecimal::from(50000),
+                trade_count: 5,
+                win_count: 3,
+                loss_count: 2,
+            }],
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let back: TraderAnalytics = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.wallet_address, "0xTrader");
+        assert_eq!(back.coin_breakdown.len(), 1);
+    }
+
+    #[test]
+    fn market_analytics_serde_roundtrip() {
+        let m = MarketAnalytics {
+            coins: vec![CoinMarketSummary {
+                coin: "ETH".to_string(),
+                total_volume: BigDecimal::from(100000),
+                unique_traders: 5,
+                total_trades: 10,
+                total_pnl: BigDecimal::from(500),
+                avg_trade_size: BigDecimal::from(1),
+            }],
+            total_volume: BigDecimal::from(100000),
+            total_unique_traders: 5,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: MarketAnalytics = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.coins.len(), 1);
+        assert_eq!(back.total_unique_traders, 5);
+    }
+}

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -2,6 +2,7 @@ pub mod compat;
 pub mod dual_write;
 pub mod evm;
 pub mod evm_parser;
+pub mod hl_analytics;
 pub mod hyperliquid;
 pub mod hyperliquid_parser;
 pub mod hyperliquid_ws;

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -5,8 +5,8 @@
 
 use chrono::{DateTime, Utc};
 use spectraplex_core::materializer::{
-    BalanceSnapshot, DecodedEvent, HlFillRecord, HlFundingPayment, HlPositionChange,
-    NativeBalanceDelta, TokenTransfer, WalletLedgerRecord,
+    BalanceSnapshot, DecodedEvent, HlFillRecord, HlFundingPayment, HlPnlSummary, HlPositionChange,
+    HlTradeHistory, NativeBalanceDelta, TokenTransfer, WalletLedgerRecord,
 };
 use spectraplex_core::v2::{
     ChainFamily, Checkpoint, CompletenessStatus, DatasetCompleteness, DatasetVersion,
@@ -936,6 +936,48 @@ fn row_to_balance_snapshot(row: &sqlx::postgres::PgRow) -> anyhow::Result<Balanc
         timestamp: row.try_get("timestamp")?,
         balance: row.try_get("balance")?,
         tx_hash: row.try_get("tx_hash")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_hl_pnl_summary(row: &sqlx::postgres::PgRow) -> anyhow::Result<HlPnlSummary> {
+    Ok(HlPnlSummary {
+        id: row.try_get("id")?,
+        wallet_address: row.try_get("wallet_address")?,
+        coin: row.try_get("coin")?,
+        network: row.try_get("network")?,
+        period_start: row.try_get("period_start")?,
+        period_end: row.try_get("period_end")?,
+        total_closed_pnl: row.try_get("total_closed_pnl")?,
+        total_funding: row.try_get("total_funding")?,
+        total_fees: row.try_get("total_fees")?,
+        net_pnl: row.try_get("net_pnl")?,
+        trade_count: row.try_get("trade_count")?,
+        fill_count: row.try_get("fill_count")?,
+        avg_trade_size: row.try_get("avg_trade_size")?,
+        win_count: row.try_get("win_count")?,
+        loss_count: row.try_get("loss_count")?,
+        dataset_version_id: row.try_get("dataset_version_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_hl_trade_history(row: &sqlx::postgres::PgRow) -> anyhow::Result<HlTradeHistory> {
+    Ok(HlTradeHistory {
+        id: row.try_get("id")?,
+        wallet_address: row.try_get("wallet_address")?,
+        coin: row.try_get("coin")?,
+        network: row.try_get("network")?,
+        side: row.try_get("side")?,
+        entry_price: row.try_get("entry_price")?,
+        exit_price: row.try_get("exit_price")?,
+        size: row.try_get("size")?,
+        opened_at: row.try_get("opened_at")?,
+        closed_at: row.try_get("closed_at")?,
+        realized_pnl: row.try_get("realized_pnl")?,
+        fees: row.try_get("fees")?,
+        num_fills: row.try_get("num_fills")?,
         dataset_version_id: row.try_get("dataset_version_id")?,
         created_at: row.try_get("created_at")?,
     })
@@ -2424,6 +2466,99 @@ impl Repository {
         time_end: Option<i64>,
     ) -> anyhow::Result<Vec<BalanceSnapshot>> {
         self.query_balance_snapshots(
+            target_id,
+            network,
+            time_start,
+            time_end,
+            Self::EXPORT_MAX_RECORDS,
+            0,
+        )
+        .await
+    }
+
+    // -- P5-W2: Hyperliquid Gold analytics query/export methods --
+
+    pub async fn query_hl_pnl_summary(
+        &self,
+        target_id: Option<Uuid>,
+        network: Option<&str>,
+        time_start: Option<i64>,
+        time_end: Option<i64>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<HlPnlSummary>> {
+        let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.period_start, \
+                    dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
+                    dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
+                    dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
+        let (sql, args) = build_dataset_filter_query(
+            cols,
+            "hl_pnl_summary",
+            "dt.period_end",
+            target_id,
+            network,
+            time_start,
+            time_end,
+            limit,
+            offset,
+        )?;
+        let rows = sqlx::query_with(&sql, args).fetch_all(self.pool()).await?;
+        rows.iter().map(row_to_hl_pnl_summary).collect()
+    }
+
+    pub async fn export_hl_pnl_summary(
+        &self,
+        target_id: Option<Uuid>,
+        network: Option<&str>,
+        time_start: Option<i64>,
+        time_end: Option<i64>,
+    ) -> anyhow::Result<Vec<HlPnlSummary>> {
+        self.query_hl_pnl_summary(
+            target_id,
+            network,
+            time_start,
+            time_end,
+            Self::EXPORT_MAX_RECORDS,
+            0,
+        )
+        .await
+    }
+
+    pub async fn query_hl_trade_history(
+        &self,
+        target_id: Option<Uuid>,
+        network: Option<&str>,
+        time_start: Option<i64>,
+        time_end: Option<i64>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<HlTradeHistory>> {
+        let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.side, dt.entry_price, \
+                    dt.exit_price, dt.size, dt.opened_at, dt.closed_at, dt.realized_pnl, \
+                    dt.fees, dt.num_fills, dt.dataset_version_id, dt.created_at";
+        let (sql, args) = build_dataset_filter_query(
+            cols,
+            "hl_trade_history",
+            "dt.closed_at",
+            target_id,
+            network,
+            time_start,
+            time_end,
+            limit,
+            offset,
+        )?;
+        let rows = sqlx::query_with(&sql, args).fetch_all(self.pool()).await?;
+        rows.iter().map(row_to_hl_trade_history).collect()
+    }
+
+    pub async fn export_hl_trade_history(
+        &self,
+        target_id: Option<Uuid>,
+        network: Option<&str>,
+        time_start: Option<i64>,
+        time_end: Option<i64>,
+    ) -> anyhow::Result<Vec<HlTradeHistory>> {
+        self.query_hl_trade_history(
             target_id,
             network,
             time_start,

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -22,7 +22,8 @@ use spectraplex_core::config::AppConfig;
 use spectraplex_core::connector::validate_target;
 use spectraplex_core::materializer::{
     BalanceSnapshot, DatasetName, DeliveryMetadata, DeliveryReceipt, ExportFormat, ExportSink,
-    ForensicsActivity, SinkConfig, SinkType, WalletLedgerRecord,
+    ForensicsActivity, HlPnlSummary, HlTradeHistory, MarketAnalytics, SinkConfig, SinkType,
+    TraderAnalytics, WalletLedgerRecord,
 };
 use spectraplex_core::models::{Chain, ChainIngestor, IndexerCheckpoint, LedgerEntry, Transaction};
 use spectraplex_core::v2::{
@@ -305,6 +306,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/export/jobs/{job_id}/download", get(download_export))
         .route("/v1/export/tax", get(tax_export))
         .route("/v1/forensics/activity", get(forensics_activity_handler))
+        .route("/v1/analytics/hl/trader", get(hl_trader_analytics_handler))
+        .route("/v1/analytics/hl/market", get(hl_market_analytics_handler))
         .layer(middleware::from_fn_with_state(
             Arc::clone(&shared_state),
             require_auth,
@@ -1584,6 +1587,8 @@ const QUERYABLE_DATASETS: &[&str] = &[
     "positions",
     "wallet_ledger",
     "balance_history",
+    "hl_pnl_summary",
+    "hl_trade_history",
 ];
 
 fn validate_dataset_name(name: &str) -> Result<(), AppError> {
@@ -1770,6 +1775,36 @@ async fn query_dataset_records(
                 .map_err(AppError::internal)?;
             serde_json::to_value(&records).map_err(AppError::internal)?
         }
+        "hl_pnl_summary" => {
+            let records = state
+                .repo
+                .query_hl_pnl_summary(
+                    params.target_id,
+                    net,
+                    params.time_start,
+                    params.time_end,
+                    limit,
+                    offset,
+                )
+                .await
+                .map_err(AppError::internal)?;
+            serde_json::to_value(&records).map_err(AppError::internal)?
+        }
+        "hl_trade_history" => {
+            let records = state
+                .repo
+                .query_hl_trade_history(
+                    params.target_id,
+                    net,
+                    params.time_start,
+                    params.time_end,
+                    limit,
+                    offset,
+                )
+                .await
+                .map_err(AppError::internal)?;
+            serde_json::to_value(&records).map_err(AppError::internal)?
+        }
         _ => unreachable!("dataset name validated above"),
     };
 
@@ -1781,7 +1816,7 @@ async fn query_dataset_records(
 // ---------------------------------------------------------------------------
 
 /// Datasets that support export via the /v1/export/dataset endpoint.
-/// Includes Silver datasets plus Gold datasets (P5-W1).
+/// Includes Silver datasets plus Gold datasets (P5-W1, P5-W2).
 const EXPORTABLE_DATASETS: &[&str] = &[
     "token_transfers",
     "native_balance_deltas",
@@ -1791,6 +1826,8 @@ const EXPORTABLE_DATASETS: &[&str] = &[
     "positions",
     "wallet_ledger",
     "balance_history",
+    "hl_pnl_summary",
+    "hl_trade_history",
 ];
 
 fn content_type_for_format(format: ExportFormat) -> &'static str {
@@ -2035,6 +2072,66 @@ fn balance_history_to_csv(records: &[BalanceSnapshot]) -> Vec<u8> {
             r.timestamp,
             r.balance,
             csv_escape(&r.tx_hash),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        ));
+    }
+    buf.into_bytes()
+}
+
+fn hl_pnl_summary_to_csv(records: &[HlPnlSummary]) -> Vec<u8> {
+    let mut buf = String::from(
+        "id,wallet_address,coin,network,period_start,period_end,total_closed_pnl,total_funding,total_fees,net_pnl,trade_count,fill_count,avg_trade_size,win_count,loss_count,dataset_version_id,created_at\n",
+    );
+    for r in records {
+        buf.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            r.id,
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.coin),
+            csv_escape(&r.network),
+            r.period_start,
+            r.period_end,
+            r.total_closed_pnl,
+            r.total_funding,
+            r.total_fees,
+            r.net_pnl,
+            r.trade_count,
+            r.fill_count,
+            r.avg_trade_size,
+            r.win_count,
+            r.loss_count,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        ));
+    }
+    buf.into_bytes()
+}
+
+fn hl_trade_history_to_csv(records: &[HlTradeHistory]) -> Vec<u8> {
+    let mut buf = String::from(
+        "id,wallet_address,coin,network,side,entry_price,exit_price,size,opened_at,closed_at,realized_pnl,fees,num_fills,dataset_version_id,created_at\n",
+    );
+    for r in records {
+        buf.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            r.id,
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.coin),
+            csv_escape(&r.network),
+            csv_escape(&r.side),
+            r.entry_price,
+            r.exit_price,
+            r.size,
+            r.opened_at,
+            r.closed_at,
+            r.realized_pnl,
+            r.fees,
+            r.num_fills,
             r.dataset_version_id
                 .map(|u| u.to_string())
                 .unwrap_or_default(),
@@ -2515,6 +2612,32 @@ async fn run_export_job(
             };
             Ok((body, count, meta))
         }
+        "hl_pnl_summary" => {
+            let records = repo
+                .export_hl_pnl_summary(target_id, network, time_start, time_end)
+                .await?;
+            let count = records.len();
+            let body = match format {
+                ExportFormat::Jsonl => {
+                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
+                }
+                ExportFormat::Csv => hl_pnl_summary_to_csv(&records),
+            };
+            Ok((body, count, meta))
+        }
+        "hl_trade_history" => {
+            let records = repo
+                .export_hl_trade_history(target_id, network, time_start, time_end)
+                .await?;
+            let count = records.len();
+            let body = match format {
+                ExportFormat::Jsonl => {
+                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
+                }
+                ExportFormat::Csv => hl_trade_history_to_csv(&records),
+            };
+            Ok((body, count, meta))
+        }
         _ => Err(anyhow::anyhow!("Unknown dataset: {dataset}")),
     }
 }
@@ -2671,6 +2794,100 @@ async fn forensics_activity_handler(
         spectraplex_adapters::ledger_derivation::build_forensics_activity(&wallet, &records);
 
     Ok(Json(activity))
+}
+
+// ---------------------------------------------------------------------------
+// Hyperliquid analytics endpoints (P5-W2)
+// ---------------------------------------------------------------------------
+
+/// Query parameters for the Hyperliquid analytics endpoints.
+#[derive(Debug, Deserialize)]
+struct HlAnalyticsParams {
+    target_id: Option<Uuid>,
+    network: Option<String>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+}
+
+/// GET /v1/analytics/hl/trader — per-trader Hyperliquid PnL analytics.
+async fn hl_trader_analytics_handler(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HlAnalyticsParams>,
+) -> Result<Json<TraderAnalytics>, AppError> {
+    validate_date_range(params.time_start, params.time_end)?;
+
+    let pnl_summaries = state
+        .repo
+        .export_hl_pnl_summary(
+            params.target_id,
+            params.network.as_deref(),
+            params.time_start,
+            params.time_end,
+        )
+        .await
+        .map_err(AppError::internal)?;
+
+    let trade_histories = state
+        .repo
+        .export_hl_trade_history(
+            params.target_id,
+            params.network.as_deref(),
+            params.time_start,
+            params.time_end,
+        )
+        .await
+        .map_err(AppError::internal)?;
+
+    let wallet = pnl_summaries
+        .first()
+        .map(|s| s.wallet_address.as_str())
+        .or_else(|| trade_histories.first().map(|t| t.wallet_address.as_str()))
+        .unwrap_or("");
+
+    let analytics = spectraplex_adapters::hl_analytics::build_trader_analytics(
+        wallet,
+        &pnl_summaries,
+        &trade_histories,
+    );
+
+    Ok(Json(analytics))
+}
+
+/// GET /v1/analytics/hl/market — per-coin Hyperliquid market analytics.
+async fn hl_market_analytics_handler(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HlAnalyticsParams>,
+) -> Result<Json<MarketAnalytics>, AppError> {
+    validate_date_range(params.time_start, params.time_end)?;
+
+    let pnl_summaries = state
+        .repo
+        .export_hl_pnl_summary(
+            params.target_id,
+            params.network.as_deref(),
+            params.time_start,
+            params.time_end,
+        )
+        .await
+        .map_err(AppError::internal)?;
+
+    let trade_histories = state
+        .repo
+        .export_hl_trade_history(
+            params.target_id,
+            params.network.as_deref(),
+            params.time_start,
+            params.time_end,
+        )
+        .await
+        .map_err(AppError::internal)?;
+
+    let analytics = spectraplex_adapters::hl_analytics::build_market_analytics(
+        &pnl_summaries,
+        &trade_histories,
+    );
+
+    Ok(Json(analytics))
 }
 
 async fn get_dataset_completeness_handler(
@@ -2866,6 +3083,8 @@ mod tests {
             .route("/v1/export/jobs/{job_id}/download", get(download_export))
             .route("/v1/export/tax", get(tax_export))
             .route("/v1/forensics/activity", get(forensics_activity_handler))
+            .route("/v1/analytics/hl/trader", get(hl_trader_analytics_handler))
+            .route("/v1/analytics/hl/market", get(hl_market_analytics_handler))
             .layer(middleware::from_fn_with_state(
                 Arc::clone(&state),
                 require_auth,
@@ -4856,7 +5075,7 @@ mod tests {
 
     #[test]
     fn test_queryable_datasets_count() {
-        assert_eq!(QUERYABLE_DATASETS.len(), 8);
+        assert_eq!(QUERYABLE_DATASETS.len(), 10);
     }
 
     #[test]
@@ -4869,6 +5088,8 @@ mod tests {
         assert!(QUERYABLE_DATASETS.contains(&"positions"));
         assert!(QUERYABLE_DATASETS.contains(&"wallet_ledger"));
         assert!(QUERYABLE_DATASETS.contains(&"balance_history"));
+        assert!(QUERYABLE_DATASETS.contains(&"hl_pnl_summary"));
+        assert!(QUERYABLE_DATASETS.contains(&"hl_trade_history"));
     }
 
     #[test]
@@ -6700,9 +6921,11 @@ mod tests {
 
     #[test]
     fn test_exportable_datasets_includes_gold() {
-        assert_eq!(EXPORTABLE_DATASETS.len(), 8);
+        assert_eq!(EXPORTABLE_DATASETS.len(), 10);
         assert!(EXPORTABLE_DATASETS.contains(&"wallet_ledger"));
         assert!(EXPORTABLE_DATASETS.contains(&"balance_history"));
+        assert!(EXPORTABLE_DATASETS.contains(&"hl_pnl_summary"));
+        assert!(EXPORTABLE_DATASETS.contains(&"hl_trade_history"));
     }
 
     #[tokio::test]
@@ -6769,6 +6992,208 @@ mod tests {
     // Verify existing dataset endpoints remain functional
     #[tokio::test]
     async fn p5w1_compat_existing_dataset_endpoints_still_routed() {
+        let dataset_uris = vec![
+            "/v1/datasets",
+            "/v1/datasets/token_transfers/versions",
+            "/v1/datasets/token_transfers/records",
+            "/v1/datasets/token_transfers/completeness",
+            "/v1/datasets/token_transfers/status",
+        ];
+        for uri in dataset_uris {
+            assert_get_routed(test_router(), uri).await;
+        }
+    }
+
+    // ── P5-W2: Hyperliquid Analytics Pack tests ───────────────────────
+
+    #[test]
+    fn test_hl_pnl_summary_in_queryable_datasets() {
+        assert!(QUERYABLE_DATASETS.contains(&"hl_pnl_summary"));
+    }
+
+    #[test]
+    fn test_hl_trade_history_in_queryable_datasets() {
+        assert!(QUERYABLE_DATASETS.contains(&"hl_trade_history"));
+    }
+
+    #[test]
+    fn test_hl_pnl_summary_in_exportable_datasets() {
+        assert!(EXPORTABLE_DATASETS.contains(&"hl_pnl_summary"));
+    }
+
+    #[test]
+    fn test_hl_trade_history_in_exportable_datasets() {
+        assert!(EXPORTABLE_DATASETS.contains(&"hl_trade_history"));
+    }
+
+    #[tokio::test]
+    async fn test_hl_pnl_summary_records_endpoint_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/hl_pnl_summary/records").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_trade_history_records_endpoint_routed() {
+        assert_get_routed(test_router(), "/v1/datasets/hl_trade_history/records").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_trader_analytics_endpoint_routed() {
+        assert_get_routed(test_router(), "/v1/analytics/hl/trader").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_market_analytics_endpoint_routed() {
+        assert_get_routed(test_router(), "/v1/analytics/hl/market").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_trader_analytics_requires_auth() {
+        assert_get_requires_auth(test_router(), "/v1/analytics/hl/trader").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_market_analytics_requires_auth() {
+        assert_get_requires_auth(test_router(), "/v1/analytics/hl/market").await;
+    }
+
+    #[tokio::test]
+    async fn test_hl_pnl_summary_export_accepted() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/export/dataset")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "dataset": "hl_pnl_summary"
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "hl_pnl_summary export should be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hl_trade_history_export_accepted() {
+        let app = test_router();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/export/dataset")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", TEST_API_KEY))
+            .body(Body::from(
+                serde_json::to_string(&serde_json::json!({
+                    "dataset": "hl_trade_history"
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "hl_trade_history export should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_hl_pnl_summary_to_csv_format() {
+        let records = vec![HlPnlSummary {
+            id: Uuid::nil(),
+            wallet_address: "0xTrader".to_string(),
+            coin: "ETH".to_string(),
+            network: "hyperliquid-mainnet".to_string(),
+            period_start: 1000,
+            period_end: 2000,
+            total_closed_pnl: bigdecimal::BigDecimal::from(100),
+            total_funding: bigdecimal::BigDecimal::from(10),
+            total_fees: bigdecimal::BigDecimal::from(5),
+            net_pnl: bigdecimal::BigDecimal::from(105),
+            trade_count: 3,
+            fill_count: 5,
+            avg_trade_size: bigdecimal::BigDecimal::from(1),
+            win_count: 2,
+            loss_count: 1,
+            dataset_version_id: None,
+            created_at: chrono::DateTime::from_timestamp(1700000000, 0).unwrap(),
+        }];
+        let csv = hl_pnl_summary_to_csv(&records);
+        let output = String::from_utf8(csv).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2); // header + 1 row
+        assert!(lines[0].contains("net_pnl"));
+        assert!(lines[0].contains("total_closed_pnl"));
+        assert!(lines[0].contains("total_funding"));
+        assert!(lines[1].contains("ETH"));
+        assert!(lines[1].contains("105"));
+    }
+
+    #[test]
+    fn test_hl_trade_history_to_csv_format() {
+        let records = vec![HlTradeHistory {
+            id: Uuid::nil(),
+            wallet_address: "0xTrader".to_string(),
+            coin: "BTC".to_string(),
+            network: "hyperliquid-mainnet".to_string(),
+            side: "B".to_string(),
+            entry_price: bigdecimal::BigDecimal::from(50000),
+            exit_price: bigdecimal::BigDecimal::from(51000),
+            size: bigdecimal::BigDecimal::from(1),
+            opened_at: 1000,
+            closed_at: 3000,
+            realized_pnl: bigdecimal::BigDecimal::from(1000),
+            fees: bigdecimal::BigDecimal::from(10),
+            num_fills: 3,
+            dataset_version_id: None,
+            created_at: chrono::DateTime::from_timestamp(1700000000, 0).unwrap(),
+        }];
+        let csv = hl_trade_history_to_csv(&records);
+        let output = String::from_utf8(csv).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 2); // header + 1 row
+        assert!(lines[0].contains("entry_price"));
+        assert!(lines[0].contains("exit_price"));
+        assert!(lines[0].contains("realized_pnl"));
+        assert!(lines[1].contains("BTC"));
+        assert!(lines[1].contains("1000"));
+    }
+
+    // Verify P5-W1 compatibility remains
+    #[tokio::test]
+    async fn p5w2_compat_existing_wallet_endpoints_still_routed() {
+        let wallet_uris = vec![
+            "/v1/transactions/SomeWallet123",
+            "/v1/ledger/SomeWallet123",
+            "/v1/export/SomeWallet123",
+            "/v1/balances/SomeWallet123",
+            "/v1/stats/SomeWallet123",
+        ];
+        for uri in wallet_uris {
+            assert_get_routed(test_router(), uri).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn p5w2_compat_p5w1_endpoints_still_routed() {
+        let uris = vec![
+            "/v1/datasets/wallet_ledger/records",
+            "/v1/datasets/balance_history/records",
+            "/v1/export/tax",
+            "/v1/forensics/activity",
+        ];
+        for uri in uris {
+            assert_get_routed(test_router(), uri).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn p5w2_compat_existing_dataset_endpoints_still_routed() {
         let dataset_uris = vec![
             "/v1/datasets",
             "/v1/datasets/token_transfers/versions",

--- a/core/src/materializer.rs
+++ b/core/src/materializer.rs
@@ -46,6 +46,10 @@ pub enum DatasetName {
     WalletLedger,
     /// Gold-tier per-asset balance history snapshots (P5-W1).
     BalanceHistory,
+    /// Gold-tier Hyperliquid PnL summary per coin per period (P5-W2).
+    HlPnlSummary,
+    /// Gold-tier Hyperliquid trade history with entry/exit grouping (P5-W2).
+    HlTradeHistory,
 }
 
 impl DatasetName {
@@ -61,6 +65,8 @@ impl DatasetName {
             DatasetName::Positions => "positions",
             DatasetName::WalletLedger => "wallet_ledger",
             DatasetName::BalanceHistory => "balance_history",
+            DatasetName::HlPnlSummary => "hl_pnl_summary",
+            DatasetName::HlTradeHistory => "hl_trade_history",
         }
     }
 
@@ -76,6 +82,8 @@ impl DatasetName {
             DatasetName::Positions,
             DatasetName::WalletLedger,
             DatasetName::BalanceHistory,
+            DatasetName::HlPnlSummary,
+            DatasetName::HlTradeHistory,
         ]
     }
 }
@@ -634,6 +642,107 @@ pub struct TypeBreakdown {
 }
 
 // ---------------------------------------------------------------------------
+// Gold Dataset Records (P5-W2): Hyperliquid Analytics
+// ---------------------------------------------------------------------------
+
+/// Gold-tier Hyperliquid PnL summary per wallet per coin per period.
+///
+/// Aggregated from Silver hl_fills (closed_pnl, fees) and hl_funding
+/// (funding amounts). Each record summarizes performance metrics for a
+/// single coin within a time period.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlPnlSummary {
+    pub id: Uuid,
+    pub wallet_address: String,
+    pub coin: String,
+    pub network: String,
+    pub period_start: i64,
+    pub period_end: i64,
+    pub total_closed_pnl: BigDecimal,
+    pub total_funding: BigDecimal,
+    pub total_fees: BigDecimal,
+    pub net_pnl: BigDecimal,
+    pub trade_count: i64,
+    pub fill_count: i64,
+    pub avg_trade_size: BigDecimal,
+    pub win_count: i64,
+    pub loss_count: i64,
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Gold-tier Hyperliquid trade history record.
+///
+/// Groups individual fills into logical trades with entry/exit prices
+/// and realized PnL. Each record represents a single open→close trade
+/// sequence for a coin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlTradeHistory {
+    pub id: Uuid,
+    pub wallet_address: String,
+    pub coin: String,
+    pub network: String,
+    pub side: String,
+    pub entry_price: BigDecimal,
+    pub exit_price: BigDecimal,
+    pub size: BigDecimal,
+    pub opened_at: i64,
+    pub closed_at: i64,
+    pub realized_pnl: BigDecimal,
+    pub fees: BigDecimal,
+    pub num_fills: i64,
+    pub dataset_version_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Per-trader analytics response for the Hyperliquid analytics endpoint.
+///
+/// Dashboard-ready summary of a trader's performance across coins,
+/// computed from Gold hl_pnl_summary and hl_trade_history records.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraderAnalytics {
+    pub wallet_address: String,
+    pub total_net_pnl: BigDecimal,
+    pub total_volume: BigDecimal,
+    pub total_trades: i64,
+    pub win_rate: f64,
+    pub coin_breakdown: Vec<CoinPnlSummary>,
+}
+
+/// Per-coin PnL breakdown within a trader analytics response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoinPnlSummary {
+    pub coin: String,
+    pub net_pnl: BigDecimal,
+    pub volume: BigDecimal,
+    pub trade_count: i64,
+    pub win_count: i64,
+    pub loss_count: i64,
+}
+
+/// Per-coin market analytics response for the Hyperliquid analytics endpoint.
+///
+/// Aggregated view of trading activity for a single coin across all traders,
+/// computed from Gold hl_pnl_summary and hl_trade_history records.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketAnalytics {
+    pub coins: Vec<CoinMarketSummary>,
+    pub total_volume: BigDecimal,
+    pub total_unique_traders: usize,
+}
+
+/// Per-coin aggregate market summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoinMarketSummary {
+    pub coin: String,
+    pub total_volume: BigDecimal,
+    pub unique_traders: usize,
+    pub total_trades: i64,
+    pub total_pnl: BigDecimal,
+    pub avg_trade_size: BigDecimal,
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -644,9 +753,9 @@ mod tests {
     use strum::IntoEnumIterator;
 
     #[test]
-    fn dataset_name_count_is_nine() {
-        assert_eq!(DatasetName::all().len(), 9);
-        assert_eq!(DatasetName::iter().count(), 9);
+    fn dataset_name_count_is_eleven() {
+        assert_eq!(DatasetName::all().len(), 11);
+        assert_eq!(DatasetName::iter().count(), 11);
     }
 
     #[test]
@@ -664,8 +773,10 @@ mod tests {
             (DatasetName::Positions, "\"positions\""),
             (DatasetName::WalletLedger, "\"wallet_ledger\""),
             (DatasetName::BalanceHistory, "\"balance_history\""),
+            (DatasetName::HlPnlSummary, "\"hl_pnl_summary\""),
+            (DatasetName::HlTradeHistory, "\"hl_trade_history\""),
         ];
-        assert_eq!(cases.len(), 9, "must cover all 9 datasets");
+        assert_eq!(cases.len(), 11, "must cover all 11 datasets");
         for (variant, expected_json) in cases {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, expected_json, "serialize {variant:?}");
@@ -688,6 +799,8 @@ mod tests {
         assert_eq!(DatasetName::Positions.to_string(), "positions");
         assert_eq!(DatasetName::WalletLedger.to_string(), "wallet_ledger");
         assert_eq!(DatasetName::BalanceHistory.to_string(), "balance_history");
+        assert_eq!(DatasetName::HlPnlSummary.to_string(), "hl_pnl_summary");
+        assert_eq!(DatasetName::HlTradeHistory.to_string(), "hl_trade_history");
     }
 
     #[test]
@@ -711,6 +824,14 @@ mod tests {
         assert_eq!(
             DatasetName::from_str("balance_history").unwrap(),
             DatasetName::BalanceHistory
+        );
+        assert_eq!(
+            DatasetName::from_str("hl_pnl_summary").unwrap(),
+            DatasetName::HlPnlSummary
+        );
+        assert_eq!(
+            DatasetName::from_str("hl_trade_history").unwrap(),
+            DatasetName::HlTradeHistory
         );
         assert!(DatasetName::from_str("unknown_dataset").is_err());
     }

--- a/migrations/20260310300000_add_hl_analytics_gold.sql
+++ b/migrations/20260310300000_add_hl_analytics_gold.sql
@@ -1,0 +1,59 @@
+-- P5-W2: Gold-tier Hyperliquid analytics tables
+-- hl_pnl_summary: per-wallet per-coin PnL summaries aggregated from Silver fills and funding
+-- hl_trade_history: logical trade records grouped from Silver fills
+
+CREATE TABLE IF NOT EXISTS hl_pnl_summary (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    wallet_address  TEXT NOT NULL,
+    coin            TEXT NOT NULL,
+    network         TEXT NOT NULL,
+    period_start    BIGINT NOT NULL,
+    period_end      BIGINT NOT NULL,
+    total_closed_pnl NUMERIC NOT NULL DEFAULT 0,
+    total_funding   NUMERIC NOT NULL DEFAULT 0,
+    total_fees      NUMERIC NOT NULL DEFAULT 0,
+    net_pnl         NUMERIC NOT NULL DEFAULT 0,
+    trade_count     BIGINT NOT NULL DEFAULT 0,
+    fill_count      BIGINT NOT NULL DEFAULT 0,
+    avg_trade_size  NUMERIC NOT NULL DEFAULT 0,
+    win_count       BIGINT NOT NULL DEFAULT 0,
+    loss_count      BIGINT NOT NULL DEFAULT 0,
+    dataset_version_id UUID REFERENCES dataset_versions(id),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hl_pnl_summary_wallet_coin
+    ON hl_pnl_summary (wallet_address, coin);
+CREATE INDEX IF NOT EXISTS idx_hl_pnl_summary_network
+    ON hl_pnl_summary (network);
+CREATE INDEX IF NOT EXISTS idx_hl_pnl_summary_period_start
+    ON hl_pnl_summary (period_start);
+CREATE INDEX IF NOT EXISTS idx_hl_pnl_summary_period_end
+    ON hl_pnl_summary (period_end);
+
+CREATE TABLE IF NOT EXISTS hl_trade_history (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    wallet_address  TEXT NOT NULL,
+    coin            TEXT NOT NULL,
+    network         TEXT NOT NULL,
+    side            TEXT NOT NULL,
+    entry_price     NUMERIC NOT NULL,
+    exit_price      NUMERIC NOT NULL,
+    size            NUMERIC NOT NULL,
+    opened_at       BIGINT NOT NULL,
+    closed_at       BIGINT NOT NULL,
+    realized_pnl    NUMERIC NOT NULL DEFAULT 0,
+    fees            NUMERIC NOT NULL DEFAULT 0,
+    num_fills       BIGINT NOT NULL DEFAULT 0,
+    dataset_version_id UUID REFERENCES dataset_versions(id),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hl_trade_history_wallet_coin
+    ON hl_trade_history (wallet_address, coin);
+CREATE INDEX IF NOT EXISTS idx_hl_trade_history_network
+    ON hl_trade_history (network);
+CREATE INDEX IF NOT EXISTS idx_hl_trade_history_opened_at
+    ON hl_trade_history (opened_at DESC);
+CREATE INDEX IF NOT EXISTS idx_hl_trade_history_closed_at
+    ON hl_trade_history (closed_at DESC);


### PR DESCRIPTION
## Summary

Phase 5, Work Packet 2: Adds Gold-tier Hyperliquid analytics datasets and dashboard-ready endpoints, proving a Hyperliquid dashboard can consume Spectraplex outputs directly without raw chain parsing.

- **Gold datasets**: `hl_pnl_summary` (closed PnL + funding − fees) and `hl_trade_history` (open→close sequences with weighted avg entry price), materialized from Silver `hl_fills` and `hl_funding`
- **Analytics endpoints**: `/v1/analytics/hl/trader` and `/v1/analytics/hl/market` for dashboard-ready aggregations, behind auth
- **Migration**: `20260310300000_add_hl_analytics_gold.sql` with `IF NOT EXISTS` guards and proper indexes
- **Dataset registry**: `DatasetName::all()` returns 11 datasets; `QUERYABLE_DATASETS` and `EXPORTABLE_DATASETS` each contain 10 entries including the two new ones
- **Full backward compatibility** with P5-W1 and P4-W5 confirmed

## Key files

| File | Purpose |
|------|---------|
| `adapters/src/hl_analytics.rs` | Materialization logic, trader/market analytics, CSV export |
| `core/src/materializer.rs` | Dataset registration for hl_pnl_summary and hl_trade_history |
| `adapters/src/v2_repo.rs` | Repository queries for Gold HL analytics tables |
| `api/src/main.rs` | `/v1/analytics/hl/trader` and `/v1/analytics/hl/market` route handlers |
| `migrations/20260310300000_add_hl_analytics_gold.sql` | Gold analytics schema |
| `README.md` | New endpoints and datasets documented |

## Validation

- All 877 tests pass
- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo build --release --workspace` succeeds
- HlPnlSummary correctly computes `net_pnl = closed_pnl + funding - fees`
- HlTradeHistory groups fills into open→close sequences with weighted avg entry price
- TraderAnalytics and MarketAnalytics produce dashboard-ready aggregations
- CSV export tests validate well-formed header+data output

## Test plan

- [ ] Verify all 877 tests pass (`cargo test --workspace`)
- [ ] Confirm fmt and clippy are clean
- [ ] Review materialization logic in `hl_analytics.rs`
- [ ] Review migration for correctness and index coverage
- [ ] Verify `/v1/analytics/hl/trader` and `/v1/analytics/hl/market` route correctly behind auth
- [ ] Confirm dataset registry counts (11 all, 10 queryable, 10 exportable)
- [ ] Confirm backward compatibility with P5-W1 wallet/tax/forensics endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)