### PR TITLE
fix: auto-run database migrations on API server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,13 @@ cargo build --workspace
 # Start PostgreSQL
 docker-compose up -d
 
-# Initialize the database
-cargo run --bin spectraplex-cli -- --db-url postgresql://localhost/spectraplex init-db
+# Start the API server (auto-runs migrations on first start)
+cargo run --bin spectraplex-api
+# → http://127.0.0.1:3000/health
 
 # Ingest some Solana transactions
 cargo run --bin spectraplex-cli -- --db-url postgresql://localhost/spectraplex ingest \
   --chain solana --wallet <WALLET_ADDRESS> --rpc https://api.mainnet-beta.solana.com --limit 10
-
-# Start the API server
-cargo run --bin spectraplex-api
-# → http://127.0.0.1:3000/health
 ```
 
 Requires Rust (stable) and PostgreSQL 14+. Docker handles Postgres if you don't have one running.

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono", "bigdecimal"] }
+sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls", "macros", "uuid", "chrono", "bigdecimal"] }
 dotenvy = "0.15"
 anyhow = "1.0"
 async-trait = "0.1"

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -320,6 +320,10 @@ async fn main() -> anyhow::Result<()> {
         .connect(&config.database_url)
         .await?;
 
+    info!("Running database migrations...");
+    sqlx::migrate!("../migrations").run(&pool).await?;
+    info!("Database migrations complete");
+
     let allowed_wallets = config.allowed_wallets_set();
     let shared_state = Arc::new(AppState {
         repo: Repository::new(pool),


### PR DESCRIPTION
## Summary

- The API server now runs `sqlx::migrate!` automatically on startup, eliminating the need to manually run `init-db` before first use.
- This fixes the broken quick-start path where `docker-compose up` would fail with schema errors because migrations were never applied.
- The `init-db` CLI command remains available for standalone migration runs outside the API server lifecycle.
- Updated README Quick Start to reflect that the API handles migrations on its own.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (300/301; 1 pre-existing flaky test unrelated to this change)
- [ ] `docker-compose up` from scratch creates schema and starts API successfully
- [ ] API server startup with existing schema is idempotent (no errors)

Closes #155