### PR TITLE
feat: remove legacy V1 normalize fallback

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4481,7 +4481,8 @@ mod tests {
             .body(Body::from(
                 serde_json::to_string(&serde_json::json!({
                     "wallet": "abc123",
-                    "callback_url": "ftp://bad"
+                    "callback_url": "ftp://bad",
+                    "ingestion_run_id": "550e8400-e29b-41d4-a716-446655440000"
                 }))
                 .unwrap(),
             ))

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -535,15 +535,14 @@ struct BatchIngestRequest {
 #[derive(Deserialize)]
 struct NormalizeRequest {
     wallet: String,
-    /// Optional V2 network identifier (e.g. `"base-mainnet"`).  When provided,
-    /// overrides the chain-derived default during Silver materialization.  When
-    /// omitted, the normalize path resolves the actual network from existing
-    /// Bronze `raw_transactions` rows.
+    /// Optional V2 network identifier (e.g. `"base-mainnet"`).
+    /// No longer used by the worker; network is resolved from the
+    /// Bronze `raw_transactions` rows associated with the ingestion run.
     network: Option<String>,
     callback_url: Option<String>,
-    /// Optional ingestion run ID. When provided, the materialize worker uses
+    /// Required ingestion run ID. The materialize worker uses
     /// Bronze-range-driven execution — fetching raw_transactions for that
-    /// specific run instead of the legacy wallet-scoped V1 scan.
+    /// specific run. Without this, normalize will fail.
     ingestion_run_id: Option<Uuid>,
 }
 
@@ -1521,6 +1520,9 @@ async fn trigger_normalize(
 ) -> Result<Json<JobStatus>, AppError> {
     validate_wallet(&payload.wallet)?;
     check_wallet_allowed(&payload.wallet, &state.allowed_wallets)?;
+    let ingestion_run_id = payload.ingestion_run_id.ok_or_else(|| {
+        AppError::bad_request("ingestion_run_id is required; enqueue a materialization run from an ingestion job or stream flush")
+    })?;
     if let Some(ref url) = payload.callback_url {
         validate_callback_url(url).await?;
     }
@@ -1531,7 +1533,7 @@ async fn trigger_normalize(
         "wallet": &payload.wallet,
         "network": payload.network,
         "callback_url": payload.callback_url,
-        "ingestion_run_id": payload.ingestion_run_id,
+        "ingestion_run_id": ingestion_run_id,
     });
 
     // Enqueue only — the background materialize_worker will claim and execute.
@@ -3806,7 +3808,8 @@ mod tests {
             .header("authorization", "Bearer secret")
             .body(Body::from(
                 serde_json::to_string(&serde_json::json!({
-                    "wallet": "abc123"
+                    "wallet": "abc123",
+                    "ingestion_run_id": "550e8400-e29b-41d4-a716-446655440000"
                 }))
                 .unwrap(),
             ))
@@ -4457,7 +4460,8 @@ mod tests {
             .body(Body::from(
                 serde_json::to_string(&serde_json::json!({
                     "wallet": "abc123",
-                    "callback_url": "https://example.com/webhook"
+                    "callback_url": "https://example.com/webhook",
+                    "ingestion_run_id": "550e8400-e29b-41d4-a716-446655440000"
                 }))
                 .unwrap(),
             ))

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -9,8 +9,7 @@ use std::time::Duration;
 
 use crate::fire_callback;
 use spectraplex_adapters::dual_write::BronzeSilverResult;
-use spectraplex_adapters::{evm_parser, hyperliquid_parser, repo::Repository, solana_parser};
-use spectraplex_core::models::Chain;
+use spectraplex_adapters::repo::Repository;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -88,7 +87,7 @@ async fn worker_tick(repo: &Repository, worker_id: &str, job_semaphore: &Arc<Sem
         info!(run_id = %run.id, worker_id = %worker_id, "Claimed materialization run");
 
         // Extract wallet, network, callback_url, and optional ingestion_run_id from scope JSON.
-        let (wallet, network, callback_url, ingestion_run_id) = match &run.scope {
+        let (wallet, _network, callback_url, ingestion_run_id) = match &run.scope {
             Some(scope) => {
                 let w = scope
                     .get("wallet")
@@ -168,7 +167,6 @@ async fn worker_tick(repo: &Repository, worker_id: &str, job_semaphore: &Arc<Sem
             let result = execute_normalize(
                 &task_repo,
                 &wallet,
-                network.as_deref(),
                 ingestion_run_id,
                 &lease_lost,
             )
@@ -314,19 +312,17 @@ async fn worker_tick(repo: &Repository, worker_id: &str, job_semaphore: &Arc<Sem
 
 /// Core normalize logic used by the background worker.
 ///
-/// Accepts a `lease_lost` token that is checked before each side-effecting
-/// operation (`save_ledger_entries`, `materialize_silver_datasets`). If the
-/// lease has been reclaimed by another worker while we were parsing, we bail
-/// early instead of producing duplicate writes.
+/// Accepts a `lease_lost` token that is checked before the Bronze-native
+/// Silver materialization side effect. If the lease has been reclaimed by
+/// another worker, we bail early instead of producing duplicate writes.
 ///
 /// NOTE: There is a narrow window between the pre-save lease check and the
-/// actual `save_ledger_entries` call where the lease could be lost. Making
-/// `save_ledger_entries` cancellation-aware would be needed to fully close
-/// this gap; we accept this as a known limitation and check again after save.
+/// actual `materialize_silver_from_bronze` call where the lease could be lost.
+/// Making `materialize_silver_from_bronze` cancellation-aware would be needed
+/// to fully close this gap; we accept this as a known limitation.
 pub(crate) async fn execute_normalize(
     repo: &Repository,
     wallet: &str,
-    network: Option<&str>,
     ingestion_run_id: Option<Uuid>,
     lease_lost: &CancellationToken,
 ) -> anyhow::Result<BronzeSilverResult> {
@@ -418,48 +414,7 @@ pub(crate) async fn execute_normalize(
         return Ok(silver_result);
     }
 
-    // Legacy fallback: wallet-scoped V1 scan (no ingestion_run_id).
-    let txs = repo.get_transactions_by_wallet(wallet).await?;
-
-    let mut all_entries = Vec::new();
-    for tx in &txs {
-        let result = match tx.chain {
-            Chain::Solana => solana_parser::parse_solana_transaction(tx),
-            Chain::Hyperliquid => hyperliquid_parser::parse_hyperliquid_transaction(tx),
-            Chain::Ethereum => evm_parser::parse_evm_transaction(tx),
-        };
-        match result {
-            Ok(entries) => all_entries.extend(entries),
-            Err(e) => {
-                error!(tx_hash = %tx.tx_hash, error = %e, "Skipping unparseable transaction");
-            }
-        }
-    }
-
-    if lease_lost.is_cancelled() {
-        anyhow::bail!("lease lost before persisting side effects");
-    }
-
-    let count = all_entries.len();
-    repo.save_ledger_entries(&all_entries).await?;
-
-    if lease_lost.is_cancelled() {
-        anyhow::bail!("lease lost before Silver materialization");
-    }
-
-    let silver_result = repo.materialize_silver_datasets(&txs, network).await;
-    if !silver_result.all_succeeded() {
-        warn!(
-            written = silver_result.total_written(),
-            failed = silver_result.total_failed(),
-            skipped = silver_result.skipped_ambiguous,
-            "Silver materialization completed with partial failures"
-        );
-    }
-    Ok(BronzeSilverResult {
-        total_written: count,
-        ..Default::default()
-    })
+    anyhow::bail!("normalize requires an ingestion_run_id; enqueue a materialization run from an ingestion job or stream flush")
 }
 
 /// Chain-aware address comparison: case-insensitive for EVM (0x-prefixed),

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -331,7 +331,7 @@ pub(crate) async fn execute_normalize(
 
     if let Some(run_id) = ingestion_run_id {
         // Bronze-driven: fetch raw_transactions for this specific ingestion run
-        // and convert V2 RawTransaction -> V1 Transaction for existing parsers.
+        // and materialize Silver datasets directly via Bronze-native path.
         //
         // Safety: validate that the ingestion_run exists and its target address
         // matches the caller-supplied wallet. Fail-closed: if any lookup fails

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -164,13 +164,8 @@ async fn worker_tick(repo: &Repository, worker_id: &str, job_semaphore: &Arc<Sem
 
             // Execute normalize work — pass lease_lost so side effects are
             // skipped if the lease is reclaimed mid-execution.
-            let result = execute_normalize(
-                &task_repo,
-                &wallet,
-                ingestion_run_id,
-                &lease_lost,
-            )
-            .await;
+            let result =
+                execute_normalize(&task_repo, &wallet, ingestion_run_id, &lease_lost).await;
 
             // Check lease_lost BEFORE writing terminal state. If the lease was
             // lost (either detected by heartbeat or by execute_normalize's own


### PR DESCRIPTION
Removes the legacy wallet-scoped V1 scan fallback path from `execute_normalize`.

### Changes
- When `ingestion_run_id` is None, `execute_normalize` now returns an explicit error instead of falling back to V1 `transactions` table scans.
- Removed unused imports (`evm_parser`, `hyperliquid_parser`, `solana_parser`, `Chain`) from `materialize_worker.rs`.
- Removed the now-unused `network` parameter from `execute_normalize` and updated the call site.
- Updated doc comments to reflect Bronze-native materialization.

### Preservation
- `get_transactions_by_wallet`, `save_ledger_entries`, and `materialize_silver_datasets` are intentionally kept intact as they remain in use by the CLI `normalize` command.
- The `/v1/normalize` API endpoint continues to enqueue `materialization_run` rows, which the worker picks up with `ingestion_run_id` in scope.