### PR TITLE
fix: apply pagination and combined filters in list_targets

### DIFF
--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1301,6 +1301,54 @@ impl Repository {
         rows.iter().map(row_to_index_target).collect()
     }
 
+    /// Unified target listing with optional filters and pagination.
+    /// Both `network` and `kind` can be applied simultaneously.
+    pub async fn list_index_targets_filtered(
+        &self,
+        network: Option<&str>,
+        kind: Option<TargetKind>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<IndexTarget>> {
+        // Build query dynamically based on which filters are present.
+        // Parameter positions are always: $1 = limit, $2 = offset, then
+        // optional filter params starting at $3.
+        let mut sql = String::from(
+            "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+             mode::text, label, owner_id, created_at, updated_at \
+             FROM index_targets",
+        );
+
+        let mut conditions: Vec<String> = Vec::new();
+        let mut param_idx = 3_usize; // $1 and $2 are limit and offset
+
+        if network.is_some() {
+            conditions.push(format!("network = ${param_idx}"));
+            param_idx += 1;
+        }
+        if kind.is_some() {
+            conditions.push(format!("kind = ${param_idx}::target_kind_enum"));
+        }
+
+        if !conditions.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&conditions.join(" AND "));
+        }
+
+        sql.push_str(" ORDER BY created_at LIMIT $1 OFFSET $2");
+
+        let mut query = sqlx::query(&sql).bind(limit).bind(offset);
+        if let Some(n) = network {
+            query = query.bind(n.to_string());
+        }
+        if let Some(ref k) = kind {
+            query = query.bind(target_kind_to_sql(k).to_string());
+        }
+
+        let rows = query.fetch_all(self.pool()).await?;
+        rows.iter().map(row_to_index_target).collect()
+    }
+
     // -----------------------------------------------------------------------
     // RawTransactions
     // -----------------------------------------------------------------------
@@ -3006,6 +3054,27 @@ mod tests {
         fn _assert_send<F: std::future::Future + Send>(_: F) {}
         fn _check(repo: &Repository) {
             _assert_send(repo.list_index_targets(10, 0));
+        }
+        let _ = _check;
+    }
+
+    #[test]
+    fn list_index_targets_filtered_compiles_all_combos() {
+        fn _assert_send<F: std::future::Future + Send>(_: F) {}
+        fn _check(repo: &Repository) {
+            // no filters
+            _assert_send(repo.list_index_targets_filtered(None, None, 10, 0));
+            // network only
+            _assert_send(repo.list_index_targets_filtered(Some("solana-mainnet"), None, 10, 0));
+            // kind only
+            _assert_send(repo.list_index_targets_filtered(None, Some(TargetKind::Wallet), 10, 0));
+            // both filters
+            _assert_send(repo.list_index_targets_filtered(
+                Some("solana-mainnet"),
+                Some(TargetKind::Contract),
+                10,
+                0,
+            ));
         }
         let _ = _check;
     }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1685,28 +1685,21 @@ async fn list_targets(
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
 
-    let targets = if let Some(ref network) = params.network {
-        state
-            .repo
-            .list_index_targets_by_network(network)
-            .await
-            .map_err(AppError::internal)?
-    } else if let Some(ref kind_str) = params.kind {
-        let kind: TargetKind = kind_str
-            .parse()
-            .map_err(|_| AppError::bad_request(format!("Invalid target kind: {kind_str}")))?;
-        state
-            .repo
-            .list_index_targets_by_kind(kind)
-            .await
-            .map_err(AppError::internal)?
-    } else {
-        state
-            .repo
-            .list_index_targets(limit, offset)
-            .await
-            .map_err(AppError::internal)?
-    };
+    // Parse kind filter (if provided) before calling the repository.
+    let kind: Option<TargetKind> = params
+        .kind
+        .as_deref()
+        .map(|k| {
+            k.parse()
+                .map_err(|_| AppError::bad_request(format!("Invalid target kind: {k}")))
+        })
+        .transpose()?;
+
+    let targets = state
+        .repo
+        .list_index_targets_filtered(params.network.as_deref(), kind, limit, offset)
+        .await
+        .map_err(AppError::internal)?;
 
     Ok(Json(targets))
 }


### PR DESCRIPTION
## Summary
- Adds `list_index_targets_filtered()` to the repository layer: a single query that accepts optional `network`, optional `kind`, `limit`, and `offset`
- Replaces the three-branch handler logic with a single call to the unified method
- Both filters can now be applied simultaneously (e.g. `?network=solana-mainnet&kind=wallet&limit=10&offset=20`)
- Pagination (limit/offset) is now always applied regardless of which filters are present
- Existing per-filter methods (`list_index_targets_by_network`, `list_index_targets_by_kind`) are preserved for backward compatibility

## Test plan
- [x] New compile-time test `list_index_targets_filtered_compiles_all_combos` covers all filter combinations
- [x] Existing `test_list_targets_bad_kind_filter` still passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (1 pre-existing flaky test excluded)

Closes #132