### PR TITLE
fix: CLI init-db exits 0 when --db-url is missing

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,13 +137,10 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::InitDb => {
-            if let Some(p) = pool {
-                info!("Running migrations...");
-                sqlx::migrate!("../migrations").run(&p).await?;
-                info!("Database initialized successfully.");
-            } else {
-                error!("--db-url is required for InitDb");
-            }
+            let p = pool.ok_or_else(|| anyhow::anyhow!("--db-url is required for init-db"))?;
+            info!("Running migrations...");
+            sqlx::migrate!("../migrations").run(&p).await?;
+            info!("Database initialized successfully.");
         }
         Commands::Ingest {
             chain,


### PR DESCRIPTION
## Summary

- When `--db-url` is not provided, `init-db` logged an error but exited with code 0, silently succeeding in scripts and CI
- Replaced the `if let` + `error!()` pattern with `pool.ok_or_else(...)` so the missing argument propagates as an `anyhow::Error` with a non-zero exit code

Closes #144