### PR TITLE
fix: stream export jobs to disk to bound memory (#208)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,12 +4571,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -7032,6 +7034,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tokio-util",
  "tracing",
  "uuid",
  "yellowstone-grpc-client",
@@ -8574,6 +8577,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -27,6 +27,7 @@ tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 alloy = { version = "1", features = ["provider-http", "rpc-types", "reqwest"] }
 governor = "0.7"
+tokio-util = "0.7"
 
 [dev-dependencies]
 log = "0.4"

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1158,6 +1158,140 @@ pub fn build_dataset_completeness_upsert(
 // Dataset filter query builder (P4-W1)
 // ---------------------------------------------------------------------------
 
+// -----------------------------------------------------------------------
+// Snapshotted streaming export types (fixes PR #238 [P1] pagination)
+// -----------------------------------------------------------------------
+
+/// One page of records produced by [`Repository::stream_export_snapshot`].
+///
+/// Each variant carries the owned `Vec` for one page, keyed by dataset.
+/// The consumer (the API-side export writer) matches the variant, hands
+/// the slice to the matching CSV/JSONL row-writer, and writes the result
+/// directly to disk.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum ExportRecordBatch {
+    TokenTransfers(Vec<TokenTransfer>),
+    NativeBalanceDeltas(Vec<NativeBalanceDelta>),
+    DecodedEvents(Vec<DecodedEvent>),
+    HlFills(Vec<HlFillRecord>),
+    HlFunding(Vec<HlFundingPayment>),
+    Positions(Vec<HlPositionChange>),
+    WalletLedger(Vec<WalletLedgerRecord>),
+    BalanceHistory(Vec<BalanceSnapshot>),
+    HlPnlSummary(Vec<HlPnlSummary>),
+    HlTradeHistory(Vec<HlTradeHistory>),
+    ProtocolEvents(Vec<ProtocolEvent>),
+    PoolSnapshots(Vec<PoolSnapshot>),
+}
+
+impl ExportRecordBatch {
+    /// Number of records in this page. Used by the consumer to decide
+    /// whether a short page (`< page_size`) means the snapshot is
+    /// exhausted.
+    pub fn len(&self) -> usize {
+        match self {
+            ExportRecordBatch::TokenTransfers(v) => v.len(),
+            ExportRecordBatch::NativeBalanceDeltas(v) => v.len(),
+            ExportRecordBatch::DecodedEvents(v) => v.len(),
+            ExportRecordBatch::HlFills(v) => v.len(),
+            ExportRecordBatch::HlFunding(v) => v.len(),
+            ExportRecordBatch::Positions(v) => v.len(),
+            ExportRecordBatch::WalletLedger(v) => v.len(),
+            ExportRecordBatch::BalanceHistory(v) => v.len(),
+            ExportRecordBatch::HlPnlSummary(v) => v.len(),
+            ExportRecordBatch::HlTradeHistory(v) => v.len(),
+            ExportRecordBatch::ProtocolEvents(v) => v.len(),
+            ExportRecordBatch::PoolSnapshots(v) => v.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Run a paged `SELECT ... LIMIT/OFFSET` inside the given transaction,
+/// mapping each page via `row_fn` and forwarding the resulting batch via
+/// `batch_fn` to `tx_out`. Honors the `cancel` token both before every
+/// query and before every send so lease-loss (heartbeat reporting the
+/// export job was reclaimed) aborts promptly.
+#[allow(clippy::too_many_arguments)]
+async fn stream_paged_in_tx<T, R, B>(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    cols: &str,
+    table: &str,
+    order_col: &str,
+    target_id: Option<Uuid>,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    page_size: i64,
+    hard_cap: i64,
+    cancel: &tokio_util::sync::CancellationToken,
+    tx_out: &tokio::sync::mpsc::Sender<ExportRecordBatch>,
+    row_fn: R,
+    batch_fn: B,
+) -> anyhow::Result<usize>
+where
+    R: Fn(&sqlx::postgres::PgRow) -> anyhow::Result<T>,
+    B: Fn(Vec<T>) -> ExportRecordBatch,
+{
+    let mut offset: i64 = 0;
+    let mut total: usize = 0;
+    loop {
+        if cancel.is_cancelled() {
+            anyhow::bail!("export snapshot cancelled (lease lost or worker shutdown)");
+        }
+
+        let (sql, args) = build_dataset_filter_query(
+            cols, table, order_col, target_id, network, time_start, time_end, page_size, offset,
+        )?;
+
+        let rows = sqlx::query_with(&sql, args).fetch_all(&mut **tx).await?;
+        let n = rows.len();
+        if n == 0 {
+            break;
+        }
+
+        let records: Vec<T> = rows
+            .iter()
+            .map(&row_fn)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        // A second cancel check immediately before the blocking send so
+        // a lost lease can't push one more page to the consumer.
+        if cancel.is_cancelled() {
+            anyhow::bail!("export snapshot cancelled (lease lost or worker shutdown)");
+        }
+
+        if tx_out.send(batch_fn(records)).await.is_err() {
+            // Consumer dropped the receiver — treat as cancellation so
+            // we short-circuit the remaining pages and roll back the
+            // snapshot transaction.
+            anyhow::bail!("export consumer dropped the record-batch channel");
+        }
+
+        total += n;
+        offset += n as i64;
+
+        // Short page means the snapshot is exhausted for this dataset.
+        if (n as i64) < page_size {
+            break;
+        }
+        if offset >= hard_cap {
+            tracing::warn!(
+                table,
+                offset,
+                hard_cap,
+                "Export hit EXPORT_HARD_CAP — truncating stream"
+            );
+            break;
+        }
+    }
+    Ok(total)
+}
+
 /// Build a filtered SELECT query for a Silver dataset table.
 ///
 /// Dynamically adds JOIN and WHERE clauses based on which filters are
@@ -1224,8 +1358,16 @@ pub fn build_dataset_filter_query(
     let lim_n = n;
     n += 1;
     let off_n = n;
+    // `order_col` alone is not a total order — on ties the physical row order
+    // is not stable, so OFFSET pagination can reshuffle rows across pages.
+    // Append `dt.id DESC` as a deterministic tiebreaker so pages are
+    // disjoint and cover the full result set exactly once, both for
+    // one-shot queries and for the snapshotted paged export in
+    // [`Repository::stream_export_snapshot`]. This fixes the PR #238
+    // [P1] correctness concern about LIMIT/OFFSET exports losing or
+    // duplicating rows across page boundaries (#208).
     sql.push_str(&format!(
-        " ORDER BY {order_col} DESC LIMIT ${lim_n} OFFSET ${off_n}"
+        " ORDER BY {order_col} DESC, dt.id DESC LIMIT ${lim_n} OFFSET ${off_n}"
     ));
     use sqlx::Arguments;
     args.add(limit).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -3172,6 +3314,336 @@ impl Repository {
             0,
         )
         .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Snapshotted streaming export (fixes PR #238 [P1] correctness)
+    // -----------------------------------------------------------------------
+
+    /// Stream a snapshotted, paged export for one dataset into `tx_out`.
+    ///
+    /// Runs every page query inside a single `REPEATABLE READ READ ONLY`
+    /// transaction so pagination is stable even if ingestion writes rows
+    /// concurrently — the reader sees a single snapshot for the duration
+    /// of the export. Combined with the `(order_col, dt.id)` total ORDER
+    /// BY (see [`build_dataset_filter_query`]), this guarantees every
+    /// page is disjoint and together they cover the full result set
+    /// exactly once. This fixes the PR #238 [P1] comment that the
+    /// previous per-page queries could skip or duplicate rows on tied
+    /// `created_at`/`timestamp` values or under concurrent insert.
+    ///
+    /// Cancellation: checks `cancel` before every query and every send.
+    /// When the heartbeat task detects that the export job's lease was
+    /// reclaimed by another worker (the PR #238 [P1] lease-loss issue),
+    /// it cancels this token; the function aborts, the transaction is
+    /// rolled back on drop, and the caller can clean up its attempt-
+    /// scoped temp artifact without racing the new owner.
+    ///
+    /// Backpressure: the per-page channel is expected to be small
+    /// (`capacity=2` in the worker) so that DB streaming throttles to
+    /// the disk-write rate rather than buffering whole pages in RAM.
+    ///
+    /// Returns the total number of records sent.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stream_export_snapshot(
+        &self,
+        dataset: &str,
+        target_id: Option<Uuid>,
+        network: Option<&str>,
+        time_start: Option<i64>,
+        time_end: Option<i64>,
+        page_size: i64,
+        hard_cap: i64,
+        cancel: tokio_util::sync::CancellationToken,
+        tx_out: tokio::sync::mpsc::Sender<ExportRecordBatch>,
+    ) -> anyhow::Result<usize> {
+        let mut tx = self.pool().begin().await?;
+        // Snapshot isolation: every page sees the same committed state
+        // that existed when this SET statement returned. READ ONLY lets
+        // Postgres skip some write-path bookkeeping.
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+            .execute(&mut *tx)
+            .await?;
+
+        let total = match dataset {
+            "token_transfers" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.token_address, \
+                            dt.token_symbol, dt.from_address, dt.to_address, dt.amount, \
+                            dt.decimals, dt.transfer_index, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::TokenTransfers.physical_table(),
+                    "dt.created_at",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_token_transfer,
+                    ExportRecordBatch::TokenTransfers,
+                )
+                .await?
+            }
+            "native_balance_deltas" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.account_address, \
+                            dt.native_token, dt.pre_balance, dt.post_balance, dt.delta, \
+                            dt.is_fee_payer, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::NativeBalanceDeltas.physical_table(),
+                    "dt.created_at",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_native_balance_delta,
+                    ExportRecordBatch::NativeBalanceDeltas,
+                )
+                .await?
+            }
+            "decoded_events" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.program_or_contract, \
+                            dt.event_signature, dt.event_name, dt.log_index, dt.decoded_fields, \
+                            dt.raw_fields, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::DecodedEvents.physical_table(),
+                    "dt.created_at",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_decoded_event,
+                    ExportRecordBatch::DecodedEvents,
+                )
+                .await?
+            }
+            "hl_fills" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.coin, dt.side, \
+                            dt.price, dt.size, dt.direction, dt.closed_pnl, dt.fee, \
+                            dt.fee_token, dt.fill_time, dt.order_id, dt.trade_id, \
+                            dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::HlFills.physical_table(),
+                    "dt.fill_time",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_hl_fill_record,
+                    ExportRecordBatch::HlFills,
+                )
+                .await?
+            }
+            "hl_funding" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.coin, dt.amount, \
+                            dt.funding_rate, dt.payment_time, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::HlFunding.physical_table(),
+                    "dt.payment_time",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_hl_funding_payment,
+                    ExportRecordBatch::HlFunding,
+                )
+                .await?
+            }
+            "positions" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.network, dt.coin, dt.side, \
+                            dt.size_delta, dt.price, dt.direction, dt.source_event, \
+                            dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::Positions.physical_table(),
+                    "dt.created_at",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_hl_position_change,
+                    ExportRecordBatch::Positions,
+                )
+                .await?
+            }
+            "wallet_ledger" => {
+                let cols = "dt.id, dt.raw_transaction_id, dt.wallet_address, dt.network, \
+                            dt.tx_hash, dt.timestamp, dt.entry_type, dt.asset_symbol, \
+                            dt.amount, dt.counterparty_address, dt.fee_amount, dt.fee_asset, \
+                            dt.cost_basis, dt.proceeds, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::WalletLedger.physical_table(),
+                    "dt.timestamp",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_wallet_ledger_record,
+                    ExportRecordBatch::WalletLedger,
+                )
+                .await?
+            }
+            "balance_history" => {
+                let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, \
+                            dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
+                            dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::BalanceHistory.physical_table(),
+                    "dt.timestamp",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_balance_snapshot,
+                    ExportRecordBatch::BalanceHistory,
+                )
+                .await?
+            }
+            "hl_pnl_summary" => {
+                let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.period_start, \
+                            dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
+                            dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
+                            dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::HlPnlSummary.physical_table(),
+                    "dt.period_end",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_hl_pnl_summary,
+                    ExportRecordBatch::HlPnlSummary,
+                )
+                .await?
+            }
+            "hl_trade_history" => {
+                let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.side, \
+                            dt.entry_price, dt.exit_price, dt.size, dt.opened_at, dt.closed_at, \
+                            dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
+                            dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::HlTradeHistory.physical_table(),
+                    "dt.closed_at",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_hl_trade_history,
+                    ExportRecordBatch::HlTradeHistory,
+                )
+                .await?
+            }
+            "protocol_events" => {
+                let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, \
+                            dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
+                            dt.timestamp, dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::ProtocolEvents.physical_table(),
+                    "dt.timestamp",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_protocol_event,
+                    ExportRecordBatch::ProtocolEvents,
+                )
+                .await?
+            }
+            "pool_snapshots" => {
+                let cols = "dt.id, dt.network, dt.pool_address, dt.protocol_address, \
+                            dt.protocol_name, dt.token0_address, dt.token0_symbol, \
+                            dt.token1_address, dt.token1_symbol, dt.reserve0, dt.reserve1, \
+                            dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
+                            dt.dataset_version_id, dt.created_at";
+                stream_paged_in_tx(
+                    &mut tx,
+                    cols,
+                    DatasetName::PoolSnapshots.physical_table(),
+                    "dt.snapshot_timestamp",
+                    target_id,
+                    network,
+                    time_start,
+                    time_end,
+                    page_size,
+                    hard_cap,
+                    &cancel,
+                    &tx_out,
+                    row_to_pool_snapshot,
+                    ExportRecordBatch::PoolSnapshots,
+                )
+                .await?
+            }
+            other => {
+                // Rolling back the snapshot transaction on unknown dataset
+                // is implicit via drop.
+                return Err(anyhow::anyhow!("Unknown export dataset: {other}"));
+            }
+        };
+
+        tx.commit().await?;
+        Ok(total)
     }
 
     // -----------------------------------------------------------------------

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1259,17 +1259,28 @@ where
             .map(&row_fn)
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        // A second cancel check immediately before the blocking send so
-        // a lost lease can't push one more page to the consumer.
-        if cancel.is_cancelled() {
-            anyhow::bail!("export snapshot cancelled (lease lost or worker shutdown)");
-        }
-
-        if tx_out.send(batch_fn(records)).await.is_err() {
-            // Consumer dropped the receiver — treat as cancellation so
-            // we short-circuit the remaining pages and roll back the
-            // snapshot transaction.
-            anyhow::bail!("export consumer dropped the record-batch channel");
+        // The send itself must be cancellation-aware: the channel has
+        // bounded capacity (PAGE_CHANNEL_CAPACITY), so if the disk
+        // writer errors or the lease is lost while the channel is
+        // full, a plain `.await` on `send` would block forever (the
+        // consumer is no longer polling `recv`, and only a receiver
+        // drop wakes a blocked send). Racing it against `cancelled()`
+        // lets the producer exit promptly and roll back the snapshot
+        // transaction.
+        let batch = batch_fn(records);
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                anyhow::bail!("export snapshot cancelled (lease lost or worker shutdown)");
+            }
+            res = tx_out.send(batch) => {
+                if res.is_err() {
+                    // Consumer dropped the receiver — treat as cancellation
+                    // so we short-circuit the remaining pages and roll back
+                    // the snapshot transaction.
+                    anyhow::bail!("export consumer dropped the record-batch channel");
+                }
+            }
         }
 
         total += n;

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,8 +21,8 @@ bigdecimal = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.19", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 subtle = "2"
-reqwest = { version = "0.12", features = ["json"] }
-tokio-util = "0.7"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+tokio-util = { version = "0.7", features = ["io"] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/api/src/export_csv.rs
+++ b/api/src/export_csv.rs
@@ -1,0 +1,571 @@
+//! Streaming-friendly CSV row writers for export datasets.
+//!
+//! Each dataset has two helpers:
+//!
+//! - `*_csv_header()` — returns the header line (including the trailing
+//!   newline). Emit once per file for CSV exports.
+//! - `write_*_csv_rows(records, w)` — appends row lines to any
+//!   [`std::io::Write`]. Used by both the streaming export writer (which
+//!   writes directly into a file's `BufWriter`) and by the legacy
+//!   `*_to_csv` helpers in `main.rs` (which collect into a `Vec<u8>` for
+//!   the in-memory handler paths such as tax export).
+//!
+//! Keeping the row emission logic separate from the `Vec<u8>`-collecting
+//! convenience wrappers is what lets the export worker stop buffering the
+//! entire dataset in memory (#208).
+//!
+//! Output format is kept byte-identical to the previous `*_to_csv`
+//! implementations, so the existing `*_to_csv_format` tests still pass.
+
+use bigdecimal::BigDecimal;
+use spectraplex_core::materializer::{
+    BalanceSnapshot, DecodedEvent, HlFillRecord, HlFundingPayment, HlPnlSummary, HlPositionChange,
+    HlTradeHistory, NativeBalanceDelta, PoolSnapshot, ProtocolEvent, TokenTransfer,
+    WalletLedgerRecord,
+};
+use std::io::Write;
+
+/// Quote a CSV field if it contains any of `,`, `"`, or newline.
+pub(crate) fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// token_transfers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn token_transfers_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,token_address,token_symbol,from_address,to_address,amount,decimals,transfer_index,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_token_transfers_csv_rows<W: Write>(
+    records: &[TokenTransfer],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.token_address),
+            r.token_symbol.as_deref().unwrap_or(""),
+            csv_escape(&r.from_address),
+            csv_escape(&r.to_address),
+            r.amount,
+            r.decimals,
+            r.transfer_index,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// native_balance_deltas
+// ---------------------------------------------------------------------------
+
+pub(crate) fn native_balance_deltas_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,account_address,native_token,pre_balance,post_balance,delta,is_fee_payer,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_native_balance_deltas_csv_rows<W: Write>(
+    records: &[NativeBalanceDelta],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.account_address),
+            csv_escape(&r.native_token),
+            r.pre_balance,
+            r.post_balance,
+            r.delta,
+            r.is_fee_payer,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// decoded_events
+// ---------------------------------------------------------------------------
+
+pub(crate) fn decoded_events_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,program_or_contract,event_signature,event_name,log_index,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_decoded_events_csv_rows<W: Write>(
+    records: &[DecodedEvent],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.program_or_contract),
+            csv_escape(r.event_signature.as_deref().unwrap_or("")),
+            csv_escape(r.event_name.as_deref().unwrap_or("")),
+            r.log_index,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hl_fills
+// ---------------------------------------------------------------------------
+
+pub(crate) fn hl_fills_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,coin,side,price,size,direction,closed_pnl,fee,fee_token,fill_time,order_id,trade_id,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_hl_fills_csv_rows<W: Write>(
+    records: &[HlFillRecord],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.coin),
+            csv_escape(&r.side),
+            r.price,
+            r.size,
+            r.direction.as_deref().unwrap_or(""),
+            r.closed_pnl
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.fee.as_ref().map(|v| v.to_string()).unwrap_or_default(),
+            r.fee_token.as_deref().unwrap_or(""),
+            r.fill_time,
+            r.order_id.map(|v| v.to_string()).unwrap_or_default(),
+            r.trade_id.map(|v| v.to_string()).unwrap_or_default(),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hl_funding
+// ---------------------------------------------------------------------------
+
+pub(crate) fn hl_funding_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,coin,amount,funding_rate,payment_time,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_hl_funding_csv_rows<W: Write>(
+    records: &[HlFundingPayment],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.coin),
+            r.amount,
+            r.funding_rate
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.payment_time,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hl_positions
+// ---------------------------------------------------------------------------
+
+pub(crate) fn hl_positions_csv_header() -> &'static str {
+    "id,raw_transaction_id,network,coin,side,size_delta,price,direction,source_event,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_hl_positions_csv_rows<W: Write>(
+    records: &[HlPositionChange],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.network),
+            csv_escape(&r.coin),
+            csv_escape(&r.side),
+            r.size_delta,
+            r.price,
+            r.direction.as_deref().unwrap_or(""),
+            csv_escape(&r.source_event),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// wallet_ledger
+// ---------------------------------------------------------------------------
+
+pub(crate) fn wallet_ledger_csv_header() -> &'static str {
+    "id,raw_transaction_id,wallet_address,network,tx_hash,timestamp,entry_type,asset_symbol,amount,counterparty_address,fee_amount,fee_asset,cost_basis,proceeds,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_wallet_ledger_csv_rows<W: Write>(
+    records: &[WalletLedgerRecord],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            r.raw_transaction_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.network),
+            csv_escape(&r.tx_hash),
+            r.timestamp,
+            csv_escape(&r.entry_type),
+            csv_escape(&r.asset_symbol),
+            r.amount,
+            r.counterparty_address.as_deref().unwrap_or(""),
+            r.fee_amount
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.fee_asset.as_deref().unwrap_or(""),
+            r.cost_basis
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.proceeds
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// balance_history
+// ---------------------------------------------------------------------------
+
+pub(crate) fn balance_history_csv_header() -> &'static str {
+    "id,wallet_address,asset_symbol,network,timestamp,balance,tx_hash,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_balance_history_csv_rows<W: Write>(
+    records: &[BalanceSnapshot],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{}",
+            r.id,
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.asset_symbol),
+            csv_escape(&r.network),
+            r.timestamp,
+            r.balance,
+            csv_escape(&r.tx_hash),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hl_pnl_summary
+// ---------------------------------------------------------------------------
+
+pub(crate) fn hl_pnl_summary_csv_header() -> &'static str {
+    "id,wallet_address,coin,network,period_start,period_end,total_closed_pnl,total_funding,total_fees,net_pnl,trade_count,fill_count,avg_trade_size,win_count,loss_count,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_hl_pnl_summary_csv_rows<W: Write>(
+    records: &[HlPnlSummary],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.coin),
+            csv_escape(&r.network),
+            r.period_start,
+            r.period_end,
+            r.total_closed_pnl,
+            r.total_funding,
+            r.total_fees,
+            r.net_pnl,
+            r.trade_count,
+            r.fill_count,
+            r.avg_trade_size,
+            r.win_count,
+            r.loss_count,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hl_trade_history
+// ---------------------------------------------------------------------------
+
+pub(crate) fn hl_trade_history_csv_header() -> &'static str {
+    "id,wallet_address,coin,network,side,entry_price,exit_price,size,opened_at,closed_at,realized_pnl,fees,num_fills,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_hl_trade_history_csv_rows<W: Write>(
+    records: &[HlTradeHistory],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            csv_escape(&r.wallet_address),
+            csv_escape(&r.coin),
+            csv_escape(&r.network),
+            csv_escape(&r.side),
+            r.entry_price,
+            r.exit_price,
+            r.size,
+            r.opened_at,
+            r.closed_at,
+            r.realized_pnl,
+            r.fees,
+            r.num_fills,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// protocol_events
+// ---------------------------------------------------------------------------
+
+pub(crate) fn protocol_events_csv_header() -> &'static str {
+    "id,network,protocol_address,protocol_name,event_type,event_details,pool_address,raw_event_id,timestamp,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_protocol_events_csv_rows<W: Write>(
+    records: &[ProtocolEvent],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            csv_escape(&r.network),
+            csv_escape(&r.protocol_address),
+            r.protocol_name.as_deref().unwrap_or(""),
+            csv_escape(&r.event_type),
+            csv_escape(&r.event_details.to_string()),
+            r.pool_address.as_deref().unwrap_or(""),
+            r.raw_event_id.map(|u| u.to_string()).unwrap_or_default(),
+            r.timestamp,
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// pool_snapshots
+// ---------------------------------------------------------------------------
+
+pub(crate) fn pool_snapshots_csv_header() -> &'static str {
+    "id,network,pool_address,protocol_address,protocol_name,token0_address,token0_symbol,token1_address,token1_symbol,reserve0,reserve1,tvl_usd,snapshot_timestamp,block_number,dataset_version_id,created_at\n"
+}
+
+pub(crate) fn write_pool_snapshots_csv_rows<W: Write>(
+    records: &[PoolSnapshot],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            r.id,
+            csv_escape(&r.network),
+            csv_escape(&r.pool_address),
+            csv_escape(&r.protocol_address),
+            r.protocol_name.as_deref().unwrap_or(""),
+            csv_escape(&r.token0_address),
+            r.token0_symbol.as_deref().unwrap_or(""),
+            csv_escape(&r.token1_address),
+            r.token1_symbol.as_deref().unwrap_or(""),
+            r.reserve0,
+            r.reserve1,
+            r.tvl_usd
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            r.snapshot_timestamp,
+            r.block_number.map(|v| v.to_string()).unwrap_or_default(),
+            r.dataset_version_id
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            r.created_at.to_rfc3339(),
+        )?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// wallet_ledger (tax CSV)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn wallet_ledger_tax_csv_header() -> &'static str {
+    "Date,Type,Sent_Asset,Sent_Amount,Received_Asset,Received_Amount,Fee_Asset,Fee_Amount,Cost_Basis,Proceeds,Gain_Loss,Tx_Hash,Network\n"
+}
+
+pub(crate) fn write_wallet_ledger_tax_csv_rows<W: Write>(
+    records: &[WalletLedgerRecord],
+    w: &mut W,
+) -> std::io::Result<()> {
+    for r in records {
+        let date = chrono::DateTime::from_timestamp(r.timestamp, 0)
+            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| r.timestamp.to_string());
+
+        let (sent_asset, sent_amount, recv_asset, recv_amount) = if r.amount < BigDecimal::from(0) {
+            (
+                r.asset_symbol.as_str(),
+                r.amount.abs().to_string(),
+                "",
+                String::new(),
+            )
+        } else {
+            (
+                "",
+                String::new(),
+                r.asset_symbol.as_str(),
+                r.amount.to_string(),
+            )
+        };
+
+        let fee_asset = r.fee_asset.as_deref().unwrap_or("");
+        let fee_amount = r
+            .fee_amount
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let cost_basis = r
+            .cost_basis
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let proceeds = r
+            .proceeds
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+
+        let gain_loss = match (&r.proceeds, &r.cost_basis) {
+            (Some(p), Some(c)) => (p - c).to_string(),
+            _ => String::new(),
+        };
+
+        writeln!(
+            w,
+            "{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            csv_escape(&date),
+            csv_escape(&r.entry_type),
+            csv_escape(sent_asset),
+            sent_amount,
+            csv_escape(recv_asset),
+            recv_amount,
+            csv_escape(fee_asset),
+            fee_amount,
+            cost_basis,
+            proceeds,
+            gain_loss,
+            csv_escape(&r.tx_hash),
+            csv_escape(&r.network),
+        )?;
+    }
+    Ok(())
+}

