### PR TITLE
fix: address 4 critical security and correctness issues

### DIFF
--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -1,5 +1,6 @@
 use bigdecimal::BigDecimal;
 use spectraplex_core::models::{EntryType, LedgerEntry, Transaction};
+use tracing::warn;
 
 use crate::deterministic_id;
 
@@ -31,7 +32,13 @@ pub fn parse_evm_transaction(tx: &Transaction) -> anyhow::Result<Vec<LedgerEntry
                     .get("data")
                     .and_then(|d| d.as_str())
                     .unwrap_or("0x0");
-                let amount_bd = hex_to_bigdecimal(data_hex);
+                let amount_bd = match hex_to_bigdecimal(data_hex) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(tx_hash = %tx.tx_hash, field = "data", raw = %data_hex, "Skipping ERC-20 transfer with malformed amount: {e}");
+                        return Ok(entries);
+                    }
+                };
 
                 // The contract address is the token address
                 let token_address = tx
@@ -174,10 +181,10 @@ fn topic_to_address(topic: &str) -> String {
 
 /// Parse a hex string (with optional 0x prefix) into BigDecimal.
 /// Handles full uint256 range without truncation.
-fn hex_to_bigdecimal(hex: &str) -> BigDecimal {
+fn hex_to_bigdecimal(hex: &str) -> anyhow::Result<BigDecimal> {
     let stripped = hex.strip_prefix("0x").unwrap_or(hex);
     if stripped.is_empty() {
-        return BigDecimal::from(0);
+        return Ok(BigDecimal::from(0));
     }
     // Parse hex digits in chunks to build a BigDecimal without overflow
     let mut result = BigDecimal::from(0);
@@ -186,11 +193,17 @@ fn hex_to_bigdecimal(hex: &str) -> BigDecimal {
         let digit = match ch.to_ascii_lowercase() {
             '0'..='9' => ch as u32 - '0' as u32,
             'a'..='f' => ch as u32 - 'a' as u32 + 10,
-            _ => return BigDecimal::from(0),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid hex character '{}' in value: {}",
+                    ch,
+                    hex
+                ))
+            }
         };
         result = result * &base + BigDecimal::from(digit);
     }
-    result
+    Ok(result)
 }
 
 /// Parse a hex string (with optional 0x prefix) into u128.
@@ -300,7 +313,13 @@ pub fn extract_evm_token_transfers(
         .get("data")
         .and_then(|d| d.as_str())
         .unwrap_or("0x0");
-    let amount_bd = hex_to_bigdecimal(data_hex);
+    let amount_bd = match hex_to_bigdecimal(data_hex) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "data", raw = %data_hex, "Skipping EVM token transfer with malformed amount: {e}");
+            return vec![];
+        }
+    };
 
     let token_address = raw_metadata
         .get("address")
@@ -322,6 +341,7 @@ pub fn extract_evm_token_transfers(
         to_address: to,
         amount: normalized,
         decimals: decimals as i32,
+        transfer_index: 0,
         dataset_version_id: None,
         created_at: Utc::now(),
     });
