### PR TITLE
Overhaul README for clarity 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,367 +3,238 @@
 [![CI](https://github.com/user1303836/spectraplex/actions/workflows/ci.yml/badge.svg)](https://github.com/user1303836/spectraplex/actions/workflows/ci.yml)
 [![Security Audit](https://github.com/user1303836/spectraplex/actions/workflows/audit.yml/badge.svg)](https://github.com/user1303836/spectraplex/actions/workflows/audit.yml)
 
-Spectraplex is a Rust multi-chain indexing and normalization system for blockchain ETL. It ingests raw chain data into canonical data tiers (Bronze records, materializes reusable Silver and Gold datasets) and exposes both compatibility wallet endpoints and newer target- and dataset-oriented APIs.
-
-The project treats wallets, contracts, programs, markets, pools, and protocol analytics as first-class indexing targets.
-
-## What Exists Today
-
-- Bronze storage for raw chain transactions and events
-- Silver datasets for transfers, balance deltas, decoded events, fills, funding, and positions
-- Gold datasets for wallet ledger, balance history, Hyperliquid analytics, protocol activity, and TVL
-- Legacy wallet-centric CLI and API flows
-- V2 target and network primitives for broader indexing use cases
-- Export jobs with JSONL and CSV output
-
-## Supported Chains and Networks
-
-Current ingestion adapters:
-
-| Family | Chain / Source | Current status |
-|--------|-----------------|----------------|
-| Solana | RPC and Yellowstone gRPC | Implemented |
-| EVM | `eth_getLogs` via `alloy` | Implemented |
-| Hyperliquid | REST and WebSocket | Implemented |
-
-Seeded V2 networks after `init-db`:
-
-| Network ID | Family | Notes |
-|-----------|--------|-------|
-| `solana-mainnet` | `solana` | probabilistic-slot finality |
-| `ethereum-mainnet` | `evm` | probabilistic-block finality |
-| `base-mainnet` | `evm` | deterministic-block finality |
-| `arbitrum-mainnet` | `evm` | deterministic-block finality |
-| `hyperevm-mainnet` | `evm` | deterministic-block finality |
-| `hypercore-mainnet` | `hyperliquid` | instant finality |
-
-## Repository Layout
-
-| Path | Purpose |
-|------|---------|
-| `core/` | shared config, V1/V2 models, target and materializer types |
-| `adapters/` | chain adapters, parsers, dataset derivation, repository layer |
-| `cli/` | CLI entry points for DB setup, ingestion, normalization, and V2 target management |
-| `api/` | Axum API server for ingestion, queries, exports, and analytics |
-| `migrations/` | PostgreSQL schema and seed data |
+Multi-chain blockchain indexer and ETL pipeline. Ingest raw data from Solana, EVM chains, and Hyperliquid, normalize it into queryable datasets, and export it as CSV or JSONL.
 
 ## Quick Start
 
-### Prerequisites
-
-- Rust stable
-- PostgreSQL 14+
-- Docker, if you want the bundled local database
-
-### 1. Clone and build
-
 ```bash
+# Clone and build
 git clone https://github.com/user1303836/spectraplex.git
 cd spectraplex
 cargo build --workspace
-```
 
-### 2. Start PostgreSQL
-
-```bash
+# Start PostgreSQL
 docker-compose up -d
-```
 
-Or point `DATABASE_URL` at an existing PostgreSQL instance.
+# Initialize the database
+cargo run --bin spectraplex-cli -- --db-url postgresql://localhost/spectraplex init-db
 
-### 3. Configure the app
+# Ingest some Solana transactions
+cargo run --bin spectraplex-cli -- --db-url postgresql://localhost/spectraplex ingest \
+  --chain solana --wallet <WALLET_ADDRESS> --rpc https://api.mainnet-beta.solana.com --limit 10
 
-Spectraplex loads configuration from:
-
-1. defaults
-2. `spectraplex.toml`
-3. `SPECTRAPLEX_*` environment variables
-4. direct env vars such as `DATABASE_URL`
-
-Start from the example file if you want a local config:
-
-```bash
-cp spectraplex.toml.example spectraplex.toml
-```
-
-Most useful environment variables:
-
-```bash
-export DATABASE_URL=postgresql://localhost/spectraplex
-export SPECTRAPLEX_API_KEY=change-me
-export SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
-export EVM_RPC_URL=https://eth.llamarpc.com
-# Optional:
-export SOLANA_GRPC_URL=https://your-yellowstone-endpoint
-export SOLANA_GRPC_TOKEN=your-token
-export SPECTRAPLEX_ALLOWED_WALLETS=<wallet1>,<wallet2>
-```
-
-### 4. Initialize the schema
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" init-db
-```
-
-### 5. Inspect seeded networks
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" list-networks
-```
-
-### 6. Ingest data
-
-Wallet compatibility path:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" ingest \
-  --chain solana \
-  --wallet <WALLET_ADDRESS> \
-  --rpc "$SOLANA_RPC_URL" \
-  --limit 10
-```
-
-Solana gRPC:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" ingest \
-  --chain solana \
-  --wallet <WALLET_ADDRESS> \
-  --grpc-url "$SOLANA_GRPC_URL" \
-  --x-token "$SOLANA_GRPC_TOKEN" \
-  --limit 10
-```
-
-EVM:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" ingest \
-  --chain ethereum \
-  --wallet <EVM_ADDRESS> \
-  --rpc "$EVM_RPC_URL" \
-  --limit 10
-```
-
-Hyperliquid:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" ingest \
-  --chain hyperliquid \
-  --wallet <HYPERLIQUID_ADDRESS> \
-  --limit 10
-```
-
-### 7. Normalize legacy wallet data
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" normalize \
-  --input db:<WALLET_ADDRESS>
-```
-
-### 8. Register a V2 target
-
-Wallet target:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" register-target \
-  --kind wallet \
-  --network solana-mainnet \
-  --address <WALLET_ADDRESS> \
-  --mode both \
-  --label "Primary wallet"
-```
-
-Topic filter target:
-
-```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" register-target \
-  --kind topic_filter \
-  --network ethereum-mainnet \
-  --filter-spec '{"topics":["0xddf252ad00000000000000000000000000000000000000000000000000000000"]}' \
-  --mode backfill \
-  --label "ERC20 transfers"
-```
-
-### 9. Start the API
-
-```bash
+# Start the API server
 cargo run --bin spectraplex-api
+# → http://127.0.0.1:3000/health
 ```
 
-The API binds to `SPECTRAPLEX_HOST:SPECTRAPLEX_PORT`, defaulting to `127.0.0.1:3000`.
+Requires Rust (stable) and PostgreSQL 14+. Docker handles Postgres if you don't have one running.
 
-## CLI Commands
+## Features
+
+**Ingest from any supported chain with a single command.** Point at a wallet, contract, or event filter and Spectraplex pulls raw transactions, logs, and fills into Bronze storage.
+
+**Normalize across chains automatically.** Raw data is materialized into canonical Silver datasets — token transfers, balance deltas, decoded events, fills, funding, and positions — regardless of which chain it came from.
+
+**Query and export structured datasets.** Silver and Gold datasets are available through a REST API with filtering, pagination, and async export to CSV, JSONL, local files, or webhooks.
+
+**Built-in analytics endpoints.** Trader PnL, market stats, protocol activity, and TVL queries ship out of the box.
+
+## Supported Chains
+
+| Chain | Data Source | Networks |
+|-------|------------|----------|
+| **Solana** | RPC + Yellowstone gRPC | `solana-mainnet` |
+| **Ethereum** | `eth_getLogs` via alloy | `ethereum-mainnet` |
+| **Base** | `eth_getLogs` via alloy | `base-mainnet` |
+| **Arbitrum** | `eth_getLogs` via alloy | `arbitrum-mainnet` |
+| **HyperEVM** | `eth_getLogs` via alloy | `hyperevm-mainnet` |
+| **Hyperliquid** | REST + WebSocket | `hypercore-mainnet` |
+
+## Datasets
+
+Data flows through three tiers: **Bronze** (raw) → **Silver** (normalized) → **Gold** (derived).
+
+| Dataset | Tier | Description |
+|---------|------|-------------|
+| `token_transfers` | Silver | Token transfer records across all chains |
+| `native_balance_deltas` | Silver | Native currency balance changes per account |
+| `decoded_events` | Silver | ABI-decoded EVM events and Solana logs |
+| `hl_fills` | Silver | Hyperliquid trade fills |
+| `hl_funding` | Silver | Hyperliquid funding payments |
+| `positions` | Silver | Position state changes from fills and liquidations |
+| `wallet_ledger` | Gold | Ledger entries with counterparty tracking |
+| `balance_history` | Gold | Per-asset balance snapshots over time |
+| `hl_pnl_summary` | Gold | Hyperliquid PnL per coin per period |
+| `hl_trade_history` | Gold | Hyperliquid trades with entry/exit grouping |
+| `protocol_events` | Gold | Protocol events derived from decoded logs |
+| `pool_snapshots` | Gold | Pool state snapshots from events and transfers |
+
+## API
+
+All `/v1/*` routes require `Authorization: Bearer <SPECTRAPLEX_API_KEY>`.
+
+### Ingestion and Jobs
+
+```bash
+# Trigger ingestion
+curl -X POST http://127.0.0.1:3000/v1/ingest \
+  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chain": "solana", "wallet": "<ADDRESS>", "rpc_url": "https://api.mainnet-beta.solana.com"}'
+
+# Check job status
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  http://127.0.0.1:3000/v1/jobs/<JOB_ID>
+```
+
+### Targets and Networks
+
+```bash
+# Register an indexing target
+curl -X POST http://127.0.0.1:3000/v1/targets \
+  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"kind": "wallet", "network": "solana-mainnet", "address": "<ADDRESS>", "mode": "both"}'
+
+# List networks
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" http://127.0.0.1:3000/v1/networks
+```
+
+### Query Datasets
+
+```bash
+# Query any dataset with filters
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  "http://127.0.0.1:3000/v1/datasets/token_transfers/records?network=solana-mainnet&limit=50"
+
+# Check dataset completeness
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  http://127.0.0.1:3000/v1/datasets/token_transfers/completeness
+```
+
+### Export
+
+```bash
+# Create an export job (CSV or JSONL)
+curl -X POST http://127.0.0.1:3000/v1/export/dataset \
+  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"dataset": "wallet_ledger", "format": "csv", "network": "solana-mainnet"}'
+
+# Download when ready
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  http://127.0.0.1:3000/v1/export/jobs/<JOB_ID>/download
+```
+
+Export jobs support optional sinks: `local_file` and `webhook`.
+
+### Analytics
+
+```bash
+# Hyperliquid trader analytics
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  "http://127.0.0.1:3000/v1/analytics/hl/trader?wallet=<ADDRESS>"
+
+# Protocol activity
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  "http://127.0.0.1:3000/v1/analytics/protocol/activity?network=ethereum-mainnet"
+
+# TVL
+curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  http://127.0.0.1:3000/v1/analytics/protocol/tvl
+```
+
+<details>
+<summary>Full endpoint reference</summary>
+
+**Ingestion and job control:**
+`POST /v1/ingest` | `POST /v1/ingest/batch` | `POST /v1/normalize` | `GET /v1/jobs/:job_id` | `POST /v1/stream/start` | `POST /v1/stream/:stream_id/stop` | `GET /v1/streams`
+
+**Wallet endpoints:**
+`GET /v1/transactions/:wallet` | `GET /v1/transactions/:wallet/:tx_hash` | `GET /v1/ledger/:wallet` | `GET /v1/export/:wallet` | `GET /v1/balances/:wallet` | `GET /v1/stats/:wallet`
+
+**Targets and networks:**
+`POST /v1/targets` | `GET /v1/targets` | `GET /v1/targets/:target_id` | `GET /v1/networks` | `GET /v1/networks/:network_id`
+
+**Datasets:**
+`GET /v1/datasets` | `GET /v1/datasets/:name/versions` | `GET /v1/datasets/:name/records` | `GET /v1/datasets/:name/completeness` | `GET /v1/datasets/:name/status`
+
+**Export:**
+`POST /v1/export/dataset` | `GET /v1/export/jobs/:job_id` | `GET /v1/export/jobs/:job_id/download` | `GET /v1/export/tax`
+
+**Analytics:**
+`GET /v1/forensics/activity` | `GET /v1/analytics/hl/trader` | `GET /v1/analytics/hl/market` | `GET /v1/analytics/protocol/activity` | `GET /v1/analytics/protocol/tvl`
+
+</details>
+
+## CLI
 
 ```bash
 cargo run --bin spectraplex-cli -- --help
 ```
 
-Current commands:
-
-- `init-db`
-- `ingest`
-- `normalize`
-- `register-target`
-- `list-targets`
-- `list-networks`
-
-Examples:
+| Command | Description |
+|---------|-------------|
+| `init-db` | Create tables, indexes, and seed network data |
+| `ingest` | Pull raw transactions from a chain into Bronze storage |
+| `normalize` | Materialize Silver datasets from ingested Bronze data |
+| `register-target` | Register a wallet, contract, program, or event filter for indexing |
+| `list-targets` | List registered targets with optional network/kind filters |
+| `list-networks` | Show all seeded networks |
 
 ```bash
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" list-targets
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" list-targets --network solana-mainnet
-cargo run --bin spectraplex-cli -- --db-url "$DATABASE_URL" list-targets --kind wallet
+# Ingest from any chain
+spectraplex-cli --db-url "$DATABASE_URL" ingest --chain ethereum --wallet <ADDRESS> --rpc "$EVM_RPC_URL" --limit 10
+spectraplex-cli --db-url "$DATABASE_URL" ingest --chain hyperliquid --wallet <ADDRESS> --limit 10
+
+# Register a target for ERC-20 Transfer events
+spectraplex-cli --db-url "$DATABASE_URL" register-target \
+  --kind topic_filter --network ethereum-mainnet \
+  --filter-spec '{"topics":["0xddf252ad00000000000000000000000000000000000000000000000000000000"]}' \
+  --mode backfill --label "ERC20 transfers"
 ```
 
-## API Overview
+## Configuration
 
-All `/v1/*` routes require:
+Spectraplex loads config from (in order of precedence):
 
-```text
-Authorization: Bearer <SPECTRAPLEX_API_KEY>
-```
+1. Defaults
+2. `spectraplex.toml` (copy from `spectraplex.toml.example`)
+3. `SPECTRAPLEX_*` environment variables
+4. Direct env vars (`DATABASE_URL`, `SOLANA_RPC_URL`, etc.)
 
-`/health` does not require auth.
-
-### Wallet Compatibility Endpoints
-
-- `POST /v1/ingest`
-- `POST /v1/ingest/batch`
-- `POST /v1/normalize`
-- `GET /v1/jobs/:job_id`
-- `GET /v1/transactions/:wallet`
-- `GET /v1/transactions/:wallet/:tx_hash`
-- `GET /v1/ledger/:wallet`
-- `GET /v1/export/:wallet`
-- `GET /v1/balances/:wallet`
-- `GET /v1/stats/:wallet`
-- `POST /v1/stream/start`
-- `POST /v1/stream/:stream_id/stop`
-- `GET /v1/streams`
-
-### Target, Network, and Dataset Endpoints
-
-- `POST /v1/targets`
-- `GET /v1/targets`
-- `GET /v1/targets/:target_id`
-- `GET /v1/networks`
-- `GET /v1/networks/:network_id`
-- `GET /v1/datasets`
-- `GET /v1/datasets/:name/versions`
-- `GET /v1/datasets/:name/records`
-- `GET /v1/datasets/:name/completeness`
-- `GET /v1/datasets/:name/status`
-- `POST /v1/export/dataset`
-- `GET /v1/export/jobs/:job_id`
-- `GET /v1/export/jobs/:job_id/download`
-
-### Analytics and Downstream-Oriented Endpoints
-
-- `GET /v1/export/tax`
-- `GET /v1/forensics/activity`
-- `GET /v1/analytics/hl/trader`
-- `GET /v1/analytics/hl/market`
-- `GET /v1/analytics/protocol/activity`
-- `GET /v1/analytics/protocol/tvl`
-
-### Example API Calls
-
-Health:
+Key environment variables:
 
 ```bash
-curl http://127.0.0.1:3000/health
+DATABASE_URL=postgresql://localhost/spectraplex
+SPECTRAPLEX_API_KEY=your-api-key
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+EVM_RPC_URL=https://eth.llamarpc.com
+# Optional
+SOLANA_GRPC_URL=https://your-yellowstone-endpoint
+SOLANA_GRPC_TOKEN=your-token
 ```
 
-List networks:
+## Project Layout
+
+```
+spectraplex/
+├── core/         Shared models, config, traits
+├── adapters/     Chain adapters, parsers, repository layer
+├── cli/          CLI entry points
+├── api/          Axum HTTP API server
+└── migrations/   PostgreSQL schema and seed data
+```
+
+## Development
 
 ```bash
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
-  http://127.0.0.1:3000/v1/networks
+cargo fmt --all --check                                    # format check
+cargo clippy --workspace --all-targets -- -D warnings      # lint
+cargo test --workspace                                     # tests
 ```
 
-Register a target:
+## License
 
-```bash
-curl -X POST http://127.0.0.1:3000/v1/targets \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "kind": "wallet",
-    "network": "solana-mainnet",
-    "address": "<WALLET_ADDRESS>",
-    "mode": "both",
-    "label": "Primary wallet"
-  }'
-```
-
-Query a dataset:
-
-```bash
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
-  "http://127.0.0.1:3000/v1/datasets/token_transfers/records?network=solana-mainnet&limit=50"
-```
-
-Create a dataset export job:
-
-```bash
-curl -X POST http://127.0.0.1:3000/v1/export/dataset \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "dataset": "wallet_ledger",
-    "format": "csv",
-    "network": "solana-mainnet"
-  }'
-```
-
-Dataset export jobs support optional sinks:
-
-- `local_file`
-- `webhook`
-
-Example webhook sink:
-
-```bash
-curl -X POST http://127.0.0.1:3000/v1/export/dataset \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "dataset": "protocol_events",
-    "format": "jsonl",
-    "sink": {
-      "sink_type": "webhook",
-      "url": "https://example.com/ingest"
-    }
-  }'
-```
-
-## Queryable and Exportable Datasets
-
-Datasets exposed today:
-
-- `token_transfers`
-- `native_balance_deltas`
-- `decoded_events`
-- `hl_fills`
-- `hl_funding`
-- `positions`
-- `wallet_ledger`
-- `balance_history`
-- `hl_pnl_summary`
-- `hl_trade_history`
-- `protocol_events`
-- `pool_snapshots`
-
-## Verification Commands
-
-```bash
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-```
-
-## Current Caveats
-
-- Wallet ingestion and wallet query paths are still the most mature parts of the system.
-- V2 target registration and dataset APIs exist, but ingestion orchestration is still uneven across target kinds.
-- Local planning and research files are intentionally kept out of version control.
+MIT


### PR DESCRIPTION
## Summary
- Replace the internal-facing "What Exists Today" section with a user-oriented Features description
- Move Quick Start to the top with a compact, copy-paste-ready flow (clone → docker → init → ingest → API)
- Add a Datasets table showing the Bronze → Silver → Gold pipeline
- Restructure API section with runnable curl examples and a collapsible full endpoint reference
- CLI section uses a clean table instead of a bullet list
- Cut overall length from ~370 lines to ~155 lines

## Test plan
- [ ] Verify all curl examples match current API routes
- [ ] Confirm Quick Start steps work on a fresh clone
- [ ] Review rendering on GitHub