--- a/api/src/export_stream.rs
+++ b/api/src/export_stream.rs
@@ -1,18 +1,32 @@
 //! Streaming export writer (fixes #208 export OOM).
 //!
 //! Replaces the previous "load the entire dataset into a `Vec<u8>` buffer,
-//! then write it to disk" pattern with cursor-paginated streaming: records
-//! are fetched from Postgres in bounded pages, each page is serialized into
-//! a small per-page buffer, and each per-page buffer is streamed to disk
-//! before the next page is fetched.
+//! then write it to disk" pattern with cursor-paginated streaming inside
+//! a `REPEATABLE READ READ ONLY` Postgres transaction. Records are
+//! fetched in bounded pages, each page is serialized into a small
+//! per-page buffer, and each per-page buffer is streamed to disk before
+//! the next page is fetched.
 //!
-//! Peak per-job memory is bounded by `(PAGE_SIZE * per-record bytes)`
-//! regardless of total dataset size, so a single large export can no longer
-//! OOM-kill the worker process and take down co-located workers.
+//! Snapshot-stable: pagination runs inside a single snapshot
+//! transaction, and the dataset `ORDER BY` carries a `dt.id DESC`
+//! tiebreaker so concurrent ingestion cannot cause page boundaries to
+//! skip or duplicate rows (addresses PR #238 [P1] pagination concern).
 //!