@@ -453,7 +473,13 @@ fn decode_evm_event_fields(
         Some(t) if t == ERC20_TRANSFER_TOPIC && topics.len() >= 3 => {
             let from = topic_to_address(topics[1].as_str().unwrap_or_default());
             let to = topic_to_address(topics[2].as_str().unwrap_or_default());
-            let value = hex_to_bigdecimal(data_hex).to_string();
+            let value = match hex_to_bigdecimal(data_hex) {
+                Ok(v) => v.to_string(),
+                Err(e) => {
+                    warn!(field = "data", raw = %data_hex, "Malformed hex in Transfer event: {e}");
+                    data_hex.to_string()
+                }
+            };
             (
                 Some("Transfer".to_string()),
                 serde_json::json!({
@@ -466,7 +492,13 @@ fn decode_evm_event_fields(
         Some(t) if t == ERC20_APPROVAL_TOPIC && topics.len() >= 3 => {
             let owner = topic_to_address(topics[1].as_str().unwrap_or_default());
             let spender = topic_to_address(topics[2].as_str().unwrap_or_default());
-            let value = hex_to_bigdecimal(data_hex).to_string();
+            let value = match hex_to_bigdecimal(data_hex) {
+                Ok(v) => v.to_string(),
+                Err(e) => {
+                    warn!(field = "data", raw = %data_hex, "Malformed hex in Approval event: {e}");
+                    data_hex.to_string()
+                }
+            };
             (
                 Some("Approval".to_string()),
                 serde_json::json!({
@@ -899,13 +931,15 @@ mod tests {
     #[test]
     fn test_hex_to_bigdecimal() {
         // Small value
-        assert_eq!(hex_to_bigdecimal("0xff"), BigDecimal::from(255));
+        assert_eq!(hex_to_bigdecimal("0xff").unwrap(), BigDecimal::from(255));
         // u128 max = 0xffffffffffffffffffffffffffffffff
-        let u128_max = hex_to_bigdecimal("0xffffffffffffffffffffffffffffffff");
+        let u128_max = hex_to_bigdecimal("0xffffffffffffffffffffffffffffffff").unwrap();
         assert_eq!(u128_max, BigDecimal::from(u128::MAX));
         // Value larger than u128 (u128::MAX + 1)
-        let over_u128 = hex_to_bigdecimal("0x100000000000000000000000000000000");
+        let over_u128 = hex_to_bigdecimal("0x100000000000000000000000000000000").unwrap();
         assert!(over_u128 > BigDecimal::from(u128::MAX));
+        // Invalid hex returns error
+        assert!(hex_to_bigdecimal("0xGG").is_err());
     }
 
     #[test]

--- a/adapters/src/hyperliquid_parser.rs
+++ b/adapters/src/hyperliquid_parser.rs
@@ -26,8 +26,20 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
     let mut entries = Vec::new();
     let mut entry_index: u32 = 0;
 
-    let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
-    let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
+    let size = match BigDecimal::from_str(&fill.sz) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(tx_hash = %tx.tx_hash, field = "sz", raw = %fill.sz, "Skipping fill with malformed size: {e}");
+            return Ok(vec![]);
+        }
+    };
+    let price = match BigDecimal::from_str(&fill.px) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(tx_hash = %tx.tx_hash, field = "px", raw = %fill.px, "Skipping fill with malformed price: {e}");
+            return Ok(vec![]);
+        }
+    };
 
     // The trade itself: amount is the size, fiat_value is size * price
     let fiat_value = &size * &price;
@@ -49,7 +61,13 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
 
     // Fee entry (if present)
     if let Some(ref fee_str) = fill.fee {
-        let fee = BigDecimal::from_str(fee_str).unwrap_or_default();
+        let fee = match BigDecimal::from_str(fee_str) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(tx_hash = %tx.tx_hash, field = "fee", raw = %fee_str, "Skipping fee with malformed amount: {e}");
+                BigDecimal::from(0)
+            }
+        };
         if fee != BigDecimal::from(0) {
             let fee_token = fill.fee_token.as_deref().unwrap_or("USDC");
             entries.push(LedgerEntry {
@@ -68,7 +86,13 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
 
     // Closed PnL as income (if nonzero)
     if let Some(ref pnl_str) = fill.closed_pnl {
-        let pnl = BigDecimal::from_str(pnl_str).unwrap_or_default();
+        let pnl = match BigDecimal::from_str(pnl_str) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(tx_hash = %tx.tx_hash, field = "closedPnl", raw = %pnl_str, "Skipping PnL with malformed amount: {e}");
+                BigDecimal::from(0)
+            }
+        };
         if pnl != BigDecimal::from(0) {
             entries.push(LedgerEntry {
                 id: deterministic_id(tx.id, entry_index),
@@ -90,7 +114,13 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
 
 fn parse_funding(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<LedgerEntry>> {
     let funding: HlFundingEntry = serde_json::from_value(data.clone())?;
-    let amount = BigDecimal::from_str(&funding.usdc).unwrap_or_default();
+    let amount = match BigDecimal::from_str(&funding.usdc) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(tx_hash = %tx.tx_hash, field = "usdc", raw = %funding.usdc, "Skipping funding with malformed amount: {e}");
+            return Ok(vec![]);
+        }
+    };
 
     // Funding payments: positive = received, negative = paid
     Ok(vec![LedgerEntry {
@@ -117,7 +147,13 @@ fn parse_ledger_update(
     match delta_type {
         "deposit" => {
             let usdc = delta["usdc"].as_str().unwrap_or("0");
-            let amount = BigDecimal::from_str(usdc).unwrap_or_default();
+            let amount = match BigDecimal::from_str(usdc) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(tx_hash = %tx.tx_hash, field = "usdc", raw = %usdc, "Skipping deposit with malformed amount: {e}");
+                    return Ok(vec![]);
+                }
+            };
             Ok(vec![LedgerEntry {
                 id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
@@ -131,7 +167,13 @@ fn parse_ledger_update(
         }
         "withdraw" => {
             let usdc = delta["usdc"].as_str().unwrap_or("0");
-            let amount = BigDecimal::from_str(usdc).unwrap_or_default();
+            let amount = match BigDecimal::from_str(usdc) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(tx_hash = %tx.tx_hash, field = "usdc", raw = %usdc, "Skipping withdraw with malformed amount: {e}");
+                    return Ok(vec![]);
+                }
+            };
             Ok(vec![LedgerEntry {
                 id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
@@ -149,7 +191,13 @@ fn parse_ledger_update(
                 .as_str()
                 .or_else(|| delta["accountValue"].as_str())
                 .unwrap_or("0");
-            let amount = BigDecimal::from_str(usdc).unwrap_or_default();
+            let amount = match BigDecimal::from_str(usdc) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(tx_hash = %tx.tx_hash, field = "usdc/accountValue", raw = %usdc, "Skipping liquidation with malformed amount: {e}");
+                    return Ok(vec![]);
+                }
+            };
             Ok(vec![LedgerEntry {
                 id: deterministic_id(tx.id, 0),
                 transaction_id: tx.id,
@@ -201,7 +249,13 @@ pub fn extract_hyperliquid_token_transfers(
             match delta_type {
                 "deposit" => {
                     let usdc = delta["usdc"].as_str().unwrap_or("0");
-                    let amount = BigDecimal::from_str(usdc).unwrap_or_default();
+                    let amount = match BigDecimal::from_str(usdc) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!(field = "usdc", raw = %usdc, "Skipping HL deposit token transfer with malformed amount: {e}");
+                            return vec![];
+                        }
+                    };
                     if amount == BigDecimal::from(0) {
                         return vec![];
                     }
@@ -215,13 +269,20 @@ pub fn extract_hyperliquid_token_transfers(
                         to_address: wallet_address.to_string(),
                         amount,
                         decimals: 6,
+                        transfer_index: 0,
                         dataset_version_id: None,
                         created_at: Utc::now(),
                     }]
                 }
                 "withdraw" => {
                     let usdc = delta["usdc"].as_str().unwrap_or("0");
-                    let amount = BigDecimal::from_str(usdc).unwrap_or_default().abs();
+                    let amount = match BigDecimal::from_str(usdc) {
+                        Ok(v) => v.abs(),
+                        Err(e) => {
+                            warn!(field = "usdc", raw = %usdc, "Skipping HL withdraw token transfer with malformed amount: {e}");
+                            return vec![];
+                        }
+                    };
                     if amount == BigDecimal::from(0) {
                         return vec![];
                     }
@@ -235,6 +296,7 @@ pub fn extract_hyperliquid_token_transfers(
                         to_address: "external".to_string(),
                         amount,
                         decimals: 6,
+                        transfer_index: 0,
                         dataset_version_id: None,
                         created_at: Utc::now(),
                     }]
@@ -272,16 +334,26 @@ pub fn extract_hyperliquid_native_balance_deltas(
             };
 
             // Fee and closed PnL represent USDC balance changes
-            let fee = fill
-                .fee
-                .as_deref()
-                .and_then(|f| BigDecimal::from_str(f).ok())
-                .unwrap_or_default();
-            let pnl = fill
-                .closed_pnl
-                .as_deref()
-                .and_then(|p| BigDecimal::from_str(p).ok())
-                .unwrap_or_default();
+            let fee = match fill.fee.as_deref() {
+                Some(f) => match BigDecimal::from_str(f) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(field = "fee", raw = %f, "Skipping HL fill native delta with malformed fee: {e}");
+                        return vec![];
+                    }
+                },
+                None => BigDecimal::from(0),
+            };
+            let pnl = match fill.closed_pnl.as_deref() {
+                Some(p) => match BigDecimal::from_str(p) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(field = "closedPnl", raw = %p, "Skipping HL fill native delta with malformed PnL: {e}");
+                        return vec![];
+                    }
+                },
+                None => BigDecimal::from(0),
+            };
 
             // Total USDC delta from this fill = -fee + closed_pnl
             let delta = &pnl - &fee.abs();
@@ -311,7 +383,13 @@ pub fn extract_hyperliquid_native_balance_deltas(
                 Err(_) => return vec![],
             };
 
-            let delta = BigDecimal::from_str(&funding.usdc).unwrap_or_default();
+            let delta = match BigDecimal::from_str(&funding.usdc) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(field = "usdc", raw = %funding.usdc, "Skipping HL funding native delta with malformed amount: {e}");
+                    return vec![];
+                }
+            };
             if delta == BigDecimal::from(0) {
                 return vec![];
             }
@@ -456,8 +534,20 @@ pub fn extract_hl_fill_records(
         Err(_) => return vec![],
     };
 
-    let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
-    let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
+    let price = match BigDecimal::from_str(&fill.px) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "px", raw = %fill.px, "Skipping HL fill record with malformed price: {e}");
+            return vec![];
+        }
+    };
+    let size = match BigDecimal::from_str(&fill.sz) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "sz", raw = %fill.sz, "Skipping HL fill record with malformed size: {e}");
+            return vec![];
+        }
+    };
 
     let closed_pnl = fill
         .closed_pnl
@@ -512,7 +602,13 @@ pub fn extract_hl_funding_payments(
         Err(_) => return vec![],
     };
 
-    let amount = BigDecimal::from_str(&funding.usdc).unwrap_or_default();
+    let amount = match BigDecimal::from_str(&funding.usdc) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "usdc", raw = %funding.usdc, "Skipping HL funding payment with malformed amount: {e}");
+            return vec![];
+        }
+    };
     let funding_rate = funding
         .funding_rate
         .as_deref()
@@ -566,8 +662,20 @@ fn extract_position_change_from_fill(
         Err(_) => return vec![],
     };
 
-    let size = BigDecimal::from_str(&fill.sz).unwrap_or_default();
-    let price = BigDecimal::from_str(&fill.px).unwrap_or_default();
+    let size = match BigDecimal::from_str(&fill.sz) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "sz", raw = %fill.sz, "Skipping HL position change with malformed size: {e}");
+            return vec![];
+        }
+    };
+    let price = match BigDecimal::from_str(&fill.px) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "px", raw = %fill.px, "Skipping HL position change with malformed price: {e}");
+            return vec![];
+        }
+    };
 
     // Determine signed size_delta: buy = positive, sell = negative
     let size_delta = if fill.side == "B" { size } else { -size };
