### PR TITLE
feat: wire durable stream subscriptions into runtime

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1813,10 +1813,75 @@ async fn start_stream(
 
     let network = resolved_network.unwrap_or_else(|| chain_resolved.clone());
 
+    // Resolve or create a V2 IndexTarget so the subscription anchors to a
+    // real row.  Wallet-backed streams (Hyperliquid) get a wallet target;
+    // targetless streams (Solana gRPC) use a "program" target that represents
+    // the global stream endpoint for that network.
+    let target_id = match chain_resolved.as_str() {
+        "hyperliquid" => {
+            let wallet = sub_config
+                .as_ref()
+                .and_then(|c| c.get("wallet").and_then(|w| w.as_str()))
+                .unwrap_or("");
+            let chain_enum = Chain::Hyperliquid;
+            let target = state
+                .repo
+                .ensure_wallet_target_for_network(&network, &chain_enum, wallet, None)
+                .await
+                .map_err(AppError::internal)?;
+            target.id
+        }
+        "solana" => {
+            // For global Solana gRPC streams, create a program-type target
+            // keyed on the network.  The address is a sentinel so the unique
+            // index on (kind, network, address) prevents duplicates.
+            let sentinel = "__global_grpc_stream__";
+            let target = match state
+                .repo
+                .get_index_target_by_address(TargetKind::Program, &network, sentinel)
+                .await
+                .map_err(AppError::internal)?
+            {
+                Some(t) => t,
+                None => {
+                    let now = chrono::Utc::now();
+                    let t = IndexTarget {
+                        id: Uuid::new_v4(),
+                        kind: TargetKind::Program,
+                        network: network.clone(),
+                        chain_family: ChainFamily::Solana,
+                        address: Some(sentinel.to_string()),
+                        filter_spec: None,
+                        mode: TargetMode::Both,
+                        label: Some("Global gRPC stream".to_string()),
+                        owner_id: None,
+                        created_at: now,
+                        updated_at: now,
+                    };
+                    state
+                        .repo
+                        .create_index_target(&t)
+                        .await
+                        .map_err(AppError::internal)?
+                }
+            };
+            target.id
+        }
+        _ => unreachable!("unsupported chains rejected above"),
+    };
+
     // Upsert the durable subscription — the orchestrator will pick it up.
+    // Anchored to target_id so the unique index (target_id, network, source)
+    // prevents duplicate subscriptions.
     let sub = state
         .repo
-        .upsert_stream_subscription(None, &network, source_str, "active", sub_config.as_ref())
+        .upsert_stream_subscription(
+            Some(target_id),
+            &network,
+            source_str,
+            "active",
+            sub_config.as_ref(),
+        )
         .await
         .map_err(AppError::internal)?;
 

--- a/api/src/stream_worker.rs
+++ b/api/src/stream_worker.rs
@@ -303,8 +303,25 @@ async fn run_solana_grpc_stream(
                         }
                     }
                     None => {
-                        info!(subscription_id = %sub_id, "gRPC stream channel closed");
-                        break;
+                        // Channel closed = gRPC task ended.  This is NOT a clean
+                        // cancellation — the adapter died or the remote closed the
+                        // connection.  Return an error so the worker marks the
+                        // subscription as failed instead of silently recycling it.
+                        warn!(subscription_id = %sub_id, "gRPC stream channel closed unexpectedly");
+
+                        // Flush remaining batch before failing
+                        if !batch.is_empty() {
+                            if let Err(e) = repo.save_transactions(&batch).await {
+                                error!(subscription_id = %sub_id, error = %e, "Failed to flush final batch");
+                            }
+                            let cursor = serde_json::json!({
+                                "tx_count": tx_count,
+                                "last_slot": last_slot,
+                            });
+                            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                        }
+                        grpc_handle.abort();
+                        return Err(anyhow::anyhow!("gRPC stream channel closed unexpectedly"));
                     }
                 }
             }
@@ -459,8 +476,21 @@ async fn run_hyperliquid_ws_stream(
                         }
                     }
                     None => {
-                        info!(subscription_id = %sub_id, "Hyperliquid WS channel closed");
-                        break;
+                        // Channel closed = WS task ended (retries exhausted or
+                        // fatal error).  NOT a clean cancellation — fail the
+                        // subscription so it doesn't silently recycle.
+                        warn!(subscription_id = %sub_id, "Hyperliquid WS channel closed (retries exhausted)");
+
+                        // Flush remaining batch before failing
+                        if !batch.is_empty() {
+                            if let Err(e) = repo.save_transactions(&batch).await {
+                                error!(subscription_id = %sub_id, error = %e, "Failed to flush final HL batch");
+                            }
+                            let cursor = serde_json::json!({ "tx_count": tx_count });
+                            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                        }
+                        ws_handle.abort();
+                        return Err(anyhow::anyhow!("Hyperliquid WS stream closed (retries exhausted)"));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Replaces in-memory stream state (`StreamEntry`, `RwLock<HashMap>`) with Postgres-backed `stream_subscriptions`. The stream orchestrator now spawns actual Solana gRPC and Hyperliquid WS adapters instead of heartbeat-only placeholders.

Builds on #198 (stream orchestrator skeleton + hardened repo methods).

## Changes

### stream_worker.rs
- `spawn_stream_task` dispatches to `run_solana_grpc_stream` or `run_hyperliquid_ws_stream` based on `StreamSource`
- Batches transactions, flushes every 5s or 100 items via `repo.save_transactions` (V1 compat)
- Updates `cursor_state` periodically with `tx_count` and `last_slot`
- Heartbeats lease alongside stream loop
- Calls `repo.fail_stream_subscription` on fatal adapter errors
- `poll_and_claim` acquires stream semaphore before claiming

### main.rs — Handler rewrites
- **start_stream**: Keeps all validation (chain/network, wallet, provider capability). Now calls `repo.upsert_stream_subscription` instead of spawning tasks. Returns StreamInfo from subscription row.
- **stop_stream**: Calls `repo.set_stream_desired_status(id, "stopped")`. Returns `{"id", "status": "stopping"}`. Orchestrator reconcile loop cancels the task.
- **list_streams**: Calls `repo.list_stream_subscriptions`, maps to StreamInfo (derives chain from network, extracts wallet/tx_count/last_slot from config/cursor_state JSON).

### main.rs — Structural
- Removed `StreamEntry` struct and `streams: RwLock<HashMap<Uuid, StreamEntry>>` from `AppState`
- Added `mod stream_worker`
- Spawned `stream_worker::spawn_stream_orchestrator` in `main()`
- Removed unused `SolanaGrpcAdapter` and `HyperliquidWsClient` imports from main.rs
- Stream semaphore now checked by orchestrator, not handler (no more 503 from handler)

### Tests
- All stream tests updated for DB-backed behavior (validation-only tests unchanged, DB-dependent tests expect 500 without real DB)

## Design decisions
- Duplicate detection via DB upsert `ON CONFLICT` instead of in-memory check
- `save_transactions` (V1 compat) kept as stream data sink per design doc
- Cursor state stored as JSON: `{"tx_count": N, "last_slot": N}`
- `stream_semaphore` kept for per-process concurrency limiting

## CI
- 1163 tests pass, 0 failures
- clippy clean (`-D warnings`)
- formatted