### PR TITLE
feat: connect stream flushes to Bronze lineage model

### DIFF
--- a/api/src/stream_worker.rs
+++ b/api/src/stream_worker.rs
@@ -317,8 +317,9 @@ async fn run_solana_grpc_stream(
                                 "tx_count": tx_count,
                                 "last_slot": last_slot,
                             });
-                            flush_stream_batch(repo, &batch, &sub.network, "grpc", sub.target_id, sub_id, Some(&cursor)).await;
-                            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                            if flush_stream_batch(repo, &batch, &sub.network, "grpc", sub.target_id, sub_id, Some(&cursor)).await {
+                                let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                            }
                         }
                         grpc_handle.abort();
                         return Err(anyhow::anyhow!("gRPC stream channel closed unexpectedly"));
@@ -334,7 +335,7 @@ async fn run_solana_grpc_stream(
             "tx_count": tx_count,
             "last_slot": last_slot,
         });
-        flush_stream_batch(
+        if flush_stream_batch(
             repo,
             &batch,
             &sub.network,
@@ -343,8 +344,10 @@ async fn run_solana_grpc_stream(
             sub_id,
             Some(&cursor),
         )
-        .await;
-        let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+        .await
+        {
+            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+        }
     }
 
     grpc_handle.abort();
@@ -489,8 +492,9 @@ async fn run_hyperliquid_ws_stream(
                         // Flush remaining batch before failing
                         if !batch.is_empty() {
                             let cursor = serde_json::json!({ "tx_count": tx_count });
-                            flush_stream_batch(repo, &batch, &sub.network, "ws", sub.target_id, sub_id, Some(&cursor)).await;
-                            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                            if flush_stream_batch(repo, &batch, &sub.network, "ws", sub.target_id, sub_id, Some(&cursor)).await {
+                                let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+                            }
                         }
                         ws_handle.abort();
                         return Err(anyhow::anyhow!("Hyperliquid WS stream closed (retries exhausted)"));
@@ -503,7 +507,7 @@ async fn run_hyperliquid_ws_stream(
     // Flush remaining batch
     if !batch.is_empty() {
         let cursor = serde_json::json!({ "tx_count": tx_count });
-        flush_stream_batch(
+        if flush_stream_batch(
             repo,
             &batch,
             &sub.network,
@@ -512,8 +516,10 @@ async fn run_hyperliquid_ws_stream(
             sub_id,
             Some(&cursor),
         )
-        .await;
-        let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+        .await
+        {
+            let _ = repo.update_stream_cursor(sub_id, &cursor).await;
+        }
     }
 
     ws_handle.abort();


### PR DESCRIPTION
Stream flushes now mirror the backfill ingestion path's Bronze lineage:

1. **IngestionRun per flush**: Each flush creates an `IngestionRun` (mode=`stream`) with the subscription's target_id, network, and source
2. **ingestion_run_id stamping**: Every `RawTransaction` carries its run ID for provenance joins
3. **Run status tracking**: Ingestion run status updated on completion/failure
4. **V2 checkpoint upsert**: Cursor state written to `checkpoints_v2` so backfill can resume from where the stream left off
5. **Auto-materialization**: Successful flushes auto-trigger `materialization_runs` (normalize) with the same scope pattern as backfill

This closes the lineage gap between stream and backfill paths (Workstream D stream-side lineage from the V2 implementation plan).