@@ -606,8 +714,20 @@ fn extract_position_change_from_liquidation(
     let price_str = delta["px"].as_str().unwrap_or("0");
     let side = delta["side"].as_str().unwrap_or("A");
 
-    let size = BigDecimal::from_str(size_str).unwrap_or_default();
-    let price = BigDecimal::from_str(price_str).unwrap_or_default();
+    let size = match BigDecimal::from_str(size_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "sz", raw = %size_str, "Skipping HL liquidation position change with malformed size: {e}");
+            return vec![];
+        }
+    };
+    let price = match BigDecimal::from_str(price_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(field = "px", raw = %price_str, "Skipping HL liquidation position change with malformed price: {e}");
+            return vec![];
+        }
+    };
 
     if size == BigDecimal::from(0) {
         return vec![];

--- a/adapters/src/ledger_derivation.rs
+++ b/adapters/src/ledger_derivation.rs
@@ -1046,6 +1046,7 @@ mod tests {
             to_address: to.to_string(),
             amount: BigDecimal::from_str(amount).unwrap(),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: Utc::now(),
         }

--- a/adapters/src/repo.rs
+++ b/adapters/src/repo.rs
@@ -28,14 +28,14 @@ fn entry_type_to_str(entry_type: &EntryType) -> &'static str {
     }
 }
 
