### PR TITLE
fix: resolve RUSTSEC-2026-0097 rand advisory (closes #236, closes #237)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,6 +15,24 @@ ignore = [
     # keccak 0.1.5 (via solana-zk-sdk/merlin/sha3): unsound ARMv8 assembly.
     # Transitive dependency pinned by solana-zk-sdk; cannot upgrade independently.
     "RUSTSEC-2026-0012",
+
+    # rand 0.8.5 (via alloy-signer-local, governor, solana-*): unsound when a
+    # CUSTOM `log::Log` implementation calls `rand::rng()` / ThreadRng methods
+    # and triggers a reseed mid-log. Affects rand `>= 0.7, < 0.9.3`; fix is
+    # rand 0.9.3+, which is a major-version bump the transitive deps above
+    # have not yet taken.
+    #
+    # Not exploitable in this workspace:
+    # - We do not implement `log::Log`. We use `tracing_subscriber::fmt` (a
+    #   tracing Layer, not a `log::Log` impl).
+    # - No code in this repo calls `rand::rng()` or `rand::thread_rng()` from
+    #   inside a logger. Transitive crates that use `rand` do so outside of
+    #   logging paths (key generation, jitter, QUIC connection IDs, etc.).
+    # Revisit when alloy / governor / solana-* bump past rand 0.9.3.
+    #
+    # We also run `cargo update -p rand` to keep the rand 0.9.x line on the
+    # latest 0.9.x (currently 0.9.4, past the advisory cutoff of 0.9.3).
+    "RUSTSEC-2026-0097",
 ]
 
 [yanked]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -786,7 +786,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2242,7 +2242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2285,7 +2285,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher 1.0.1",
 ]
 
@@ -3580,7 +3580,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4159,7 +4159,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4303,15 +4303,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4373,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4670,7 +4670,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4739,7 +4739,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4797,7 +4797,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4808,9 +4808,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7732,7 +7732,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8262,7 +8262,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -8669,7 +8669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/adapters/src/hl_analytics.rs
+++ b/adapters/src/hl_analytics.rs
@@ -247,7 +247,7 @@ pub fn build_trade_history(
         }
     }
 
-    trades.sort_by(|a, b| a.closed_at.cmp(&b.closed_at));
+    trades.sort_by_key(|t| t.closed_at);
     trades
 }
 

--- a/adapters/src/ledger_derivation.rs
+++ b/adapters/src/ledger_derivation.rs
@@ -907,7 +907,7 @@ pub fn build_forensics_activity(
             networks: agg.networks.into_iter().collect(),
         })
         .collect();
-    top_counterparties.sort_by(|a, b| b.interaction_count.cmp(&a.interaction_count));
+    top_counterparties.sort_by_key(|c| std::cmp::Reverse(c.interaction_count));
     top_counterparties.truncate(20);
 
     // Network activity


### PR DESCRIPTION
## Summary

Closes #236 and closes #237 (both filed for [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097)).

The advisory flags rand `>= 0.7, < 0.9.3` as unsound when a **custom `log::Log` implementation** calls `rand::rng()` / `ThreadRng` methods and triggers a reseed mid-log. This workspace:

- does **not** implement `log::Log` (we use `tracing_subscriber::fmt`, a tracing `Layer`, not a logger impl), and
- never calls `rand::rng()` / `rand::thread_rng()` from inside a logger.

So the unsoundness pattern is not reachable from our code. The transitive crates that pull in `rand` (`alloy-signer-local`, `governor`, `solana-*`, `quinn-proto`) use it for key generation, jitter, QUIC connection IDs, etc. — all outside logging paths.

## Changes

- **`.cargo/audit.toml`** — ignore `RUSTSEC-2026-0097` with a written justification covering (a) why we are not exploitable and (b) when to revisit (alloy / governor / solana-* bumping past rand 0.9.3). Sits alongside the existing ignores for `RUSTSEC-2023-0071` / `-2026-0009` / `-2026-0012`, which were added for the same "transitive, can't upgrade" reason.
- **`Cargo.lock`** — `cargo update -p rand@0.9.2` bumps the `rand` 0.9.x line from 0.9.2 to 0.9.4 (past the advisory's 0.9.3 cutoff). The `rand` 0.8.x line stays on 0.8.5 because it is pinned transitively and 0.8 → 0.9 is a major-version bump the upstream transitive deps have not yet taken.
- **`Cargo.lock`** — `cargo update -p quinn-proto -p rustls-webpki` also picks up:
  - `RUSTSEC-2026-0037` (quinn-proto 0.11.13 → 0.11.14 DoS fix)
  - `RUSTSEC-2026-0098` / `RUSTSEC-2026-0099` (rustls-webpki 0.103.10 → 0.103.12 name-constraints fix)

  Those weren't in the original `RUSTSEC-2026-0097` issues but were also failing the scheduled Security Audit run, and they're safe pure-lockfile picks so I rolled them into the same PR.

## Verification

- `cargo audit` — 0 vulnerabilities after this change. The 3 remaining allowed warnings (`bincode`, `derivative`, `paste` unmaintained-crate warnings) are pre-existing and unrelated.
- `cargo check --workspace --all-targets` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --all --check` clean.
- `cargo test --workspace --lib --bins` — 1104 tests pass.
- Docker-backed integration tests could not be run locally (no container runtime on this machine); relying on CI.

## Test plan

- [ ] CI passes (fmt, clippy, tests, release build)
- [ ] Scheduled Security Audit workflow passes on next run (or on the Cargo.lock-triggered run in this PR)