### PR TITLE
fix: warn on missing Hyperliquid fee_token instead of silent default

### DIFF
--- a/adapters/src/hyperliquid_parser.rs
+++ b/adapters/src/hyperliquid_parser.rs
@@ -69,7 +69,13 @@ fn parse_fill(tx: &Transaction, data: &serde_json::Value) -> anyhow::Result<Vec<
             }
         };
         if fee != BigDecimal::from(0) {
-            let fee_token = fill.fee_token.as_deref().unwrap_or("USDC");
+            let fee_token = match fill.fee_token.as_deref() {
+                Some(t) => t,
+                None => {
+                    warn!(tx_hash = %tx.tx_hash, "fee_token missing from fill, defaulting to USDC");
+                    "USDC"
+                }
+            };
             entries.push(LedgerEntry {
                 id: deterministic_id(tx.id, entry_index),
                 transaction_id: tx.id,

--- a/adapters/src/ledger_derivation.rs
+++ b/adapters/src/ledger_derivation.rs
@@ -11,6 +11,7 @@ use spectraplex_core::materializer::{
 };
 use spectraplex_core::models::{Chain, EntryType, LedgerEntry};
 use spectraplex_core::v2::ChainFamily;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::deterministic_id;
@@ -198,7 +199,13 @@ pub fn derive_ledger_from_hl_fills(
 
         if let Some(ref fee) = fill.fee {
             if *fee != BigDecimal::from(0) {
-                let fee_token = fill.fee_token.as_deref().unwrap_or("USDC");
+                let fee_token = match fill.fee_token.as_deref() {
+                    Some(t) => t,
+                    None => {
+                        warn!(coin = %fill.coin, fill_time = fill.fill_time, "fee_token missing from HL fill record, defaulting to USDC");
+                        "USDC"
+                    }
+                };
                 entries.push(LedgerEntry {
                     id: deterministic_id(tx_id, *entry_offset),
                     transaction_id: tx_id,
@@ -639,7 +646,13 @@ pub fn derive_wallet_ledger_from_hl_fills(
 
         if let Some(ref fee) = fill.fee {
             if *fee != BigDecimal::from(0) {
-                let fee_token = fill.fee_token.as_deref().unwrap_or("USDC");
+                let fee_token = match fill.fee_token.as_deref() {
+                    Some(t) => t,
+                    None => {
+                        warn!(coin = %fill.coin, fill_time = fill.fill_time, "fee_token missing from HL fill record, defaulting to USDC");
+                        "USDC"
+                    }
+                };
                 records.push(WalletLedgerRecord {
                     id: deterministic_id(
                         fill.raw_transaction_id.unwrap_or(Uuid::nil()),


### PR DESCRIPTION
## Summary

- The HL fill `fee_token` field now logs a warning when absent rather than silently defaulting to USDC. This surfaces potential API changes early while preserving USDC as the correct default for current HL behavior.
- Updated in three locations: V1 parser (`parse_fill`), Silver-to-ledger derivation, and wallet ledger derivation.
- Deposit/withdrawal token transfers remain hardcoded USDC since Hyperliquid L1 only supports USDC for deposits and withdrawals (the API field is literally named `usdc`).

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (300/301; 1 pre-existing flaky test unrelated to this change)
- [ ] Verify warning appears in logs when processing fills without a `feeToken` field

Closes #156