-fn str_to_entry_type(s: &str) -> EntryType {
+fn str_to_entry_type(s: &str) -> anyhow::Result<EntryType> {
     match s {
-        "trade" => EntryType::Trade,
-        "fee" => EntryType::Fee,
-        "transfer" => EntryType::Transfer,
-        "staking" => EntryType::Staking,
-        "income" => EntryType::Income,
-        _ => EntryType::Transfer,
+        "trade" => Ok(EntryType::Trade),
+        "fee" => Ok(EntryType::Fee),
+        "transfer" => Ok(EntryType::Transfer),
+        "staking" => Ok(EntryType::Staking),
+        "income" => Ok(EntryType::Income),
+        _ => Err(anyhow::anyhow!("Unknown entry type: {}", s)),
     }
 }
 
@@ -330,7 +330,7 @@ impl Repository {
         let mut entries = Vec::new();
         for row in rows {
             let entry_type_str: String = row.try_get("entry_type")?;
-            let entry_type = str_to_entry_type(&entry_type_str);
+            let entry_type = str_to_entry_type(&entry_type_str)?;
 
             entries.push(LedgerEntry {
                 id: row.try_get("id")?,
@@ -687,12 +687,24 @@ mod tests {
 
     #[test]
     fn test_str_to_entry_type() {
-        assert!(matches!(str_to_entry_type("trade"), EntryType::Trade));
-        assert!(matches!(str_to_entry_type("fee"), EntryType::Fee));
-        assert!(matches!(str_to_entry_type("transfer"), EntryType::Transfer));
-        assert!(matches!(str_to_entry_type("staking"), EntryType::Staking));
-        assert!(matches!(str_to_entry_type("income"), EntryType::Income));
-        assert!(matches!(str_to_entry_type("unknown"), EntryType::Transfer));
+        assert!(matches!(
+            str_to_entry_type("trade").unwrap(),
+            EntryType::Trade
+        ));
+        assert!(matches!(str_to_entry_type("fee").unwrap(), EntryType::Fee));
+        assert!(matches!(
+            str_to_entry_type("transfer").unwrap(),
+            EntryType::Transfer
+        ));
+        assert!(matches!(
+            str_to_entry_type("staking").unwrap(),
+            EntryType::Staking
+        ));
+        assert!(matches!(
+            str_to_entry_type("income").unwrap(),
+            EntryType::Income
+        ));
+        assert!(str_to_entry_type("unknown").is_err());
     }
 
     #[test]
@@ -762,7 +774,7 @@ mod tests {
             EntryType::Income,
         ] {
             let s = entry_type_to_str(&et);
-            let recovered = str_to_entry_type(s);
+            let recovered = str_to_entry_type(s).unwrap();
             assert_eq!(entry_type_to_str(&recovered), s);
         }
     }

--- a/adapters/src/solana_parser.rs
+++ b/adapters/src/solana_parser.rs
@@ -212,6 +212,8 @@ pub fn extract_solana_token_transfers(
     }
 
     let mut transfers = Vec::new();
+    let mut group_counts: std::collections::HashMap<(String, String, String), i32> =
+        std::collections::HashMap::new();
 
     if let OptionSerializer::Some(pre_token_balances) = &meta.pre_token_balances {
         if let OptionSerializer::Some(post_token_balances) = &meta.post_token_balances {
@@ -248,6 +250,11 @@ pub fn extract_solana_token_transfers(
                     (owner, "unknown".to_string())
                 };
 
+                let key = (from.clone(), to.clone(), mint.clone());
+                let idx = group_counts.entry(key).or_insert(0);
+                let transfer_index = *idx;
+                *idx += 1;
+
                 transfers.push(TokenTransfer {
                     id: Uuid::new_v4(),
                     raw_transaction_id: raw_tx_id,
@@ -258,6 +265,7 @@ pub fn extract_solana_token_transfers(
                     to_address: to,
                     amount,
                     decimals: decimals as i32,
+                    transfer_index,
                     dataset_version_id: None,
                     created_at: Utc::now(),
                 });

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -441,6 +441,7 @@ fn row_to_token_transfer(row: &sqlx::postgres::PgRow) -> anyhow::Result<TokenTra
         to_address: row.try_get("to_address")?,
         amount: row.try_get::<BigDecimal, _>("amount")?,
         decimals: row.try_get("decimals")?,
+        transfer_index: row.try_get("transfer_index")?,
         dataset_version_id: row.try_get("dataset_version_id")?,
         created_at: row.try_get("created_at")?,
     })
@@ -473,17 +474,17 @@ pub fn build_token_transfer_insert(
 ) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
     let mut query = String::from(
         "INSERT INTO token_transfers \
-         (id, raw_transaction_id, network, token_address, token_symbol, from_address, to_address, amount, decimals, dataset_version_id, created_at) \
+         (id, raw_transaction_id, network, token_address, token_symbol, from_address, to_address, amount, decimals, transfer_index, dataset_version_id, created_at) \
          VALUES ",
     );
     let mut args = sqlx::postgres::PgArguments::default();
     for (i, t) in transfers.iter().enumerate() {
-        let base = i * 11;
+        let base = i * 12;
         if i > 0 {
             query.push_str(", ");
         }
         query.push_str(&format!(
-            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
             base + 1,
             base + 2,
             base + 3,
@@ -495,6 +496,7 @@ pub fn build_token_transfer_insert(
             base + 9,
             base + 10,
             base + 11,
+            base + 12,
         ));
         use sqlx::Arguments;
         args.add(t.id).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -511,12 +513,14 @@ pub fn build_token_transfer_insert(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         args.add(&t.amount).map_err(|e| anyhow::anyhow!("{e}"))?;
         args.add(t.decimals).map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(t.transfer_index)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
         args.add(t.dataset_version_id)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         args.add(t.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
     }
     query.push_str(
-        " ON CONFLICT (raw_transaction_id, from_address, to_address, token_address, amount) \
+        " ON CONFLICT (raw_transaction_id, from_address, to_address, token_address, transfer_index) \
          WHERE raw_transaction_id IS NOT NULL DO NOTHING",
     );
     Ok((query, args))
@@ -572,7 +576,7 @@ pub fn build_native_balance_delta_insert(
         args.add(d.created_at).map_err(|e| anyhow::anyhow!("{e}"))?;
     }
     query.push_str(
-        " ON CONFLICT (raw_transaction_id, account_address) \
+        " ON CONFLICT (raw_transaction_id, account_address, native_token) \
          WHERE raw_transaction_id IS NOT NULL DO NOTHING",
     );
     Ok((query, args))
@@ -1634,7 +1638,7 @@ impl Repository {
     ) -> anyhow::Result<Vec<TokenTransfer>> {
         let rows = sqlx::query(
             "SELECT id, raw_transaction_id, network, token_address, token_symbol, \
-             from_address, to_address, amount, decimals, dataset_version_id, created_at \
+             from_address, to_address, amount, decimals, transfer_index, dataset_version_id, created_at \
              FROM token_transfers \
              WHERE from_address = $1 OR to_address = $1 \
              ORDER BY created_at DESC LIMIT $2 OFFSET $3",
@@ -1654,7 +1658,7 @@ impl Repository {
     ) -> anyhow::Result<Vec<TokenTransfer>> {
         let rows = sqlx::query(
             "SELECT id, raw_transaction_id, network, token_address, token_symbol, \
-             from_address, to_address, amount, decimals, dataset_version_id, created_at \
+             from_address, to_address, amount, decimals, transfer_index, dataset_version_id, created_at \
              FROM token_transfers WHERE raw_transaction_id = $1 ORDER BY created_at",
         )
         .bind(raw_tx_id)
@@ -2069,7 +2073,7 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<TokenTransfer>> {
         let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.token_address, dt.token_symbol, \
-                    dt.from_address, dt.to_address, dt.amount, dt.decimals, dt.dataset_version_id, dt.created_at";
+                    dt.from_address, dt.to_address, dt.amount, dt.decimals, dt.transfer_index, dt.dataset_version_id, dt.created_at";
         let (sql, args) = build_dataset_filter_query(
             cols,
             "token_transfers",
@@ -3027,6 +3031,7 @@ mod tests {
             to_address: "0x2222222222222222222222222222222222222222".to_string(),
             amount: BigDecimal::from(100),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: Utc::now(),
         }
@@ -3055,7 +3060,7 @@ mod tests {
         let (query, _) = build_token_transfer_insert(&[tt]).unwrap();
 
         assert!(query.starts_with("INSERT INTO token_transfers"));
-        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"));
         assert!(query.contains("ON CONFLICT"));
     }
 
@@ -3064,18 +3069,18 @@ mod tests {
         let transfers: Vec<_> = (0..3).map(|_| make_token_transfer()).collect();
         let (query, _) = build_token_transfer_insert(&transfers).unwrap();
 
-        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"));
-        assert!(query.contains("($12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)"));
-        assert!(query.contains("($23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)"));
+        assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"));
+        assert!(query.contains("($13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)"));
+        assert!(query.contains("($25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)"));
     }
 
     #[test]
     fn token_transfer_insert_param_count() {
         let transfers: Vec<_> = (0..5).map(|_| make_token_transfer()).collect();
         let (query, _) = build_token_transfer_insert(&transfers).unwrap();
-        // 5 rows * 11 params = 55 => highest param is $55
-        assert!(query.contains("$55"));
-        assert!(!query.contains("$56"));
+        // 5 rows * 12 params = 60 => highest param is $60
+        assert!(query.contains("$60"));
+        assert!(!query.contains("$61"));
     }
 
     // -- native_balance_delta batch insert (P3-W2) --

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -558,6 +558,33 @@ fn validate_callback_url(url: &str) -> Result<(), AppError> {
 // Sink implementations
 // ---------------------------------------------------------------------------
 
+/// Header names that must not be set by user-supplied sink configuration.
+const FORBIDDEN_HEADER_NAMES: &[&str] = &[
+    "authorization",
+    "cookie",
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "set-cookie",
+    "x-forwarded-for",
+    "x-forwarded-proto",
+    "x-forwarded-host",
+];
+
+/// Validate that a header name contains only allowed characters: `[a-zA-Z0-9\-_]`.
+fn is_valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Validate that a header value contains no control characters
+/// (except horizontal tab, which is allowed in HTTP header values).
+fn is_valid_header_value(value: &str) -> bool {
+    value.chars().all(|c| !c.is_control() || c == '\t')
+}
+
 /// Validates a SinkConfig at job creation time.
 fn validate_sink_config(config: &SinkConfig) -> Result<(), AppError> {
     config
@@ -568,6 +595,26 @@ fn validate_sink_config(config: &SinkConfig) -> Result<(), AppError> {
         SinkType::Webhook => {
             if let Some(ref url) = config.url {
                 validate_callback_url(url)?;
+            }
+            if let Some(ref headers) = config.headers {
+                for (name, value) in headers {
+                    let lower = name.to_lowercase();
+                    if FORBIDDEN_HEADER_NAMES.contains(&lower.as_str()) {
+                        return Err(AppError::bad_request(format!(
+                            "Forbidden webhook header: {name}"
+                        )));
+                    }
+                    if !is_valid_header_name(name) {
+                        return Err(AppError::bad_request(format!(
+                            "Invalid header name: {name}. Header names must contain only [a-zA-Z0-9-_]"
+                        )));
+                    }
+                    if !is_valid_header_value(value) {
+                        return Err(AppError::bad_request(format!(
+                            "Invalid header value for {name}: header values must not contain control characters"
+                        )));
+                    }
+                }
             }
         }
         SinkType::LocalFile => {
@@ -1888,11 +1935,11 @@ fn serialize_to_jsonl<T: Serialize>(records: &[T]) -> Result<Vec<u8>, AppError> 
 
 fn token_transfers_to_csv(records: &[spectraplex_core::materializer::TokenTransfer]) -> Vec<u8> {
     let mut buf = String::from(
-        "id,raw_transaction_id,network,token_address,token_symbol,from_address,to_address,amount,decimals,dataset_version_id,created_at\n",
+        "id,raw_transaction_id,network,token_address,token_symbol,from_address,to_address,amount,decimals,transfer_index,dataset_version_id,created_at\n",
     );
     for r in records {
         buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{}\n",
+            "{},{},{},{},{},{},{},{},{},{},{},{}\n",
             r.id,
             r.raw_transaction_id
                 .map(|u| u.to_string())
@@ -1904,6 +1951,7 @@ fn token_transfers_to_csv(records: &[spectraplex_core::materializer::TokenTransf
             csv_escape(&r.to_address),
             r.amount,
             r.decimals,
+            r.transfer_index,
             r.dataset_version_id
                 .map(|u| u.to_string())
                 .unwrap_or_default(),
@@ -5982,6 +6030,7 @@ mod tests {
             to_address: "receiver".to_string(),
             amount: bigdecimal::BigDecimal::from(100),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: chrono::DateTime::from_timestamp(1700000000, 0).unwrap(),
         }];
@@ -6007,6 +6056,7 @@ mod tests {
             to_address: "0xto".to_string(),
             amount: bigdecimal::BigDecimal::from(50),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: chrono::DateTime::from_timestamp(1700000000, 0).unwrap(),
         }];
@@ -6113,6 +6163,85 @@ mod tests {
         };
         let err = validate_sink_config(&config).unwrap_err();
         assert!(err.message.contains("not yet implemented"));
+    }
+
+    #[test]
+    fn test_validate_sink_config_webhook_forbidden_header() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer secret".to_string());
+        let config = SinkConfig {
+            sink_type: SinkType::Webhook,
+            file_path: None,
+            url: Some("https://example.com/hook".to_string()),
+            headers: Some(headers),
+            connection_string: None,
+            table: None,
+        };
+        let err = validate_sink_config(&config).unwrap_err();
+        assert!(err.message.contains("Forbidden webhook header"));
+    }
+
+    #[test]
+    fn test_validate_sink_config_webhook_invalid_header_name() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("Bad Header\r\n".to_string(), "value".to_string());
+        let config = SinkConfig {
+            sink_type: SinkType::Webhook,
+            file_path: None,
+            url: Some("https://example.com/hook".to_string()),
+            headers: Some(headers),
+            connection_string: None,
+            table: None,
+        };
+        let err = validate_sink_config(&config).unwrap_err();
+        assert!(err.message.contains("Invalid header name"));
+    }
+
+    #[test]
+    fn test_validate_sink_config_webhook_control_char_in_value() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("X-Custom".to_string(), "val\r\nInjected: true".to_string());
+        let config = SinkConfig {
+            sink_type: SinkType::Webhook,
+            file_path: None,
+            url: Some("https://example.com/hook".to_string()),
+            headers: Some(headers),
+            connection_string: None,
+            table: None,
+        };
+        let err = validate_sink_config(&config).unwrap_err();
+        assert!(err.message.contains("control characters"));
+    }
+
+    #[test]
+    fn test_validate_sink_config_webhook_valid_custom_headers() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("X-Custom-Header".to_string(), "some-value".to_string());
+        headers.insert("X-Api_Key".to_string(), "key123".to_string());
+        let config = SinkConfig {
+            sink_type: SinkType::Webhook,
+            file_path: None,
+            url: Some("https://example.com/hook".to_string()),
+            headers: Some(headers),
+            connection_string: None,
+            table: None,
+        };
+        assert!(validate_sink_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_sink_config_webhook_tab_in_value_allowed() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("X-Custom".to_string(), "value\twith\ttabs".to_string());
+        let config = SinkConfig {
+            sink_type: SinkType::Webhook,
+            file_path: None,
+            url: Some("https://example.com/hook".to_string()),
+            headers: Some(headers),
+            connection_string: None,
+            table: None,
+        };
+        assert!(validate_sink_config(&config).is_ok());
     }
 
     #[test]

--- a/core/src/materializer.rs
+++ b/core/src/materializer.rs
@@ -384,6 +384,8 @@ pub struct TokenTransfer {
     pub amount: BigDecimal,
     /// Token decimals used for normalization.
     pub decimals: i32,
+    /// Ordinal position within the same (raw_transaction_id, from, to, token) group.
+    pub transfer_index: i32,
     /// FK to dataset_versions; nullable during transition.
     pub dataset_version_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
@@ -1190,6 +1192,7 @@ mod tests {
             to_address: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string(),
             amount: BigDecimal::from_str("1000.50").unwrap(),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: chrono::Utc::now(),
         };
@@ -1213,6 +1216,7 @@ mod tests {
             to_address: "0x2222222222222222222222222222222222222222".to_string(),
             amount: BigDecimal::from(100),
             decimals: 6,
+            transfer_index: 0,
             dataset_version_id: None,
             created_at: chrono::Utc::now(),
         };

--- a/migrations/20260311100000_fix_dedup_constraints.sql
+++ b/migrations/20260311100000_fix_dedup_constraints.sql
@@ -1,0 +1,34 @@
+-- Fix dedup constraints for token_transfers and native_balance_deltas.
+--
+-- token_transfers: Including `amount` in the unique index rejects legitimate
+-- records when the same (tx, from, to, token) group has multiple transfers
+-- with different amounts.  Replace with a (raw_transaction_id, from_address,
+-- to_address, token_address, transfer_index) constraint and add the
+-- transfer_index column.
+--
+-- native_balance_deltas: The existing constraint omits `native_token`, which
+-- rejects legitimate records when the same account has deltas for different
+-- native tokens in the same transaction.  Add `native_token` to the index.
+
+-- ---------------------------------------------------------------------------
+-- 1. token_transfers: add transfer_index column and fix unique index
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE token_transfers
+    ADD COLUMN IF NOT EXISTS transfer_index INT NOT NULL DEFAULT 0;
+
+DROP INDEX IF EXISTS uq_token_transfers_dedup;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_token_transfers_dedup
+    ON token_transfers(raw_transaction_id, from_address, to_address, token_address, transfer_index)
+    WHERE raw_transaction_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. native_balance_deltas: fix unique index to include native_token
+-- ---------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS uq_native_balance_deltas_dedup;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_native_balance_deltas_dedup
+    ON native_balance_deltas(raw_transaction_id, account_address, native_token)
+    WHERE raw_transaction_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Fixes four critical issues in a single surgical changeset:

- **#135 — Webhook header injection**: Custom headers in webhook sink configs are now validated at job creation time. Forbidden header names (authorization, cookie, host, content-length, transfer-encoding, set-cookie, x-forwarded-for/proto/host) are blocked, header names must match `[a-zA-Z0-9-_]`, and header values must not contain control characters (horizontal tab is allowed per HTTP spec).

- **#137 — Silent default on unknown entry type**: `str_to_entry_type()` now returns `anyhow::Result<EntryType>` instead of silently defaulting unknown values to `Transfer`. All call sites propagate the error. The test now verifies unknown types return an error.

- **#138 — Dedup constraint includes amount / misses native_token**: New migration (`20260311100000_fix_dedup_constraints.sql`) drops and recreates both unique indexes. `token_transfers` gets a `transfer_index INT NOT NULL DEFAULT 0` column replacing `amount` in the constraint. `native_balance_deltas` adds `native_token` to its constraint. Rust insert queries, struct definitions, SELECT projections, and CSV export are updated accordingly.

- **#139 — Silent zero on malformed amounts**: All `BigDecimal::from_str(...).unwrap_or_default()` calls in `hyperliquid_parser.rs` and the `hex_to_bigdecimal()` function in `evm_parser.rs` now use proper error handling — logging a `tracing::warn!` with context (raw value, field name) and skipping the record instead of silently recording zero.

## Files changed

- `api/src/main.rs` — header validation in `validate_sink_config()`, new tests, `transfer_index` in TokenTransfer constructions and CSV export
- `adapters/src/repo.rs` — `str_to_entry_type` returns `Result`, call site updated, tests updated
- `adapters/src/evm_parser.rs` — `hex_to_bigdecimal` returns `Result`, call sites handle errors with warn+skip
- `adapters/src/hyperliquid_parser.rs` — all `unwrap_or_default()` on `BigDecimal::from_str` replaced with warn+skip
- `adapters/src/v2_repo.rs` — insert queries updated for `transfer_index`, ON CONFLICT clauses fixed
- `adapters/src/solana_parser.rs` — `transfer_index` tracking per (from, to, token) group
- `adapters/src/ledger_derivation.rs` — `transfer_index` field added to test helper
- `core/src/materializer.rs` — `transfer_index: i32` added to `TokenTransfer` struct
- `migrations/20260311100000_fix_dedup_constraints.sql` — new migration

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 286 tests pass; 1 pre-existing failure (`test_semaphore_limits_concurrent_jobs`) confirmed on clean `main`
- [ ] Verify migration applies cleanly against a running PostgreSQL instance
- [ ] Verify webhook header validation rejects injection attempts end-to-end

Closes #135, closes #137, closes #138, closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)