-//! File opens use `O_NOFOLLOW` in the same way as [`crate::write_no_follow`]
-//! (defense-in-depth for #220 TOCTOU symlink attacks) but the file handle is
-//! kept open across the paged write loop rather than opened/closed per page.
+//! Cancellable: the caller supplies a [`CancellationToken`] that the
+//! worker drives from the heartbeat task — when the export job's lease
+//! is reclaimed by another worker, the token is cancelled, and this
+//! function aborts cleanly without emitting more bytes. The caller is
+//! responsible for cleaning up any attempt-scoped temp artifact before
+//! publishing to the final download path.
+//!
+//! Peak per-job memory is bounded by `PAGE_SIZE * per-record bytes`
+//! regardless of total dataset size, so a single large export can no
+//! longer OOM-kill the worker process and take down co-located workers.
+//!
+//! File opens use `O_NOFOLLOW` in the same way as
+//! [`crate::write_no_follow`] (defense-in-depth for #220 TOCTOU symlink
+//! attacks) but the file handle is kept open across the paged write
+//! loop rather than opened/closed per page.
 
 use crate::export_csv::{
     balance_history_csv_header, decoded_events_csv_header, hl_fills_csv_header,
@@ -28,9 +42,11 @@ use crate::export_csv::{
 use crate::ExportMetadata;
 use serde::Serialize;
 use spectraplex_adapters::repo::Repository;
+use spectraplex_adapters::v2_repo::ExportRecordBatch;
 use spectraplex_core::materializer::ExportFormat;
 use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 use uuid::Uuid;
 
@@ -42,13 +58,7 @@ use uuid::Uuid;
 /// a concurrent fleet of export workers cannot collectively OOM the host.
 pub(crate) const PAGE_SIZE: i64 = 10_000;
 
-/// Absolute safety cap on records per export job. The previous
-/// `EXPORT_MAX_RECORDS = 100_000` cap in `v2_repo` is effectively replaced
-/// by this cap (applied at the streaming layer, not the query layer).
-///
-/// Kept high enough that it does not become a surprise limit for real
-/// exports but low enough that a misconfigured filter cannot accidentally
-/// walk the entire dataset.
+/// Absolute safety cap on records per export job.
 const EXPORT_HARD_CAP: i64 = 1_000_000;
 
 /// BufWriter buffer capacity. Large enough that the writer does not flush
@@ -56,12 +66,14 @@ const EXPORT_HARD_CAP: i64 = 1_000_000;
 /// PAGE_SIZE-bounded peak.
 const WRITER_BUFFER_BYTES: usize = 256 * 1024;
 
+/// Channel depth for page handoff between the DB snapshot task and the
+/// disk writer. Kept small so DB streaming throttles to disk speed
+/// rather than buffering whole pages in RAM.
+const PAGE_CHANNEL_CAPACITY: usize = 2;
+
 /// Open the export target file with `O_NOFOLLOW` (mirrors
 /// [`crate::write_no_follow`]'s symlink-refusing open) and return it as an
 /// async [`tokio::fs::File`] suitable for streaming writes.
-///
-/// The underlying `std::fs::File::open` is performed on the blocking thread
-/// pool so the async runtime is not blocked on filesystem syscalls.
 async fn open_no_follow(path: &str) -> std::io::Result<File> {
     use std::os::unix::fs::OpenOptionsExt;
     let path_owned = path.to_owned();
@@ -79,9 +91,6 @@ async fn open_no_follow(path: &str) -> std::io::Result<File> {
 }
 
 /// Look up dataset-version and completeness provenance for an export job.
-///
-/// Mirrors the metadata preamble that lived inside the old `run_export_job`
-/// so the streaming path produces the same ExportJob row fields.
 pub(crate) async fn fetch_export_metadata(
     repo: &Repository,
     dataset: &str,
@@ -159,6 +168,26 @@ pub(crate) async fn fetch_export_metadata(
     meta
 }
 
+/// Return the canonical CSV header line for a given dataset name, or
+/// `None` if the dataset is unknown.
+fn csv_header_for(dataset: &str) -> Option<&'static str> {
+    Some(match dataset {
+        "token_transfers" => token_transfers_csv_header(),
+        "native_balance_deltas" => native_balance_deltas_csv_header(),
+        "decoded_events" => decoded_events_csv_header(),
+        "hl_fills" => hl_fills_csv_header(),
+        "hl_funding" => hl_funding_csv_header(),
+        "positions" => hl_positions_csv_header(),
+        "wallet_ledger" => wallet_ledger_csv_header(),
+        "balance_history" => balance_history_csv_header(),
+        "hl_pnl_summary" => hl_pnl_summary_csv_header(),
+        "hl_trade_history" => hl_trade_history_csv_header(),
+        "protocol_events" => protocol_events_csv_header(),
+        "pool_snapshots" => pool_snapshots_csv_header(),
+        _ => return None,
+    })
+}
+
 /// Encode a page of records as JSONL into `buf`.
 fn encode_jsonl_page<T: Serialize>(records: &[T], buf: &mut Vec<u8>) -> anyhow::Result<()> {
     for r in records {
@@ -168,101 +197,82 @@ fn encode_jsonl_page<T: Serialize>(records: &[T], buf: &mut Vec<u8>) -> anyhow::
     Ok(())
 }
 
-/// Serialize a single page into an intermediate buffer, then stream it to
-/// the async writer. Returns the number of bytes written.
-async fn write_page<W, T, F>(
-    writer: &mut BufWriter<W>,
-    records: &[T],
+/// Serialize one batch (a page returned by the snapshot streamer) into
+/// the caller-provided byte buffer. CSV rows only — the CSV header is
+/// emitted once before the loop by [`write_export_to_file`].
+fn encode_batch(
+    batch: &ExportRecordBatch,
     format: ExportFormat,
-    csv_header: &str,
-    write_header: bool,
-    mut csv_row_writer: F,
-) -> anyhow::Result<()>
-where
-    W: tokio::io::AsyncWrite + Unpin,
-    T: Serialize,
-    F: FnMut(&[T], &mut Vec<u8>) -> std::io::Result<()>,
-{
-    // Buffer one page's bytes, then hand off to the async writer. The crucial
-    // property is that we never accumulate more than one page's worth at a
-    // time.
-    let mut buf: Vec<u8> = Vec::with_capacity(records.len().saturating_mul(512));
-
-    match format {
-        ExportFormat::Jsonl => {
-            encode_jsonl_page(records, &mut buf)?;
+    buf: &mut Vec<u8>,
+) -> anyhow::Result<()> {
+    match (format, batch) {
+        (ExportFormat::Jsonl, ExportRecordBatch::TokenTransfers(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::NativeBalanceDeltas(v)) => {
+            encode_jsonl_page(v, buf)
         }
-        ExportFormat::Csv => {
-            if write_header {
-                std::io::Write::write_all(&mut buf, csv_header.as_bytes())?;
-            }
-            csv_row_writer(records, &mut buf)?;
+        (ExportFormat::Jsonl, ExportRecordBatch::DecodedEvents(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::HlFills(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::HlFunding(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::Positions(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::WalletLedger(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::BalanceHistory(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::HlPnlSummary(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::HlTradeHistory(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::ProtocolEvents(v)) => encode_jsonl_page(v, buf),
+        (ExportFormat::Jsonl, ExportRecordBatch::PoolSnapshots(v)) => encode_jsonl_page(v, buf),
+
+        (ExportFormat::Csv, ExportRecordBatch::TokenTransfers(v)) => {
+            Ok(write_token_transfers_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::NativeBalanceDeltas(v)) => {
+            Ok(write_native_balance_deltas_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::DecodedEvents(v)) => {
+            Ok(write_decoded_events_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::HlFills(v)) => Ok(write_hl_fills_csv_rows(v, buf)?),
+        (ExportFormat::Csv, ExportRecordBatch::HlFunding(v)) => {
+            Ok(write_hl_funding_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::Positions(v)) => {
+            Ok(write_hl_positions_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::WalletLedger(v)) => {
+            Ok(write_wallet_ledger_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::BalanceHistory(v)) => {
+            Ok(write_balance_history_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::HlPnlSummary(v)) => {
+            Ok(write_hl_pnl_summary_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::HlTradeHistory(v)) => {
+            Ok(write_hl_trade_history_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::ProtocolEvents(v)) => {
+            Ok(write_protocol_events_csv_rows(v, buf)?)
+        }
+        (ExportFormat::Csv, ExportRecordBatch::PoolSnapshots(v)) => {
+            Ok(write_pool_snapshots_csv_rows(v, buf)?)
         }
     }
-
-    writer.write_all(&buf).await?;
-    Ok(())
 }
 
-/// Generate one streaming-dispatch arm for a dataset. Expanded inside
-/// [`write_export_to_file`] below.
-macro_rules! stream_dataset {
-    (
-        $repo:expr, $writer:expr, $format:expr, $target_id:expr, $network:expr,
-        $time_start:expr, $time_end:expr, $query_fn:ident,
-        $csv_header_fn:path, $csv_rows_fn:path $(,)?
-    ) => {{
-        let mut offset: i64 = 0;
-        let mut total: usize = 0;
-        let mut write_header = true;
-        loop {
-            let records = $repo
-                .$query_fn(
-                    $target_id,
-                    $network,
-                    $time_start,
-                    $time_end,
-                    PAGE_SIZE,
-                    offset,
-                )
-                .await?;
-            let n = records.len();
-            if n == 0 {
-                break;
-            }
-
-            write_page(
-                &mut $writer,
-                &records,
-                $format,
-                $csv_header_fn(),
-                write_header,
-                |recs, buf| $csv_rows_fn(recs, buf),
-            )
-            .await?;
-
-            write_header = false;
-            total += n;
-            offset += n as i64;
-
-            // Short page means the underlying query is exhausted.
-            if (n as i64) < PAGE_SIZE {
-                break;
-            }
-            if offset >= EXPORT_HARD_CAP {
-                break;
-            }
-        }
-        total
-    }};
-}
-
-/// Stream an export for `dataset` to `output_path`, fetching records in
-/// pages of [`PAGE_SIZE`] and writing each page directly to disk.
+/// Stream an export for `dataset` to `output_path`, fetching records
+/// in pages of [`PAGE_SIZE`] inside a `REPEATABLE READ READ ONLY`
+/// transaction and writing each page directly to disk.
 ///
-/// Returns the total number of records written and the provenance metadata
-/// gathered at the start of the export (matches the old `run_export_job`
-/// contract minus the giant `Vec<u8>`).
+/// Returns the total number of records written and the provenance
+/// metadata gathered at the start of the export.
+///
+/// # Cancellation
+///
+/// The `cancel` token is checked before the write loop pulls each
+/// page from the channel and before each async write. When cancelled,
+/// the snapshot task aborts the remaining pages, the transaction is
+/// rolled back implicitly on drop, and this function returns an error.
+/// The caller is responsible for deleting the (attempt-scoped) output
+/// file so a reclaiming worker never sees partial bytes.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn write_export_to_file(
     repo: &Repository,
@@ -273,159 +283,91 @@ pub(crate) async fn write_export_to_file(
     time_start: Option<i64>,
     time_end: Option<i64>,
     output_path: &str,
+    cancel: CancellationToken,
 ) -> anyhow::Result<(usize, ExportMetadata)> {
     let meta = fetch_export_metadata(repo, dataset, target_id, network).await;
+
+    // Reject unknown datasets before opening the file so we don't leave
+    // an empty artifact behind.
+    let csv_header =
+        csv_header_for(dataset).ok_or_else(|| anyhow::anyhow!("Unknown dataset: {dataset}"))?;
 
     let file = open_no_follow(output_path).await?;
     let mut writer = BufWriter::with_capacity(WRITER_BUFFER_BYTES, file);
 
-    let total = match dataset {
-        "token_transfers" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_token_transfers,
-            token_transfers_csv_header,
-            write_token_transfers_csv_rows,
-        ),
-        "native_balance_deltas" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_native_balance_deltas,
-            native_balance_deltas_csv_header,
-            write_native_balance_deltas_csv_rows,
-        ),
-        "decoded_events" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_decoded_events,
-            decoded_events_csv_header,
-            write_decoded_events_csv_rows,
-        ),
-        "hl_fills" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_hl_fill_records,
-            hl_fills_csv_header,
-            write_hl_fills_csv_rows,
-        ),
-        "hl_funding" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_hl_funding_payments,
-            hl_funding_csv_header,
-            write_hl_funding_csv_rows,
-        ),
-        "positions" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_hl_position_changes,
-            hl_positions_csv_header,
-            write_hl_positions_csv_rows,
-        ),
-        "wallet_ledger" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_wallet_ledger_records,
-            wallet_ledger_csv_header,
-            write_wallet_ledger_csv_rows,
-        ),
-        "balance_history" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_balance_snapshots,
-            balance_history_csv_header,
-            write_balance_history_csv_rows,
-        ),
-        "hl_pnl_summary" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_hl_pnl_summary,
-            hl_pnl_summary_csv_header,
-            write_hl_pnl_summary_csv_rows,
-        ),
-        "hl_trade_history" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_hl_trade_history,
-            hl_trade_history_csv_header,
-            write_hl_trade_history_csv_rows,
-        ),
-        "protocol_events" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_protocol_events,
-            protocol_events_csv_header,
-            write_protocol_events_csv_rows,
-        ),
-        "pool_snapshots" => stream_dataset!(
-            repo,
-            writer,
-            format,
-            target_id,
-            network,
-            time_start,
-            time_end,
-            query_pool_snapshots,
-            pool_snapshots_csv_header,
-            write_pool_snapshots_csv_rows,
-        ),
-        other => return Err(anyhow::anyhow!("Unknown dataset: {other}")),
-    };
+    // Always emit the CSV header before the page loop so an export with
+    // zero rows still produces a header-only file (fixes PR #238 [P2]
+    // empty-CSV regression). For JSONL, zero rows correctly produces an
+    // empty file.
+    if matches!(format, ExportFormat::Csv) {
+        writer.write_all(csv_header.as_bytes()).await?;
+    }
+
+    // Spawn the snapshot streamer on a separate task so the snapshot
+    // transaction and the write loop run concurrently, with backpressure
+    // provided by the small channel.
+    let (page_tx, mut page_rx) =
+        tokio::sync::mpsc::channel::<ExportRecordBatch>(PAGE_CHANNEL_CAPACITY);
+    let repo_clone = repo.clone();
+    let dataset_owned = dataset.to_string();
+    let network_owned = network.map(|s| s.to_string());
+    let cancel_for_stream = cancel.clone();
+
+    let stream_task = tokio::spawn(async move {
+        repo_clone
+            .stream_export_snapshot(
+                &dataset_owned,
+                target_id,
+                network_owned.as_deref(),
+                time_start,
+                time_end,
+                PAGE_SIZE,
+                EXPORT_HARD_CAP,
+                cancel_for_stream,
+                page_tx,
+            )
+            .await
+    });
+
+    let mut total: usize = 0;
+    let write_result: anyhow::Result<()> = async {
+        while let Some(batch) = page_rx.recv().await {
+            if cancel.is_cancelled() {
+                anyhow::bail!("export cancelled during write loop");
+            }
+
+            let n = batch.len();
+            let mut buf: Vec<u8> = Vec::with_capacity(n.saturating_mul(512));
+            encode_batch(&batch, format, &mut buf)?;
+            writer.write_all(&buf).await?;
+            total += n;
+        }
+        Ok(())
+    }
+    .await;
+
+    // Always drain the snapshot task so we propagate its errors (e.g.
+    // lease-lost cancellation, DB errors) and don't leak a pending
+    // transaction. If the write loop failed, cancel the token so the
+    // snapshot task short-circuits rather than continuing to push
+    // pages into a dropped channel.
+    if write_result.is_err() {
+        cancel.cancel();
+    }
+
+    let stream_result = stream_task
+        .await
+        .map_err(|e| anyhow::anyhow!("export snapshot task panicked: {e}"))?;
+
+    // Surface the first error we have. The write loop's error is
+    // generally the root cause (cancellation, disk failure); the
+    // snapshot task typically reports the secondary "channel dropped".
+    write_result?;
+    let streamed = stream_result?;
+
+    // Sanity check: the DB-reported total must match what we wrote.
+    // A mismatch would indicate dropped pages or a bookkeeping bug.
+    debug_assert_eq!(streamed, total);
 
     writer.flush().await?;
 

--- a/api/src/export_stream.rs
+++ b/api/src/export_stream.rs
@@ -1,0 +1,440 @@
+//! Streaming export writer (fixes #208 export OOM).
+//!
+//! Replaces the previous "load the entire dataset into a `Vec<u8>` buffer,
+//! then write it to disk" pattern with cursor-paginated streaming: records
+//! are fetched from Postgres in bounded pages, each page is serialized into
+//! a small per-page buffer, and each per-page buffer is streamed to disk
+//! before the next page is fetched.
+//!
+//! Peak per-job memory is bounded by `(PAGE_SIZE * per-record bytes)`
+//! regardless of total dataset size, so a single large export can no longer
+//! OOM-kill the worker process and take down co-located workers.
+//!
+//! File opens use `O_NOFOLLOW` in the same way as [`crate::write_no_follow`]
+//! (defense-in-depth for #220 TOCTOU symlink attacks) but the file handle is
+//! kept open across the paged write loop rather than opened/closed per page.
+
+use crate::export_csv::{
+    balance_history_csv_header, decoded_events_csv_header, hl_fills_csv_header,
+    hl_funding_csv_header, hl_pnl_summary_csv_header, hl_positions_csv_header,
+    hl_trade_history_csv_header, native_balance_deltas_csv_header, pool_snapshots_csv_header,
+    protocol_events_csv_header, token_transfers_csv_header, wallet_ledger_csv_header,
+    write_balance_history_csv_rows, write_decoded_events_csv_rows, write_hl_fills_csv_rows,
+    write_hl_funding_csv_rows, write_hl_pnl_summary_csv_rows, write_hl_positions_csv_rows,
+    write_hl_trade_history_csv_rows, write_native_balance_deltas_csv_rows,
+    write_pool_snapshots_csv_rows, write_protocol_events_csv_rows, write_token_transfers_csv_rows,
+    write_wallet_ledger_csv_rows,
+};
+use crate::ExportMetadata;
+use serde::Serialize;
+use spectraplex_adapters::repo::Repository;
+use spectraplex_core::materializer::ExportFormat;
+use tokio::fs::File;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tracing::info;
+use uuid::Uuid;
+
+/// Records per paged query. Keeps peak per-job memory bounded to
+/// roughly `PAGE_SIZE * sizeof(record)` regardless of total dataset size.
+///
+/// Chosen to match the "10,000 records per batch" suggestion from issue
+/// #208 — large enough to amortize query round-trip cost, small enough that
+/// a concurrent fleet of export workers cannot collectively OOM the host.
+pub(crate) const PAGE_SIZE: i64 = 10_000;
+
+/// Absolute safety cap on records per export job. The previous
+/// `EXPORT_MAX_RECORDS = 100_000` cap in `v2_repo` is effectively replaced
+/// by this cap (applied at the streaming layer, not the query layer).
+///
+/// Kept high enough that it does not become a surprise limit for real
+/// exports but low enough that a misconfigured filter cannot accidentally
+/// walk the entire dataset.
+const EXPORT_HARD_CAP: i64 = 1_000_000;
+
+/// BufWriter buffer capacity. Large enough that the writer does not flush
+/// on every serialized record, small enough to stay well under the
+/// PAGE_SIZE-bounded peak.
+const WRITER_BUFFER_BYTES: usize = 256 * 1024;
+
+/// Open the export target file with `O_NOFOLLOW` (mirrors
+/// [`crate::write_no_follow`]'s symlink-refusing open) and return it as an
+/// async [`tokio::fs::File`] suitable for streaming writes.
+///
+/// The underlying `std::fs::File::open` is performed on the blocking thread
+/// pool so the async runtime is not blocked on filesystem syscalls.
+async fn open_no_follow(path: &str) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let path_owned = path.to_owned();
+    let std_file = tokio::task::spawn_blocking(move || {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&path_owned)
+    })
+    .await
+    .map_err(std::io::Error::other)??;
+    Ok(File::from_std(std_file))
+}
+
+/// Look up dataset-version and completeness provenance for an export job.
+///
+/// Mirrors the metadata preamble that lived inside the old `run_export_job`
+/// so the streaming path produces the same ExportJob row fields.
+pub(crate) async fn fetch_export_metadata(
+    repo: &Repository,
+    dataset: &str,
+    target_id: Option<Uuid>,
+    network: Option<&str>,
+) -> ExportMetadata {
+    let active_version = repo
+        .get_active_dataset_version(dataset)
+        .await
+        .ok()
+        .flatten();
+
+    let completeness_records = repo
+        .list_completeness_filtered(dataset, target_id, network)
+        .await
+        .unwrap_or_default();
+
+    let mut meta = ExportMetadata::default();
+    if let Some(ref dv) = active_version {
+        meta.dataset_version_id = Some(dv.id);
+        meta.dataset_version = Some(dv.version);
+    }
+
+    if !completeness_records.is_empty() {
+        let statuses: Vec<&str> = completeness_records
+            .iter()
+            .map(|c| match c.status {
+                spectraplex_core::v2::CompletenessStatus::Complete => "complete",
+                spectraplex_core::v2::CompletenessStatus::Partial => "partial",
+                spectraplex_core::v2::CompletenessStatus::Backfilling => "backfilling",
+                spectraplex_core::v2::CompletenessStatus::Gap => "gap",
+            })
+            .collect();
+
+        let status = if statuses.contains(&"gap") {
+            "gap"
+        } else if statuses.contains(&"backfilling") {
+            "backfilling"
+        } else if statuses.contains(&"partial") {
+            "partial"
+        } else {
+            "complete"
+        };
+        meta.completeness_status = Some(status.to_string());
+
+        let coverage_start = completeness_records
+            .iter()
+            .filter_map(|c| c.coverage_start)
+            .min();
+        let coverage_end = completeness_records
+            .iter()
+            .filter_map(|c| c.coverage_end)
+            .max();
+        let block_start = completeness_records
+            .iter()
+            .filter_map(|c| c.block_start)
+            .min();
+        let block_end = completeness_records
+            .iter()
+            .filter_map(|c| c.block_end)
+            .max();
+        meta.completeness_coverage = Some(serde_json::json!({
+            "coverage_start": coverage_start,
+            "coverage_end": coverage_end,
+            "block_start": block_start,
+            "block_end": block_end,
+        }));
+
+        meta.last_ingestion_run_id = completeness_records
+            .iter()
+            .rev()
+            .find_map(|c| c.last_ingestion_run_id);
+    }
+
+    meta
+}
+
+/// Encode a page of records as JSONL into `buf`.
+fn encode_jsonl_page<T: Serialize>(records: &[T], buf: &mut Vec<u8>) -> anyhow::Result<()> {
+    for r in records {
+        serde_json::to_writer(&mut *buf, r)?;
+        buf.push(b'\n');
+    }
+    Ok(())
+}
+
+/// Serialize a single page into an intermediate buffer, then stream it to
+/// the async writer. Returns the number of bytes written.
+async fn write_page<W, T, F>(
+    writer: &mut BufWriter<W>,
+    records: &[T],
+    format: ExportFormat,
+    csv_header: &str,
+    write_header: bool,
+    mut csv_row_writer: F,
+) -> anyhow::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+    T: Serialize,
+    F: FnMut(&[T], &mut Vec<u8>) -> std::io::Result<()>,
+{
+    // Buffer one page's bytes, then hand off to the async writer. The crucial
+    // property is that we never accumulate more than one page's worth at a
+    // time.
+    let mut buf: Vec<u8> = Vec::with_capacity(records.len().saturating_mul(512));
+
+    match format {
+        ExportFormat::Jsonl => {
+            encode_jsonl_page(records, &mut buf)?;
+        }
+        ExportFormat::Csv => {
+            if write_header {
+                std::io::Write::write_all(&mut buf, csv_header.as_bytes())?;
+            }
+            csv_row_writer(records, &mut buf)?;
+        }
+    }
+
+    writer.write_all(&buf).await?;
+    Ok(())
+}
+
+/// Generate one streaming-dispatch arm for a dataset. Expanded inside
+/// [`write_export_to_file`] below.
+macro_rules! stream_dataset {
+    (
+        $repo:expr, $writer:expr, $format:expr, $target_id:expr, $network:expr,
+        $time_start:expr, $time_end:expr, $query_fn:ident,
+        $csv_header_fn:path, $csv_rows_fn:path $(,)?
+    ) => {{
+        let mut offset: i64 = 0;
+        let mut total: usize = 0;
+        let mut write_header = true;
+        loop {
+            let records = $repo
+                .$query_fn(
+                    $target_id,
+                    $network,
+                    $time_start,
+                    $time_end,
+                    PAGE_SIZE,
+                    offset,
+                )
+                .await?;
+            let n = records.len();
+            if n == 0 {
+                break;
+            }
+
+            write_page(
+                &mut $writer,
+                &records,
+                $format,
+                $csv_header_fn(),
+                write_header,
+                |recs, buf| $csv_rows_fn(recs, buf),
+            )
+            .await?;
+
+            write_header = false;
+            total += n;
+            offset += n as i64;
+
+            // Short page means the underlying query is exhausted.
+            if (n as i64) < PAGE_SIZE {
+                break;
+            }
+            if offset >= EXPORT_HARD_CAP {
+                break;
+            }
+        }
+        total
+    }};
+}
+
+/// Stream an export for `dataset` to `output_path`, fetching records in
+/// pages of [`PAGE_SIZE`] and writing each page directly to disk.
+///
+/// Returns the total number of records written and the provenance metadata
+/// gathered at the start of the export (matches the old `run_export_job`
+/// contract minus the giant `Vec<u8>`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn write_export_to_file(
+    repo: &Repository,
+    dataset: &str,
+    format: ExportFormat,
+    target_id: Option<Uuid>,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    output_path: &str,
+) -> anyhow::Result<(usize, ExportMetadata)> {
+    let meta = fetch_export_metadata(repo, dataset, target_id, network).await;
+
+    let file = open_no_follow(output_path).await?;
+    let mut writer = BufWriter::with_capacity(WRITER_BUFFER_BYTES, file);
+
+    let total = match dataset {
+        "token_transfers" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_token_transfers,
+            token_transfers_csv_header,
+            write_token_transfers_csv_rows,
+        ),
+        "native_balance_deltas" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_native_balance_deltas,
+            native_balance_deltas_csv_header,
+            write_native_balance_deltas_csv_rows,
+        ),
+        "decoded_events" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_decoded_events,
+            decoded_events_csv_header,
+            write_decoded_events_csv_rows,
+        ),
+        "hl_fills" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_hl_fill_records,
+            hl_fills_csv_header,
+            write_hl_fills_csv_rows,
+        ),
+        "hl_funding" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_hl_funding_payments,
+            hl_funding_csv_header,
+            write_hl_funding_csv_rows,
+        ),
+        "positions" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_hl_position_changes,
+            hl_positions_csv_header,
+            write_hl_positions_csv_rows,
+        ),
+        "wallet_ledger" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_wallet_ledger_records,
+            wallet_ledger_csv_header,
+            write_wallet_ledger_csv_rows,
+        ),
+        "balance_history" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_balance_snapshots,
+            balance_history_csv_header,
+            write_balance_history_csv_rows,
+        ),
+        "hl_pnl_summary" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_hl_pnl_summary,
+            hl_pnl_summary_csv_header,
+            write_hl_pnl_summary_csv_rows,
+        ),
+        "hl_trade_history" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_hl_trade_history,
+            hl_trade_history_csv_header,
+            write_hl_trade_history_csv_rows,
+        ),
+        "protocol_events" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_protocol_events,
+            protocol_events_csv_header,
+            write_protocol_events_csv_rows,
+        ),
+        "pool_snapshots" => stream_dataset!(
+            repo,
+            writer,
+            format,
+            target_id,
+            network,
+            time_start,
+            time_end,
+            query_pool_snapshots,
+            pool_snapshots_csv_header,
+            write_pool_snapshots_csv_rows,
+        ),
+        other => return Err(anyhow::anyhow!("Unknown dataset: {other}")),
+    };
+
+    writer.flush().await?;
+
+    info!(
+        dataset,
+        record_count = total,
+        output_path,
+        "Export streamed to disk"
+    );
+
+    Ok((total, meta))
+}

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -1,9 +1,25 @@
 //! Durable export worker loop.
 //!
-//! Claims pending `export_jobs` rows from Postgres, executes the actual
-//! export via [`crate::run_export_job`], optionally delivers to a configured
-//! sink, and marks jobs complete/failed durably. Heartbeats while running so
-//! that dead workers are detected and their jobs reclaimed.
+//! Claims pending `export_jobs` rows from Postgres, streams the export
+//! to disk via [`crate::export_stream::write_export_to_file`], optionally
+//! delivers to a configured sink, and marks jobs complete/failed
+//! durably. Heartbeats while running so that dead workers are detected
+//! and their jobs reclaimed.
+//!
+//! Lease safety (PR #238 [P1] fix):
+//!
+//! The worker writes the export artifact to an *attempt-scoped* temp
+//! file named `{job_id}.{worker_hash}.{ext}.tmp`, and only atomically
+//! renames it to the canonical `{job_id}.{ext}` download path after a
+//! lease-holder-confirming `update_export_job_status(..., worker_id)`
+//! has returned `Ok(true)`. If the heartbeat loop reports the job's
+//! lease was reclaimed, a `lease_lost` [`CancellationToken`] is
+//! cancelled — that token is propagated into the page loop in
+//! `write_export_to_file`, so the stale worker short-circuits the DB
+//! snapshot, skips the rename, and removes its temp file. The new
+//! owner starts from a clean state and writes to a distinct temp path,
+//! so the two workers cannot truncate each other's artifacts or hand
+//! out partial bytes via `/download`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,8 +33,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-// These items are defined in main.rs and need to be pub(crate) for this
-// module to use them.  The parent task will adjust visibility.
 use crate::build_sink;
 use crate::export_stream::write_export_to_file;
 
@@ -58,13 +72,9 @@ async fn worker_tick(
     job_semaphore: &Arc<Semaphore>,
     worker_id: &str,
 ) {
-    // Try to acquire a semaphore permit before claiming a job.
-    // This prevents the worker from claiming more jobs than it can execute
-    // concurrently.
     let permit = match Arc::clone(job_semaphore).try_acquire_owned() {
         Ok(permit) => permit,
         Err(_) => {
-            // All permits are in use — back off and retry.
             tokio::time::sleep(POLL_INTERVAL).await;
             return;
         }
@@ -82,7 +92,6 @@ async fn worker_tick(
             execute_export_job(repo, config, worker_id, &job, permit).await;
         }
         Ok(None) => {
-            // No jobs available — drop the permit and sleep before polling again.
             drop(permit);
             tokio::time::sleep(POLL_INTERVAL).await;
         }
@@ -90,6 +99,39 @@ async fn worker_tick(
             drop(permit);
             error!(error = %e, worker_id = %worker_id, "Failed to claim export job");
             tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Build an attempt-scoped temp path for this worker's export. Two
+/// workers that race on the same `job_id` get different temp paths, so
+/// a stale worker cannot truncate the new owner's artifact.
+fn attempt_temp_path(exports_dir: &str, job_id: Uuid, worker_id: &str, ext: &str) -> String {
+    // Short, filesystem-safe tag derived from the worker id. FNV-style
+    // hash is fine — collision risk is negligible at the (active worker
+    // count) scale this operates at.
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    worker_id.hash(&mut h);
+    let tag = format!("{:016x}", h.finish());
+    format!("{exports_dir}/{job_id}.{tag}.{ext}.tmp")
+}
+
+/// Best-effort remove a file, swallowing NotFound and logging other
+/// errors. Used by the failure paths in `execute_export_job` to clean
+/// up attempt-scoped temp artifacts without masking the real error.
+async fn best_effort_unlink(path: &str, job_id: Uuid) {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            warn!(
+                job_id = %job_id,
+                error = %e,
+                file = %path,
+                "Failed to clean up temp export artifact",
+            );
         }
     }
 }
@@ -104,38 +146,49 @@ async fn execute_export_job(
     let job_id = job.id;
     let export_dir = &config.export_dir;
 
-    // Spawn a heartbeat task that runs until we signal completion.
+    // `heartbeat_cancel` stops the heartbeat task when the export is
+    // done. `lease_lost` is a *distinct* token that the heartbeat task
+    // flips when `heartbeat_export_job` reports the job has been
+    // reclaimed. Downstream code (the streaming writer and the final
+    // rename) checks `lease_lost` to short-circuit its side effects
+    // so a stale worker cannot publish a partial/bogus artifact over
+    // the new owner's work.
     let heartbeat_cancel = CancellationToken::new();
-    let hb_repo = repo.clone();
-    let hb_worker = worker_id.to_string();
-    let hb_cancel = heartbeat_cancel.clone();
-    let hb_job_id = job_id;
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
-        interval.tick().await; // first tick is immediate
-        loop {
-            tokio::select! {
-                _ = hb_cancel.cancelled() => { return; }
-                _ = interval.tick() => {
-                    match hb_repo.heartbeat_export_job(hb_job_id, &hb_worker).await {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            warn!(job_id = %hb_job_id, "Heartbeat returned false — lease lost");
-                            return;
-                        }
-                        Err(e) => {
-                            warn!(job_id = %hb_job_id, error = %e, "Heartbeat failed");
+    let lease_lost = CancellationToken::new();
+    {
+        let hb_repo = repo.clone();
+        let hb_worker = worker_id.to_string();
+        let hb_cancel = heartbeat_cancel.clone();
+        let hb_lost = lease_lost.clone();
+        let hb_job_id = job_id;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+            interval.tick().await; // first tick is immediate
+            loop {
+                tokio::select! {
+                    _ = hb_cancel.cancelled() => { return; }
+                    _ = interval.tick() => {
+                        match hb_repo.heartbeat_export_job(hb_job_id, &hb_worker).await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                warn!(job_id = %hb_job_id, "Heartbeat returned false — lease lost");
+                                // Propagate to the write loop so it stops
+                                // before any more side effects.
+                                hb_lost.cancel();
+                                return;
+                            }
+                            Err(e) => {
+                                warn!(job_id = %hb_job_id, error = %e, "Heartbeat failed");
+                            }
                         }
                     }
                 }
             }
-        }
-    });
+        });
+    }
 
-    // Parse filters from the job to extract query parameters.
     let (target_id, network, time_start, time_end) = parse_filters(&job.filters);
 
-    // Parse the export format.
     let format: ExportFormat = match job.format.parse() {
         Ok(f) => f,
         Err(_) => {
@@ -165,11 +218,6 @@ async fn execute_export_job(
         }
     };
 
-    // Determine file extension from format, so we can build the artifact
-    // path before running the export. The path is needed up-front because
-    // `write_export_to_file` streams records directly to this path, page by
-    // page (fix for #208: the old code accumulated the whole export in
-    // memory first).
     let ext = match format {
         ExportFormat::Jsonl => "jsonl",
         ExportFormat::Csv => "csv",
@@ -199,11 +247,11 @@ async fn execute_export_job(
         return;
     }
 
-    let file_path = format!("{}/{}.{}", exports_dir, job_id, ext);
+    let temp_path = attempt_temp_path(&exports_dir, job_id, worker_id, ext);
+    let final_path = format!("{}/{}.{}", exports_dir, job_id, ext);
 
-    // Stream the export directly to disk. Peak per-job memory is bounded by
-    // `export_stream::PAGE_SIZE * per-record bytes`, not by total dataset
-    // size.
+    // Stream the export into the attempt-scoped temp path. Lease-loss
+    // cancellation propagates into the snapshot+write loop.
     let result = write_export_to_file(
         repo,
         &job.dataset,
@@ -212,31 +260,46 @@ async fn execute_export_job(
         network.as_deref(),
         time_start,
         time_end,
-        &file_path,
+        &temp_path,
+        lease_lost.clone(),
     )
     .await;
 
-    // NOTE: Heartbeat stays alive through file write, sink delivery, and
-    // final status update. Stopping it early would let claim_export_job()
-    // reclaim a "delivering" job that is still actively writing/delivering,
-    // causing duplicate deliveries and conflicting final states.
+    // Heartbeat deliberately stays alive through publish + sink
+    // delivery + final status update, so we don't release the lease
+    // until side effects are durable.
 
     match result {
         Ok((record_count, _export_meta)) => {
+            // Before touching the canonical download path, confirm we
+            // still hold the lease. If we don't, the heartbeat task has
+            // already set `lease_lost`; clean up the temp and bail
+            // without racing the new owner.
+            if lease_lost.is_cancelled() {
+                warn!(
+                    job_id = %job_id,
+                    "Lease lost after write — discarding temp artifact without publishing"
+                );
+                best_effort_unlink(&temp_path, job_id).await;
+                heartbeat_cancel.cancel();
+                return;
+            }
+
             let has_sink = job.sink_config.is_some();
 
-            // Extract provenance fields from export metadata for persistence.
             let prov_dv_id = _export_meta.dataset_version_id;
             let prov_dv = _export_meta.dataset_version;
             let prov_cs = _export_meta.completeness_status.as_deref();
             let prov_cc = _export_meta.completeness_coverage.as_ref();
             let prov_lri = _export_meta.last_ingestion_run_id;
 
-            // Canonical on-disk artifact path — always preserved for download.
             let result_location = format!("exports/{}.{}", job_id, ext);
 
             if has_sink {
-                // Transition to 'delivering'. If Ok(false), lease was lost.
+                // Transition to 'delivering'. update_or_abort only
+                // writes the row if we still own the lease (Ok(true)).
+                // If Ok(false) ("someone else took over"), we clean up
+                // our temp and exit without publishing.
                 match update_or_abort(
                     repo,
                     job_id,
@@ -256,60 +319,77 @@ async fn execute_export_job(
                 {
                     Ok(()) => {}
                     Err(()) => {
+                        best_effort_unlink(&temp_path, job_id).await;
                         heartbeat_cancel.cancel();
                         return;
                     }
                 }
 
-                // Attempt sink delivery.
-                //
-                // The streaming writer already produced the export artifact
-                // on disk. The current `ExportSink::deliver` contract takes
-                // `&[u8]`, so we read the artifact back into memory once for
-                // the sink call. Peak memory here is bounded by the disk
-                // artifact size (which is itself bounded by
-                // `export_stream::EXPORT_HARD_CAP * per-record bytes`) — much
-                // smaller than the pre-#208 behavior where the full export
-                // was also held in memory for the disk write. Converting the
-                // sink trait to take a file path / reader is a follow-up.
+                // Publish: atomic rename temp -> final. Only after the
+                // lease-confirming 'delivering' update above, so a
+                // stale worker never publishes over the new owner's
+                // artifact. rename is atomic within the same
+                // filesystem; the exports_dir is a single dir so this
+                // holds.
+                if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
+                    let err_msg = format!("Failed to publish export artifact: {e}");
+                    error!(job_id = %job_id, error = %err_msg, "Export job failed");
+                    best_effort_unlink(&temp_path, job_id).await;
+                    let _ = update_or_abort(
+                        repo,
+                        job_id,
+                        "failed",
+                        Some(record_count as i32),
+                        Some(&result_location),
+                        Some(&err_msg),
+                        worker_id,
+                        None,
+                        prov_dv_id,
+                        prov_dv,
+                        prov_cs,
+                        prov_cc,
+                        prov_lri,
+                    )
+                    .await;
+                    heartbeat_cancel.cancel();
+                    return;
+                }
+
+                // Deliver to the sink from the already-streamed file.
+                // `deliver_from_file` avoids loading the full artifact
+                // into memory (fixes PR #238 [P2] sink-OOM concern):
+                // LocalFileSink does a streaming `io::copy`; WebhookSink
+                // uses `ReaderStream` for a streaming request body.
                 let sink_value = job.sink_config.as_ref().unwrap();
                 let delivery_result = match serde_json::from_value::<SinkConfig>(sink_value.clone())
                 {
                     Ok(sink_config) => match build_sink(&sink_config, export_dir) {
-                        Ok(sink) => match tokio::fs::read(&file_path).await {
-                            Ok(body) => {
-                                let delivery_meta = DeliveryMetadata {
-                                    job_id,
-                                    dataset: job.dataset.clone(),
-                                    format: job.format.clone(),
-                                    record_count,
-                                    dataset_version_id: _export_meta.dataset_version_id,
-                                    completeness_status: _export_meta.completeness_status.clone(),
-                                };
-                                match sink.deliver(&body, &delivery_meta).await {
-                                    Ok(receipt) => Ok(receipt.destination),
-                                    Err(e) => {
-                                        warn!(job_id = %job_id, error = %e, "Sink delivery failed");
-                                        Err(format!(
-                                            "Exported {} records, but sink delivery failed: {e}",
-                                            record_count
-                                        ))
-                                    }
+                        Ok(sink) => {
+                            let delivery_meta = DeliveryMetadata {
+                                job_id,
+                                dataset: job.dataset.clone(),
+                                format: job.format.clone(),
+                                record_count,
+                                dataset_version_id: _export_meta.dataset_version_id,
+                                completeness_status: _export_meta.completeness_status.clone(),
+                            };
+                            match sink
+                                .deliver_from_file(
+                                    std::path::Path::new(&final_path),
+                                    &delivery_meta,
+                                )
+                                .await
+                            {
+                                Ok(receipt) => Ok(receipt.destination),
+                                Err(e) => {
+                                    warn!(job_id = %job_id, error = %e, "Sink delivery failed");
+                                    Err(format!(
+                                        "Exported {} records, but sink delivery failed: {e}",
+                                        record_count
+                                    ))
                                 }
                             }
-                            Err(e) => {
-                                warn!(
-                                    job_id = %job_id,
-                                    error = %e,
-                                    file = %file_path,
-                                    "Failed to read export artifact for sink delivery",
-                                );
-                                Err(format!(
-                                    "Exported {} records to disk, but reading artifact for sink delivery failed: {e}",
-                                    record_count
-                                ))
-                            }
-                        },
+                        }
                         Err(e) => {
                             warn!(job_id = %job_id, error = %e, "Failed to build sink");
                             Err(format!(
@@ -335,8 +415,6 @@ async fn execute_export_job(
                             destination = %destination,
                             "Export job completed with sink delivery"
                         );
-                        // Keep result_location as the on-disk file path for download.
-                        // The sink destination is stored in delivery_destination.
                         let _ = update_or_abort(
                             repo,
                             job_id,
@@ -375,14 +453,46 @@ async fn execute_export_job(
                     }
                 }
             } else {
-                // No sink — mark completed directly with the filesystem location.
+                // No sink. Publish + mark completed.
+                //
+                // Order: we do the rename first (best-effort) and then
+                // update the job row. If the update fails because our
+                // lease was lost in this narrow window, the
+                // `update_or_abort(Err(()))` branch below unlinks the
+                // just-published final_path so a reclaiming worker
+                // does not hand out our artifact via `/download`. This
+                // mirrors the pre-publish lease check above.
+                if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
+                    let err_msg = format!("Failed to publish export artifact: {e}");
+                    error!(job_id = %job_id, error = %err_msg, "Export job failed");
+                    best_effort_unlink(&temp_path, job_id).await;
+                    let _ = update_or_abort(
+                        repo,
+                        job_id,
+                        "failed",
+                        None,
+                        None,
+                        Some(&err_msg),
+                        worker_id,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await;
+                    heartbeat_cancel.cancel();
+                    return;
+                }
+
                 info!(
                     job_id = %job_id,
                     record_count,
                     result_location = %result_location,
                     "Export job completed"
                 );
-                let _ = update_or_abort(
+                match update_or_abort(
                     repo,
                     job_id,
                     "completed",
@@ -397,26 +507,28 @@ async fn execute_export_job(
                     prov_cc,
                     prov_lri,
                 )
-                .await;
+                .await
+                {
+                    Ok(()) => {}
+                    Err(()) => {
+                        // Lease was taken between rename and update. Pull
+                        // the published artifact back so the new owner
+                        // does not see our output.
+                        warn!(
+                            job_id = %job_id,
+                            "Lease lost at final update — unpublishing artifact"
+                        );
+                        best_effort_unlink(&final_path, job_id).await;
+                    }
+                }
             }
         }
         Err(e) => {
             let err_msg = format!("Export failed: {e}");
             error!(job_id = %job_id, error = %err_msg, "Export job failed");
-            // The streaming writer may have created a partial artifact before
-            // failing. Best-effort remove it so a retry does not append to a
-            // truncated file and so we do not hand out a partial artifact via
-            // `/download`.
-            if let Err(rm_err) = tokio::fs::remove_file(&file_path).await {
-                if rm_err.kind() != std::io::ErrorKind::NotFound {
-                    warn!(
-                        job_id = %job_id,
-                        error = %rm_err,
-                        file = %file_path,
-                        "Failed to clean up partial export artifact after failure",
-                    );
-                }
-            }
+            // Attempt-scoped temp path: nothing was ever published at
+            // final_path, so we only need to remove our temp.
+            best_effort_unlink(&temp_path, job_id).await;
             let _ = update_or_abort(
                 repo,
                 job_id,

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -453,15 +453,42 @@ async fn execute_export_job(
                     }
                 }
             } else {
-                // No sink. Publish + mark completed.
-                //
-                // Order: we do the rename first (best-effort) and then
-                // update the job row. If the update fails because our
-                // lease was lost in this narrow window, the
-                // `update_or_abort(Err(()))` branch below unlinks the
-                // just-published final_path so a reclaiming worker
-                // does not hand out our artifact via `/download`. This
-                // mirrors the pre-publish lease check above.
+                // No sink. Mirror the sink path's lease-guarded publish:
+                // transition the row to `delivering` BEFORE the rename so
+                // a stale worker that has been reclaimed cannot overwrite
+                // the new owner's artifact. `update_or_abort` fails
+                // closed (Err) when `worker_id = $7 AND status IN
+                // ('running','delivering')` matches zero rows, i.e. the
+                // lease is no longer ours.
+                match update_or_abort(
+                    repo,
+                    job_id,
+                    "delivering",
+                    Some(record_count as i32),
+                    Some(&result_location),
+                    None,
+                    worker_id,
+                    None,
+                    prov_dv_id,
+                    prov_dv,
+                    prov_cs,
+                    prov_cc,
+                    prov_lri,
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    Err(()) => {
+                        best_effort_unlink(&temp_path, job_id).await;
+                        heartbeat_cancel.cancel();
+                        return;
+                    }
+                }
+
+                // Publish: atomic rename temp -> final. Only runs after
+                // the lease-confirming `delivering` update above, so a
+                // stale worker never publishes over the new owner's
+                // artifact.
                 if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
                     let err_msg = format!("Failed to publish export artifact: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
@@ -470,16 +497,16 @@ async fn execute_export_job(
                         repo,
                         job_id,
                         "failed",
-                        None,
-                        None,
+                        Some(record_count as i32),
+                        Some(&result_location),
                         Some(&err_msg),
                         worker_id,
                         None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
+                        prov_dv_id,
+                        prov_dv,
+                        prov_cs,
+                        prov_cc,
+                        prov_lri,
                     )
                     .await;
                     heartbeat_cancel.cancel();
@@ -511,9 +538,12 @@ async fn execute_export_job(
                 {
                     Ok(()) => {}
                     Err(()) => {
-                        // Lease was taken between rename and update. Pull
-                        // the published artifact back so the new owner
-                        // does not see our output.
+                        // Lease was taken between the `delivering`
+                        // transition and the `completed` transition
+                        // (narrow window — our lease-holding update to
+                        // `delivering` just succeeded). Pull the
+                        // published artifact back so the new owner does
+                        // not serve our output via `/download`.
                         warn!(
                             job_id = %job_id,
                             "Lease lost at final update — unpublishing artifact"

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -19,7 +19,8 @@ use uuid::Uuid;
 
 // These items are defined in main.rs and need to be pub(crate) for this
 // module to use them.  The parent task will adjust visibility.
-use crate::{build_sink, run_export_job, write_no_follow};
+use crate::build_sink;
+use crate::export_stream::write_export_to_file;
 
 /// How often the worker polls for new jobs when idle.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -164,8 +165,46 @@ async fn execute_export_job(
         }
     };
 
-    // Execute the actual export.
-    let result = run_export_job(
+    // Determine file extension from format, so we can build the artifact
+    // path before running the export. The path is needed up-front because
+    // `write_export_to_file` streams records directly to this path, page by
+    // page (fix for #208: the old code accumulated the whole export in
+    // memory first).
+    let ext = match format {
+        ExportFormat::Jsonl => "jsonl",
+        ExportFormat::Csv => "csv",
+    };
+
+    let exports_dir = format!("{}/exports", export_dir);
+    if let Err(e) = tokio::fs::create_dir_all(&exports_dir).await {
+        let err_msg = format!("Failed to create exports directory: {e}");
+        error!(job_id = %job_id, error = %err_msg, "Export job failed");
+        let _ = update_or_abort(
+            repo,
+            job_id,
+            "failed",
+            None,
+            None,
+            Some(&err_msg),
+            worker_id,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        heartbeat_cancel.cancel();
+        return;
+    }
+
+    let file_path = format!("{}/{}.{}", exports_dir, job_id, ext);
+
+    // Stream the export directly to disk. Peak per-job memory is bounded by
+    // `export_stream::PAGE_SIZE * per-record bytes`, not by total dataset
+    // size.
+    let result = write_export_to_file(
         repo,
         &job.dataset,
         format,
@@ -173,6 +212,7 @@ async fn execute_export_job(
         network.as_deref(),
         time_start,
         time_end,
+        &file_path,
     )
     .await;
 
@@ -182,7 +222,7 @@ async fn execute_export_job(
     // causing duplicate deliveries and conflicting final states.
 
     match result {
-        Ok((body, record_count, _export_meta)) => {
+        Ok((record_count, _export_meta)) => {
             let has_sink = job.sink_config.is_some();
 
             // Extract provenance fields from export metadata for persistence.
@@ -191,61 +231,6 @@ async fn execute_export_job(
             let prov_cs = _export_meta.completeness_status.as_deref();
             let prov_cc = _export_meta.completeness_coverage.as_ref();
             let prov_lri = _export_meta.last_ingestion_run_id;
-
-            // Determine file extension from format.
-            let ext = match format {
-                ExportFormat::Jsonl => "jsonl",
-                ExportFormat::Csv => "csv",
-            };
-
-            // Write export data to filesystem.
-            let exports_dir = format!("{}/exports", export_dir);
-            if let Err(e) = tokio::fs::create_dir_all(&exports_dir).await {
-                let err_msg = format!("Failed to create exports directory: {e}");
-                error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                let _ = update_or_abort(
-                    repo,
-                    job_id,
-                    "failed",
-                    None,
-                    None,
-                    Some(&err_msg),
-                    worker_id,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-                .await;
-                heartbeat_cancel.cancel();
-                return;
-            }
-
-            let file_path = format!("{}/{}.{}", exports_dir, job_id, ext);
-            if let Err(e) = write_no_follow(&file_path, &body).await {
-                let err_msg = format!("Failed to write export file: {e}");
-                error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                let _ = update_or_abort(
-                    repo,
-                    job_id,
-                    "failed",
-                    None,
-                    None,
-                    Some(&err_msg),
-                    worker_id,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-                .await;
-                heartbeat_cancel.cancel();
-                return;
-            }
 
             // Canonical on-disk artifact path — always preserved for download.
             let result_location = format!("exports/{}.{}", job_id, ext);
@@ -277,30 +262,54 @@ async fn execute_export_job(
                 }
 
                 // Attempt sink delivery.
+                //
+                // The streaming writer already produced the export artifact
+                // on disk. The current `ExportSink::deliver` contract takes
+                // `&[u8]`, so we read the artifact back into memory once for
+                // the sink call. Peak memory here is bounded by the disk
+                // artifact size (which is itself bounded by
+                // `export_stream::EXPORT_HARD_CAP * per-record bytes`) — much
+                // smaller than the pre-#208 behavior where the full export
+                // was also held in memory for the disk write. Converting the
+                // sink trait to take a file path / reader is a follow-up.
                 let sink_value = job.sink_config.as_ref().unwrap();
                 let delivery_result = match serde_json::from_value::<SinkConfig>(sink_value.clone())
                 {
                     Ok(sink_config) => match build_sink(&sink_config, export_dir) {
-                        Ok(sink) => {
-                            let delivery_meta = DeliveryMetadata {
-                                job_id,
-                                dataset: job.dataset.clone(),
-                                format: job.format.clone(),
-                                record_count,
-                                dataset_version_id: _export_meta.dataset_version_id,
-                                completeness_status: _export_meta.completeness_status.clone(),
-                            };
-                            match sink.deliver(&body, &delivery_meta).await {
-                                Ok(receipt) => Ok(receipt.destination),
-                                Err(e) => {
-                                    warn!(job_id = %job_id, error = %e, "Sink delivery failed");
-                                    Err(format!(
-                                        "Exported {} records, but sink delivery failed: {e}",
-                                        record_count
-                                    ))
+                        Ok(sink) => match tokio::fs::read(&file_path).await {
+                            Ok(body) => {
+                                let delivery_meta = DeliveryMetadata {
+                                    job_id,
+                                    dataset: job.dataset.clone(),
+                                    format: job.format.clone(),
+                                    record_count,
+                                    dataset_version_id: _export_meta.dataset_version_id,
+                                    completeness_status: _export_meta.completeness_status.clone(),
+                                };
+                                match sink.deliver(&body, &delivery_meta).await {
+                                    Ok(receipt) => Ok(receipt.destination),
+                                    Err(e) => {
+                                        warn!(job_id = %job_id, error = %e, "Sink delivery failed");
+                                        Err(format!(
+                                            "Exported {} records, but sink delivery failed: {e}",
+                                            record_count
+                                        ))
+                                    }
                                 }
                             }
-                        }
+                            Err(e) => {
+                                warn!(
+                                    job_id = %job_id,
+                                    error = %e,
+                                    file = %file_path,
+                                    "Failed to read export artifact for sink delivery",
+                                );
+                                Err(format!(
+                                    "Exported {} records to disk, but reading artifact for sink delivery failed: {e}",
+                                    record_count
+                                ))
+                            }
+                        },
                         Err(e) => {
                             warn!(job_id = %job_id, error = %e, "Failed to build sink");
                             Err(format!(
@@ -394,6 +403,20 @@ async fn execute_export_job(
         Err(e) => {
             let err_msg = format!("Export failed: {e}");
             error!(job_id = %job_id, error = %err_msg, "Export job failed");
+            // The streaming writer may have created a partial artifact before
+            // failing. Best-effort remove it so a retry does not append to a
+            // truncated file and so we do not hand out a partial artifact via
+            // `/download`.
+            if let Err(rm_err) = tokio::fs::remove_file(&file_path).await {
+                if rm_err.kind() != std::io::ErrorKind::NotFound {
+                    warn!(
+                        job_id = %job_id,
+                        error = %rm_err,
+                        file = %file_path,
+                        "Failed to clean up partial export artifact after failure",
+                    );
+                }
+            }
             let _ = update_or_abort(
                 repo,
                 job_id,

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1050,6 +1050,66 @@ impl ExportSink for LocalFileSink {
             delivered_at: chrono::Utc::now(),
         })
     }
+
+    /// Copy the already-streamed export artifact from `path` to the
+    /// sink's target path without ever reading the full artifact into
+    /// memory (fixes the PR #238 [P2] concern that sink jobs still
+    /// hit the OOM class after #208).
+    async fn deliver_from_file(
+        &self,
+        path: &std::path::Path,
+        _metadata: &DeliveryMetadata,
+    ) -> Result<DeliveryReceipt, String> {
+        if let Some(parent) = std::path::Path::new(&self.path).parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("Failed to create directory for {}: {e}", self.path))?;
+        }
+
+        copy_no_follow(path, &self.path).await.map_err(|e| {
+            format!(
+                "Failed to copy export artifact {} -> {}: {e}",
+                path.display(),
+                self.path
+            )
+        })?;
+
+        let bytes_written = tokio::fs::metadata(&self.path)
+            .await
+            .map(|m| m.len() as usize)
+            .unwrap_or(0);
+
+        Ok(DeliveryReceipt {
+            sink_type: SinkType::LocalFile,
+            destination: self.path.clone(),
+            bytes_written,
+            delivered_at: chrono::Utc::now(),
+        })
+    }
+}
+
+/// Copy `src` to `dst` with a streaming `io::copy`, opening `dst` with
+/// `O_NOFOLLOW` so symlink attacks on the sink destination still fail
+/// (shares the same defense as [`write_no_follow`] for #220).
+async fn copy_no_follow(src: &std::path::Path, dst: &str) -> std::io::Result<u64> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let src_owned = src.to_path_buf();
+    let dst_owned = dst.to_owned();
+    tokio::task::spawn_blocking(move || -> std::io::Result<u64> {
+        let mut reader = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&src_owned)?;
+        let mut writer = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&dst_owned)?;
+        std::io::copy(&mut reader, &mut writer)
+    })
+    .await
+    .map_err(std::io::Error::other)?
 }
 
 /// Opens a file for writing with `O_NOFOLLOW` to prevent symlink-following
@@ -1097,25 +1157,7 @@ impl ExportSink for WebhookSink {
         // Re-resolve and validate at delivery time to prevent DNS rebinding.
         let client = build_ssrf_safe_client(&self.url, Duration::from_secs(30)).await?;
 
-        let content_type = match metadata.format.as_str() {
-            "csv" => "text/csv; charset=utf-8",
-            _ => "application/x-ndjson",
-        };
-
-        let mut req = client
-            .post(&self.url)
-            .header("Content-Type", content_type)
-            .header("X-Export-Dataset", &metadata.dataset)
-            .header("X-Export-Format", &metadata.format)
-            .header("X-Export-Record-Count", metadata.record_count.to_string())
-            .header("X-Export-Job-Id", metadata.job_id.to_string());
-
-        if let Some(ref headers) = self.headers {
-            for (key, value) in headers {
-                req = req.header(key, value);
-            }
-        }
-
+        let req = self.build_request(&client, metadata);
         let response = req
             .body(data.to_vec())
             .send()
@@ -1135,6 +1177,88 @@ impl ExportSink for WebhookSink {
             bytes_written: data.len(),
             delivered_at: chrono::Utc::now(),
         })
+    }
+
+    /// Stream the export artifact as the request body without ever
+    /// reading the full file into memory (fixes the PR #238 [P2]
+    /// concern about sink jobs still hitting the OOM class after
+    /// #208). We preflight the file size so `Content-Length` is set
+    /// correctly for non-chunked HTTP and so the returned bytes_written
+    /// receipt is accurate, then hand reqwest a `Stream` built from a
+    /// `tokio::fs::File` via `tokio_util::io::ReaderStream`.
+    async fn deliver_from_file(
+        &self,
+        path: &std::path::Path,
+        metadata: &DeliveryMetadata,
+    ) -> Result<DeliveryReceipt, String> {
+        let client = build_ssrf_safe_client(&self.url, Duration::from_secs(30)).await?;
+
+        let size = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| format!("Failed to stat export artifact {}: {e}", path.display()))?
+            .len();
+
+        let file = tokio::fs::File::open(path)
+            .await
+            .map_err(|e| format!("Failed to open export artifact {}: {e}", path.display()))?;
+        let stream = tokio_util::io::ReaderStream::new(file);
+        let body = reqwest::Body::wrap_stream(stream);
+
+        let req = self
+            .build_request(&client, metadata)
+            .header(reqwest::header::CONTENT_LENGTH, size.to_string());
+
+        let response = req
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| format!("Webhook POST to {} failed: {e}", self.url))?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "Webhook returned non-success status: {}",
+                response.status()
+            ));
+        }
+
+        Ok(DeliveryReceipt {
+            sink_type: SinkType::Webhook,
+            destination: self.url.clone(),
+            bytes_written: size as usize,
+            delivered_at: chrono::Utc::now(),
+        })
+    }
+}
+
+impl WebhookSink {
+    /// Builder for the request shared by `deliver` and
+    /// `deliver_from_file`. Sets the Content-Type based on format, the
+    /// X-Export-* provenance headers, and any user-configured custom
+    /// headers.
+    fn build_request(
+        &self,
+        client: &reqwest::Client,
+        metadata: &DeliveryMetadata,
+    ) -> reqwest::RequestBuilder {
+        let content_type = match metadata.format.as_str() {
+            "csv" => "text/csv; charset=utf-8",
+            _ => "application/x-ndjson",
+        };
+
+        let mut req = client
+            .post(&self.url)
+            .header("Content-Type", content_type)
+            .header("X-Export-Dataset", &metadata.dataset)
+            .header("X-Export-Format", &metadata.format)
+            .header("X-Export-Record-Count", metadata.record_count.to_string())
+            .header("X-Export-Job-Id", metadata.job_id.to_string());
+
+        if let Some(ref headers) = self.headers {
+            for (key, value) in headers {
+                req = req.header(key, value);
+            }
+        }
+        req
     }
 }
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,3 +1,5 @@
+mod export_csv;
+mod export_stream;
 mod export_worker;
 mod materialize_worker;
 mod stream_worker;
@@ -19,10 +21,18 @@ use spectraplex_adapters::v2_repo::EnqueueIngestionJobParams;
 use spectraplex_core::config::AppConfig;
 use spectraplex_core::connector::validate_target;
 use spectraplex_core::materializer::{
-    BalanceSnapshot, DatasetName, DatasetRegistry, DeliveryMetadata, DeliveryReceipt, ExportFormat,
-    ExportSink, ForensicsActivity, HlPnlSummary, HlTradeHistory, MarketAnalytics, PoolSnapshot,
-    ProtocolActivity, ProtocolEvent, SinkConfig, SinkType, TraderAnalytics, TvlAnalytics,
-    WalletLedgerRecord,
+    DatasetName, DatasetRegistry, DeliveryMetadata, DeliveryReceipt, ExportFormat, ExportSink,
+    ForensicsActivity, MarketAnalytics, ProtocolActivity, SinkConfig, SinkType, TraderAnalytics,
+    TvlAnalytics, WalletLedgerRecord,
+};
+// Types used only by the test-only `*_to_csv` helpers below and the
+// `*_to_csv_format` / `*_summary_to_csv_format` tests. Kept behind
+// `#[cfg(test)]` so non-test builds don't warn about unused imports now
+// that the streaming export path (`export_stream`) uses the row-writer
+// helpers in `export_csv` directly, not the `*_to_csv` wrappers.
+#[cfg(test)]
+use spectraplex_core::materializer::{
+    BalanceSnapshot, HlPnlSummary, HlTradeHistory, PoolSnapshot, ProtocolEvent,
 };
 use spectraplex_core::models::{Chain, EntryType, LedgerEntry, Transaction};
 use spectraplex_core::provider::{
@@ -2424,6 +2434,17 @@ fn content_type_for_format(format: ExportFormat) -> &'static str {
     }
 }
 
+// Test-only convenience wrappers.
+//
+// Before #208, these were the primary serialization entry points called
+// from `run_export_job` to produce a single `Vec<u8>`. The streaming export
+// path (`export_stream::write_export_to_file`) now writes pages directly
+// to disk via the row-emitters in `export_csv`, and production code no
+// longer needs a single `Vec<u8>`. The wrappers remain so the existing
+// `*_to_csv_format` / `test_serialize_to_jsonl` tests keep asserting the
+// exact output format.
+
+#[cfg(test)]
 fn serialize_to_jsonl<T: Serialize>(records: &[T]) -> Result<Vec<u8>, AppError> {
     let mut buf = Vec::new();
     for record in records {
@@ -2433,358 +2454,67 @@ fn serialize_to_jsonl<T: Serialize>(records: &[T]) -> Result<Vec<u8>, AppError> 
     Ok(buf)
 }
 
+#[cfg(test)]
 fn token_transfers_to_csv(records: &[spectraplex_core::materializer::TokenTransfer]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,token_address,token_symbol,from_address,to_address,amount,decimals,transfer_index,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.token_address),
-            r.token_symbol.as_deref().unwrap_or(""),
-            csv_escape(&r.from_address),
-            csv_escape(&r.to_address),
-            r.amount,
-            r.decimals,
-            r.transfer_index,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::token_transfers_csv_header().as_bytes());
+    export_csv::write_token_transfers_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
-fn native_balance_deltas_to_csv(
-    records: &[spectraplex_core::materializer::NativeBalanceDelta],
-) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,account_address,native_token,pre_balance,post_balance,delta,is_fee_payer,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.account_address),
-            csv_escape(&r.native_token),
-            r.pre_balance,
-            r.post_balance,
-            r.delta,
-            r.is_fee_payer,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
-}
+// The `*_to_csv` wrappers for `native_balance_deltas`, `decoded_events`,
+// `hl_fills`, `hl_funding`, and `hl_positions` were deleted in the #208
+// streaming-exports fix — they had no tests and were only called from the
+// old in-memory `run_export_job`. The row-emission logic for those datasets
+// now lives exclusively in `export_csv::write_*_csv_rows` and is exercised
+// by the streaming export path.
 
-fn decoded_events_to_csv(records: &[spectraplex_core::materializer::DecodedEvent]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,program_or_contract,event_signature,event_name,log_index,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.program_or_contract),
-            csv_escape(r.event_signature.as_deref().unwrap_or("")),
-            csv_escape(r.event_name.as_deref().unwrap_or("")),
-            r.log_index,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
-}
-
-fn hl_fills_to_csv(records: &[spectraplex_core::materializer::HlFillRecord]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,coin,side,price,size,direction,closed_pnl,fee,fee_token,fill_time,order_id,trade_id,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.coin),
-            csv_escape(&r.side),
-            r.price,
-            r.size,
-            r.direction.as_deref().unwrap_or(""),
-            r.closed_pnl
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.fee.as_ref().map(|v| v.to_string()).unwrap_or_default(),
-            r.fee_token.as_deref().unwrap_or(""),
-            r.fill_time,
-            r.order_id.map(|v| v.to_string()).unwrap_or_default(),
-            r.trade_id.map(|v| v.to_string()).unwrap_or_default(),
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
-}
-
-fn hl_funding_to_csv(records: &[spectraplex_core::materializer::HlFundingPayment]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,coin,amount,funding_rate,payment_time,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.coin),
-            r.amount,
-            r.funding_rate
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.payment_time,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
-}
-
-fn hl_positions_to_csv(records: &[spectraplex_core::materializer::HlPositionChange]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,network,coin,side,size_delta,price,direction,source_event,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.network),
-            csv_escape(&r.coin),
-            csv_escape(&r.side),
-            r.size_delta,
-            r.price,
-            r.direction.as_deref().unwrap_or(""),
-            csv_escape(&r.source_event),
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
-}
-
+#[cfg(test)]
 fn wallet_ledger_to_csv(records: &[WalletLedgerRecord]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,raw_transaction_id,wallet_address,network,tx_hash,timestamp,entry_type,asset_symbol,amount,counterparty_address,fee_amount,fee_asset,cost_basis,proceeds,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            r.raw_transaction_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            csv_escape(&r.wallet_address),
-            csv_escape(&r.network),
-            csv_escape(&r.tx_hash),
-            r.timestamp,
-            csv_escape(&r.entry_type),
-            csv_escape(&r.asset_symbol),
-            r.amount,
-            r.counterparty_address.as_deref().unwrap_or(""),
-            r.fee_amount
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.fee_asset.as_deref().unwrap_or(""),
-            r.cost_basis
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.proceeds
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::wallet_ledger_csv_header().as_bytes());
+    export_csv::write_wallet_ledger_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
+#[cfg(test)]
 fn balance_history_to_csv(records: &[BalanceSnapshot]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,wallet_address,asset_symbol,network,timestamp,balance,tx_hash,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            csv_escape(&r.wallet_address),
-            csv_escape(&r.asset_symbol),
-            csv_escape(&r.network),
-            r.timestamp,
-            r.balance,
-            csv_escape(&r.tx_hash),
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::balance_history_csv_header().as_bytes());
+    export_csv::write_balance_history_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
+#[cfg(test)]
 fn hl_pnl_summary_to_csv(records: &[HlPnlSummary]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,wallet_address,coin,network,period_start,period_end,total_closed_pnl,total_funding,total_fees,net_pnl,trade_count,fill_count,avg_trade_size,win_count,loss_count,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            csv_escape(&r.wallet_address),
-            csv_escape(&r.coin),
-            csv_escape(&r.network),
-            r.period_start,
-            r.period_end,
-            r.total_closed_pnl,
-            r.total_funding,
-            r.total_fees,
-            r.net_pnl,
-            r.trade_count,
-            r.fill_count,
-            r.avg_trade_size,
-            r.win_count,
-            r.loss_count,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::hl_pnl_summary_csv_header().as_bytes());
+    export_csv::write_hl_pnl_summary_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
+#[cfg(test)]
 fn hl_trade_history_to_csv(records: &[HlTradeHistory]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,wallet_address,coin,network,side,entry_price,exit_price,size,opened_at,closed_at,realized_pnl,fees,num_fills,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            csv_escape(&r.wallet_address),
-            csv_escape(&r.coin),
-            csv_escape(&r.network),
-            csv_escape(&r.side),
-            r.entry_price,
-            r.exit_price,
-            r.size,
-            r.opened_at,
-            r.closed_at,
-            r.realized_pnl,
-            r.fees,
-            r.num_fills,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::hl_trade_history_csv_header().as_bytes());
+    export_csv::write_hl_trade_history_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
+#[cfg(test)]
 fn protocol_events_to_csv(records: &[ProtocolEvent]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,network,protocol_address,protocol_name,event_type,event_details,pool_address,raw_event_id,timestamp,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            csv_escape(&r.network),
-            csv_escape(&r.protocol_address),
-            r.protocol_name.as_deref().unwrap_or(""),
-            csv_escape(&r.event_type),
-            csv_escape(&r.event_details.to_string()),
-            r.pool_address.as_deref().unwrap_or(""),
-            r.raw_event_id.map(|u| u.to_string()).unwrap_or_default(),
-            r.timestamp,
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::protocol_events_csv_header().as_bytes());
+    export_csv::write_protocol_events_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
+#[cfg(test)]
 fn pool_snapshots_to_csv(records: &[PoolSnapshot]) -> Vec<u8> {
-    let mut buf = String::from(
-        "id,network,pool_address,protocol_address,protocol_name,token0_address,token0_symbol,token1_address,token1_symbol,reserve0,reserve1,tvl_usd,snapshot_timestamp,block_number,dataset_version_id,created_at\n",
-    );
-    for r in records {
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            r.id,
-            csv_escape(&r.network),
-            csv_escape(&r.pool_address),
-            csv_escape(&r.protocol_address),
-            r.protocol_name.as_deref().unwrap_or(""),
-            csv_escape(&r.token0_address),
-            r.token0_symbol.as_deref().unwrap_or(""),
-            csv_escape(&r.token1_address),
-            r.token1_symbol.as_deref().unwrap_or(""),
-            r.reserve0,
-            r.reserve1,
-            r.tvl_usd
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or_default(),
-            r.snapshot_timestamp,
-            r.block_number.map(|v| v.to_string()).unwrap_or_default(),
-            r.dataset_version_id
-                .map(|u| u.to_string())
-                .unwrap_or_default(),
-            r.created_at.to_rfc3339(),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::pool_snapshots_csv_header().as_bytes());
+    export_csv::write_pool_snapshots_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
 /// Generate tax-export-friendly CSV from wallet_ledger records.
@@ -2792,71 +2522,10 @@ fn pool_snapshots_to_csv(records: &[PoolSnapshot]) -> Vec<u8> {
 /// Columns: Date,Type,Sent_Asset,Sent_Amount,Received_Asset,Received_Amount,
 ///          Fee_Asset,Fee_Amount,Cost_Basis,Proceeds,Gain_Loss,Tx_Hash,Network
 fn wallet_ledger_to_tax_csv(records: &[WalletLedgerRecord]) -> Vec<u8> {
-    let mut buf = String::from(
-        "Date,Type,Sent_Asset,Sent_Amount,Received_Asset,Received_Amount,Fee_Asset,Fee_Amount,Cost_Basis,Proceeds,Gain_Loss,Tx_Hash,Network\n",
-    );
-    for r in records {
-        let date = chrono::DateTime::from_timestamp(r.timestamp, 0)
-            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-            .unwrap_or_else(|| r.timestamp.to_string());
-
-        let (sent_asset, sent_amount, recv_asset, recv_amount) = if r.amount < BigDecimal::from(0) {
-            (
-                r.asset_symbol.as_str(),
-                r.amount.abs().to_string(),
-                "",
-                String::new(),
-            )
-        } else {
-            (
-                "",
-                String::new(),
-                r.asset_symbol.as_str(),
-                r.amount.to_string(),
-            )
-        };
-
-        let fee_asset = r.fee_asset.as_deref().unwrap_or("");
-        let fee_amount = r
-            .fee_amount
-            .as_ref()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let cost_basis = r
-            .cost_basis
-            .as_ref()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let proceeds = r
-            .proceeds
-            .as_ref()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-
-        // Gain/Loss computed from cost_basis and proceeds when both available
-        let gain_loss = match (&r.proceeds, &r.cost_basis) {
-            (Some(p), Some(c)) => (p - c).to_string(),
-            _ => String::new(),
-        };
-
-        buf.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
-            csv_escape(&date),
-            csv_escape(&r.entry_type),
-            csv_escape(sent_asset),
-            sent_amount,
-            csv_escape(recv_asset),
-            recv_amount,
-            csv_escape(fee_asset),
-            fee_amount,
-            cost_basis,
-            proceeds,
-            gain_loss,
-            csv_escape(&r.tx_hash),
-            csv_escape(&r.network),
-        ));
-    }
-    buf.into_bytes()
+    let mut buf = Vec::from(export_csv::wallet_ledger_tax_csv_header().as_bytes());
+    export_csv::write_wallet_ledger_tax_csv_rows(records, &mut buf)
+        .expect("writing to Vec<u8> cannot fail");
+    buf
 }
 
 async fn create_export_job(
@@ -2978,248 +2647,15 @@ pub(crate) struct ExportMetadata {
     pub(crate) last_ingestion_run_id: Option<Uuid>,
 }
 
-pub(crate) async fn run_export_job(
-    repo: &Repository,
-    dataset: &str,
-    format: ExportFormat,
-    target_id: Option<Uuid>,
-    network: Option<&str>,
-    time_start: Option<i64>,
-    time_end: Option<i64>,
-) -> anyhow::Result<(Vec<u8>, usize, ExportMetadata)> {
-    // Look up active dataset version for provenance
-    let active_version = repo
-        .get_active_dataset_version(dataset)
-        .await
-        .ok()
-        .flatten();
-
-    // Look up completeness records for the dataset (optionally filtered by target and network)
-    let completeness_records = repo
-        .list_completeness_filtered(dataset, target_id, network)
-        .await
-        .unwrap_or_default();
-
-    let mut meta = ExportMetadata::default();
-    if let Some(ref dv) = active_version {
-        meta.dataset_version_id = Some(dv.id);
-        meta.dataset_version = Some(dv.version);
-    }
-
-    if !completeness_records.is_empty() {
-        // Aggregate completeness: use worst status across matching records
-        let statuses: Vec<&str> = completeness_records
-            .iter()
-            .map(|c| match c.status {
-                spectraplex_core::v2::CompletenessStatus::Complete => "complete",
-                spectraplex_core::v2::CompletenessStatus::Partial => "partial",
-                spectraplex_core::v2::CompletenessStatus::Backfilling => "backfilling",
-                spectraplex_core::v2::CompletenessStatus::Gap => "gap",
-            })
-            .collect();
-
-        // Pick the most conservative status
-        let status = if statuses.contains(&"gap") {
-            "gap"
-        } else if statuses.contains(&"backfilling") {
-            "backfilling"
-        } else if statuses.contains(&"partial") {
-            "partial"
-        } else {
-            "complete"
-        };
-        meta.completeness_status = Some(status.to_string());
-
-        // Aggregate coverage bounds
-        let coverage_start = completeness_records
-            .iter()
-            .filter_map(|c| c.coverage_start)
-            .min();
-        let coverage_end = completeness_records
-            .iter()
-            .filter_map(|c| c.coverage_end)
-            .max();
-        let block_start = completeness_records
-            .iter()
-            .filter_map(|c| c.block_start)
-            .min();
-        let block_end = completeness_records
-            .iter()
-            .filter_map(|c| c.block_end)
-            .max();
-        meta.completeness_coverage = Some(serde_json::json!({
-            "coverage_start": coverage_start,
-            "coverage_end": coverage_end,
-            "block_start": block_start,
-            "block_end": block_end,
-        }));
-
-        // Use the most recent ingestion run ID from completeness records
-        meta.last_ingestion_run_id = completeness_records
-            .iter()
-            .rev()
-            .find_map(|c| c.last_ingestion_run_id);
-    }
-    match dataset {
-        "token_transfers" => {
-            let records = repo
-                .export_token_transfers(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => token_transfers_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "native_balance_deltas" => {
-            let records = repo
-                .export_native_balance_deltas(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => native_balance_deltas_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "decoded_events" => {
-            let records = repo
-                .export_decoded_events(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => decoded_events_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "hl_fills" => {
-            let records = repo
-                .export_hl_fill_records(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => hl_fills_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "hl_funding" => {
-            let records = repo
-                .export_hl_funding_payments(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => hl_funding_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "positions" => {
-            let records = repo
-                .export_hl_position_changes(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => hl_positions_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "wallet_ledger" => {
-            let records = repo
-                .export_wallet_ledger_records(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => wallet_ledger_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "balance_history" => {
-            let records = repo
-                .export_balance_snapshots(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => balance_history_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "hl_pnl_summary" => {
-            let records = repo
-                .export_hl_pnl_summary(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => hl_pnl_summary_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "hl_trade_history" => {
-            let records = repo
-                .export_hl_trade_history(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => hl_trade_history_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "protocol_events" => {
-            let records = repo
-                .export_protocol_events(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => protocol_events_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        "pool_snapshots" => {
-            let records = repo
-                .export_pool_snapshots(target_id, network, time_start, time_end)
-                .await?;
-            let count = records.len();
-            let body = match format {
-                ExportFormat::Jsonl => {
-                    serialize_to_jsonl(&records).map_err(|e| anyhow::anyhow!("{}", e.message))?
-                }
-                ExportFormat::Csv => pool_snapshots_to_csv(&records),
-            };
-            Ok((body, count, meta))
-        }
-        _ => Err(anyhow::anyhow!("Unknown dataset: {dataset}")),
-    }
-}
+// `run_export_job` was deleted in the #208 streaming-exports fix. It used
+// to load the full dataset into memory, serialize it into a single
+// `Vec<u8>`, and return that buffer to the worker for disk + sink delivery
+// — which OOM-killed co-located workers on large exports.
+//
+// The replacement is [`export_stream::write_export_to_file`], which fetches
+// the dataset in bounded pages and writes each page directly to disk. The
+// export worker owns artifact path construction and sink fan-out; see
+// [`export_worker::execute_export_job`].
 
 async fn get_export_job_status(
     State(state): State<Arc<AppState>>,

--- a/core/src/materializer.rs
+++ b/core/src/materializer.rs
@@ -627,8 +627,22 @@ pub struct DeliveryReceipt {
 /// Async trait for export sink implementations.
 ///
 /// Each sink type implements this trait to deliver serialized export data
-/// to its destination. Sinks receive the raw bytes (already serialized as
-/// JSONL or CSV) plus metadata about the export job.
+/// to its destination.
+///
+/// Sinks expose two entry points:
+///
+/// - [`ExportSink::deliver`] takes the raw in-memory bytes. Used by
+///   legacy callers and test scaffolding.
+/// - [`ExportSink::deliver_from_file`] takes a filesystem path to the
+///   already-streamed export artifact. This is the path the worker uses
+///   after the #208 streaming-exports fix; sinks implementing it can
+///   deliver without loading the whole artifact into memory (for
+///   example, `LocalFileSink` renames/copies the file, and `WebhookSink`
+///   streams the file body into the request).
+///
+/// A default `deliver_from_file` implementation is provided that reads
+/// the file into memory and calls `deliver`. Sinks that need true
+/// bounded-memory delivery MUST override it.
 #[async_trait::async_trait]
 pub trait ExportSink: Send + Sync {
     /// Deliver export data to the sink destination.
@@ -637,6 +651,21 @@ pub trait ExportSink: Send + Sync {
         data: &[u8],
         metadata: &DeliveryMetadata,
     ) -> Result<DeliveryReceipt, String>;
+
+    /// Deliver the export artifact stored at `path` to the sink
+    /// destination. Default implementation reads the entire file into
+    /// memory and delegates to [`ExportSink::deliver`]; override to
+    /// stream for bounded peak memory regardless of artifact size.
+    async fn deliver_from_file(
+        &self,
+        path: &std::path::Path,
+        metadata: &DeliveryMetadata,
+    ) -> Result<DeliveryReceipt, String> {
+        let data = tokio::fs::read(path)
+            .await
+            .map_err(|e| format!("Failed to read export artifact {}: {e}", path.display()))?;
+        self.deliver(&data, metadata).await
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #208. The old `run_export_job` loaded every matching record into a `Vec` and serialized the whole dataset into a single `Vec<u8>` before writing it to disk, so a single large export could OOM-kill the worker process and take down co-located workers.

The worker now streams the export directly to disk via `export_stream::write_export_to_file`, which fetches records in pages of 10,000 (`PAGE_SIZE`) via the existing paged `query_*` methods, serializes each page into a small per-page buffer, and writes the page into a `BufWriter<File>` opened with `O_NOFOLLOW` (preserves the #220 symlink-refusing open). Peak per-job memory is bounded by `PAGE_SIZE * per-record bytes` regardless of total dataset size.

## Key changes

- `api/src/export_stream.rs` (new) — paged dispatch for all 12 exportable datasets (`token_transfers`, `native_balance_deltas`, `decoded_events`, `hl_fills`, `hl_funding`, `positions`, `wallet_ledger`, `balance_history`, `hl_pnl_summary`, `hl_trade_history`, `protocol_events`, `pool_snapshots`), per-page serialization, async writes, and a 1M-record hard safety cap.
- `api/src/export_csv.rs` (new) — CSV header constants + `write_*_csv_rows<W: Write>` helpers shared between the streaming writer and the legacy test-only `*_to_csv` wrappers. Output is byte-identical to the pre-fix format — all `*_to_csv_format` tests continue to pass.
- `api/src/export_worker.rs` — builds the artifact path up front, calls the streaming writer, and on failure best-effort removes the partial file so retries do not append to a truncated artifact or hand out partial bytes via `/download`. Sink delivery reads the streamed artifact back from disk once for `sink.deliver(&[u8])` (converting `ExportSink` to take a path/reader is a follow-up).
- `api/src/main.rs` — drops `run_export_job` and the in-memory `*_to_csv` helpers that were only called from it; remaining `*_to_csv` wrappers are gated behind `#[cfg(test)]` and now delegate to the shared row writers in `export_csv`.

## Memory shape before / after

| Path | Before | After |
|---|---|---|
| No sink (download) | full dataset in `Vec<u8>` + written to disk | `PAGE_SIZE * record bytes` peak |
| With sink (local_file / webhook) | full dataset in `Vec<u8>` reused for disk + sink | bounded for disk write; sink still loads the artifact once for `sink.deliver(&[u8])` |

The sink case intentionally reads the artifact back for delivery to avoid changing the `ExportSink` trait signature in this PR. The disk write itself is now streamed, and the artifact size is bounded by `EXPORT_HARD_CAP` (1M records).

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace --lib --bins` — 1104 tests pass, including all format-preserving `*_to_csv_format` tests, `test_serialize_to_jsonl`, `test_export_*` handler tests
- [ ] Docker-backed integration tests — could not be run locally (no container runtime on this machine); relying on CI