### PR TITLE
feat: per-user/tenant isolation at the query layer (#216)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7056,6 +7056,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "spectraplex-adapters",
  "spectraplex-core",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,9 +4810,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/adapters/src/dual_write.rs
+++ b/adapters/src/dual_write.rs
@@ -500,7 +500,7 @@ impl Repository {
     ) -> anyhow::Result<IndexTarget> {
         // Check if target already exists
         if let Some(existing) = self
-            .get_index_target_by_address(TargetKind::Wallet, network, wallet_address)
+            .get_index_target_by_address(TargetKind::Wallet, network, wallet_address, owner_id)
             .await?
         {
             return Ok(existing);
@@ -912,7 +912,7 @@ impl Repository {
             for ((network, wallet_address), group_txs) in &wallet_groups {
                 // Look up or create the IndexTarget for this wallet.
                 let target = match self
-                    .get_index_target_by_address(TargetKind::Wallet, network, wallet_address)
+                    .get_index_target_by_address(TargetKind::Wallet, network, wallet_address, None)
                     .await
                 {
                     Ok(Some(t)) => t,
@@ -1570,7 +1570,7 @@ impl Repository {
                 }
                 for (network, group) in &net_groups {
                     let target_id = match self
-                        .get_index_target_by_address(TargetKind::Wallet, network, wallet)
+                        .get_index_target_by_address(TargetKind::Wallet, network, wallet, None)
                         .await
                     {
                         Ok(Some(t)) => t.id,
@@ -2291,7 +2291,7 @@ impl Repository {
 
             // Look up the target for this wallet.
             let target_id = match self
-                .get_index_target_by_address(TargetKind::Wallet, network, wallet_address)
+                .get_index_target_by_address(TargetKind::Wallet, network, wallet_address, None)
                 .await
             {
                 Ok(Some(target)) => target.id,

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -4685,7 +4685,7 @@ impl Repository {
              delivery_destination, error_message, \
              dataset_version_id, dataset_version, completeness_status, \
              completeness_coverage, last_ingestion_run_id, \
-             created_at, updated_at, started_at, completed_at, heartbeat_at \
+             created_at, updated_at, started_at, completed_at, heartbeat_at, owner_id \
              FROM export_jobs WHERE id = $1",
         )
         .bind(job_id)
@@ -4788,7 +4788,7 @@ impl Repository {
              delivery_destination, error_message, \
              dataset_version_id, dataset_version, completeness_status, \
              completeness_coverage, last_ingestion_run_id, \
-             created_at, updated_at, started_at, completed_at, heartbeat_at \
+             created_at, updated_at, started_at, completed_at, heartbeat_at, owner_id \
              FROM export_jobs WHERE id = $1",
         )
         .bind(id)

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -20,7 +20,7 @@ use spectraplex_core::materializer::{
     ProtocolEvent, TokenTransfer, WalletLedgerRecord,
 };
 use spectraplex_core::v2::{
-    ChainFamily, Checkpoint, CompletenessStatus, DatasetCompleteness, DatasetVersion,
+    ApiKey, ChainFamily, Checkpoint, CompletenessStatus, DatasetCompleteness, DatasetVersion,
     DatasetVersionStatus, DatasetWatermark, EvmTraceType, ExportJob, ExportJobStatus, IndexTarget,
     IngestionJob, IngestionJobMode, IngestionJobStatus, IngestionRun, MaterializationRun,
     MaterializationRunStatus, Network, RawEvmTrace, RawTransaction, StreamActualStatus,
@@ -1519,6 +1519,16 @@ fn row_to_export_job(row: &sqlx::postgres::PgRow) -> anyhow::Result<ExportJob> {
         started_at: row.try_get("started_at")?,
         completed_at: row.try_get("completed_at")?,
         heartbeat_at: row.try_get("heartbeat_at")?,
+    })
+}
+fn row_to_api_key(row: &sqlx::postgres::PgRow) -> anyhow::Result<ApiKey> {
+    Ok(ApiKey {
+        id: row.try_get("id")?,
+        key_hash: row.try_get("key_hash")?,
+        name: row.try_get("name")?,
+        owner_id: row.try_get("owner_id")?,
+        created_at: row.try_get("created_at")?,
+        revoked_at: row.try_get("revoked_at")?,
     })
 }
 
@@ -4696,6 +4706,70 @@ impl Repository {
     // -----------------------------------------------------------------------
     // Materialization Runs (Durable Control Plane)
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // API Keys (Tenant Isolation — Issue #216)
+    // -----------------------------------------------------------------------
+
+    /// Insert a new API key. The caller is responsible for hashing the key.
+    pub async fn create_api_key(
+        &self,
+        key_hash: &str,
+        name: Option<&str>,
+        owner_id: Uuid,
+    ) -> anyhow::Result<ApiKey> {
+        let row = sqlx::query(
+            "INSERT INTO api_keys (key_hash, name, owner_id) \
+             VALUES ($1, $2, $3) \
+             RETURNING id, key_hash, name, owner_id, created_at, revoked_at",
+        )
+        .bind(key_hash)
+        .bind(name)
+        .bind(owner_id)
+        .fetch_one(self.pool())
+        .await?;
+        row_to_api_key(&row)
+    }
+
+    /// Validate an API key by its raw hash. Returns `Ok(None)` if the key
+    /// does not exist or has been revoked.
+    pub async fn validate_api_key(&self, key_hash: &str) -> anyhow::Result<Option<ApiKey>> {
+        let row = sqlx::query(
+            "SELECT id, key_hash, name, owner_id, created_at, revoked_at \
+             FROM api_keys \
+             WHERE key_hash = $1 AND revoked_at IS NULL",
+        )
+        .bind(key_hash)
+        .fetch_optional(self.pool())
+        .await?;
+        match row {
+            Some(r) => Ok(Some(row_to_api_key(&r)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Revoke an API key by id.
+    pub async fn revoke_api_key(&self, id: Uuid) -> anyhow::Result<()> {
+        sqlx::query("UPDATE api_keys SET revoked_at = NOW() WHERE id = $1")
+            .bind(id)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    /// List API keys for a given owner (excluding revoked).
+    pub async fn list_api_keys_by_owner(&self, owner_id: Uuid) -> anyhow::Result<Vec<ApiKey>> {
+        let rows = sqlx::query(
+            "SELECT id, key_hash, name, owner_id, created_at, revoked_at \
+             FROM api_keys \
+             WHERE owner_id = $1 AND revoked_at IS NULL \
+             ORDER BY created_at",
+        )
+        .bind(owner_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_api_key).collect()
+    }
 
     /// Create a new materialization run with status=pending.
     pub async fn create_materialization_run(

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -5048,6 +5048,7 @@ impl Repository {
     pub async fn get_wallet_transactions_v2(
         &self,
         wallet: &str,
+        owner_id: Option<Uuid>,
         limit: i64,
         offset: i64,
         from: Option<i64>,
@@ -5068,6 +5069,11 @@ impl Repository {
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         let mut n: usize = 1;
 
+        if let Some(oid) = owner_id {
+            n += 1;
+            sql.push_str(&format!(" AND it.owner_id = ${n}"));
+            args.add(oid).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
         if let Some(start) = from {
             n += 1;
             sql.push_str(&format!(" AND rt.timestamp >= ${n}"));
@@ -5098,19 +5104,33 @@ impl Repository {
         &self,
         wallet: &str,
         tx_hash: &str,
+        owner_id: Option<Uuid>,
     ) -> anyhow::Result<Option<RawTransaction>> {
-        let row = sqlx::query(
+        let mut sql = String::from(
             "SELECT DISTINCT rt.id, rt.network, rt.tx_hash, rt.timestamp, rt.block_number, \
              rt.raw_metadata, rt.source, rt.ingestion_run_id, rt.ingested_at \
              FROM raw_transactions rt \
              JOIN target_matches tm ON tm.raw_transaction_id = rt.id \
              JOIN index_targets it ON it.id = tm.target_id \
              WHERE it.address = $1 AND it.kind = 'wallet' AND rt.tx_hash = $2",
-        )
-        .bind(wallet)
-        .bind(tx_hash)
-        .fetch_optional(self.pool())
-        .await?;
+        );
+        let mut args = sqlx::postgres::PgArguments::default();
+        use sqlx::Arguments;
+        args.add(wallet.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        args.add(tx_hash.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut n: usize = 2;
+
+        if let Some(oid) = owner_id {
+            n += 1;
+            sql.push_str(&format!(" AND it.owner_id = ${n}"));
+            args.add(oid).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+
+        let row = sqlx::query_with(&sql, args)
+            .fetch_optional(self.pool())
+            .await?;
         row.as_ref().map(row_to_raw_transaction).transpose()
     }
 
@@ -5118,11 +5138,27 @@ impl Repository {
     pub async fn get_wallet_ledger_v2(
         &self,
         wallet: &str,
+        owner_id: Option<Uuid>,
         limit: i64,
         offset: i64,
         from: Option<i64>,
         to: Option<i64>,
     ) -> anyhow::Result<Vec<WalletLedgerRecord>> {
+        // Defense-in-depth: reject tenant requests for unowned wallets.
+        // TODO: add owner_id to wallet_ledger for true row-level isolation.
+        if let Some(oid) = owner_id {
+            let owned: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM index_targets WHERE kind = 'wallet' AND address = $1 AND owner_id = $2"
+            )
+            .bind(wallet)
+            .bind(oid)
+            .fetch_one(self.pool())
+            .await?;
+            if owned.0 == 0 {
+                return Ok(vec![]);
+            }
+        }
+
         let limit = limit.min(MAX_QUERY_LIMIT);
         let mut sql = String::from(
             "SELECT id, raw_transaction_id, wallet_address, network, tx_hash, \
@@ -5166,8 +5202,24 @@ impl Repository {
     pub async fn get_wallet_balances_v2(
         &self,
         wallet: &str,
+        owner_id: Option<Uuid>,
         at: Option<i64>,
     ) -> anyhow::Result<Vec<(String, bigdecimal::BigDecimal)>> {
+        // Defense-in-depth: reject tenant requests for unowned wallets.
+        // TODO: add owner_id to wallet_ledger for true row-level isolation.
+        if let Some(oid) = owner_id {
+            let owned: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM index_targets WHERE kind = 'wallet' AND address = $1 AND owner_id = $2"
+            )
+            .bind(wallet)
+            .bind(oid)
+            .fetch_one(self.pool())
+            .await?;
+            if owned.0 == 0 {
+                return Ok(vec![]);
+            }
+        }
+
         let rows = if let Some(at_ts) = at {
             sqlx::query(
                 "SELECT asset_symbol, SUM(amount) as balance \
@@ -5205,11 +5257,37 @@ impl Repository {
     }
 
     /// Get wallet stats from V2 tables (raw_transactions + target_matches + wallet_ledger).
-    pub async fn get_wallet_stats_v2(&self, wallet: &str) -> anyhow::Result<WalletStatsV2> {
+    pub async fn get_wallet_stats_v2(
+        &self,
+        wallet: &str,
+        owner_id: Option<Uuid>,
+    ) -> anyhow::Result<WalletStatsV2> {
         use sqlx::Row;
 
+        // Defense-in-depth: reject tenant requests for unowned wallets.
+        // TODO: add owner_id to wallet_ledger for true row-level isolation.
+        if let Some(oid) = owner_id {
+            let owned: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM index_targets WHERE kind = 'wallet' AND address = $1 AND owner_id = $2"
+            )
+            .bind(wallet)
+            .bind(oid)
+            .fetch_one(self.pool())
+            .await?;
+            if owned.0 == 0 {
+                return Ok(WalletStatsV2 {
+                    tx_count: 0,
+                    earliest_timestamp: None,
+                    latest_timestamp: None,
+                    network_count: 0,
+                    unique_assets: 0,
+                    per_network: vec![],
+                });
+            }
+        }
+
         // Transaction counts from raw_transactions via target_matches
-        let tx_row = sqlx::query(
+        let mut tx_sql = String::from(
             "SELECT COUNT(DISTINCT rt.id) AS tx_count, \
                     MIN(rt.timestamp) AS earliest_timestamp, \
                     MAX(rt.timestamp) AS latest_timestamp, \
@@ -5218,10 +5296,21 @@ impl Repository {
              JOIN target_matches tm ON tm.raw_transaction_id = rt.id \
              JOIN index_targets it ON it.id = tm.target_id \
              WHERE it.address = $1 AND it.kind = 'wallet'",
-        )
-        .bind(wallet)
-        .fetch_one(self.pool())
-        .await?;
+        );
+        let mut tx_args = sqlx::postgres::PgArguments::default();
+        use sqlx::Arguments;
+        tx_args
+            .add(wallet.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut n: usize = 1;
+        if let Some(oid) = owner_id {
+            n += 1;
+            tx_sql.push_str(&format!(" AND it.owner_id = ${n}"));
+            tx_args.add(oid).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        let tx_row = sqlx::query_with(&tx_sql, tx_args)
+            .fetch_one(self.pool())
+            .await?;
 
         let tx_count: i64 = tx_row.try_get("tx_count")?;
         let earliest_timestamp: Option<i64> = tx_row.try_get("earliest_timestamp")?;
@@ -5239,17 +5328,27 @@ impl Repository {
         let unique_assets: i64 = asset_row.try_get("unique_assets")?;
 
         // Per-network counts
-        let net_rows = sqlx::query(
+        let mut net_sql = String::from(
             "SELECT rt.network, COUNT(DISTINCT rt.id) AS count \
              FROM raw_transactions rt \
              JOIN target_matches tm ON tm.raw_transaction_id = rt.id \
              JOIN index_targets it ON it.id = tm.target_id \
-             WHERE it.address = $1 AND it.kind = 'wallet' \
-             GROUP BY rt.network ORDER BY rt.network",
-        )
-        .bind(wallet)
-        .fetch_all(self.pool())
-        .await?;
+             WHERE it.address = $1 AND it.kind = 'wallet'",
+        );
+        let mut net_args = sqlx::postgres::PgArguments::default();
+        net_args
+            .add(wallet.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut net_n: usize = 1;
+        if let Some(oid) = owner_id {
+            net_n += 1;
+            net_sql.push_str(&format!(" AND it.owner_id = ${net_n}"));
+            net_args.add(oid).map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
+        net_sql.push_str(" GROUP BY rt.network ORDER BY rt.network");
+        let net_rows = sqlx::query_with(&net_sql, net_args)
+            .fetch_all(self.pool())
+            .await?;
 
         let per_network: Vec<(String, i64)> = net_rows
             .iter()

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -398,7 +398,7 @@ pub fn build_index_target_insert(
         "INSERT INTO index_targets \
          (id, kind, network, chain_family, address, filter_spec, mode, label, owner_id, created_at, updated_at) \
          VALUES ($1, $2::target_kind_enum, $3, $4::chain_family_enum, $5, $6, $7::target_mode_enum, $8, $9, $10, $11) \
-         ON CONFLICT (kind, network, address) WHERE address IS NOT NULL DO UPDATE SET updated_at = NOW() \
+         ON CONFLICT (kind, network, address, owner_id) WHERE address IS NOT NULL DO UPDATE SET updated_at = NOW() \
          RETURNING id, kind::text, network, chain_family::text, address, filter_spec, mode::text, label, owner_id, created_at, updated_at",
     );
     let mut args = sqlx::postgres::PgArguments::default();
@@ -1519,6 +1519,7 @@ fn row_to_export_job(row: &sqlx::postgres::PgRow) -> anyhow::Result<ExportJob> {
         started_at: row.try_get("started_at")?,
         completed_at: row.try_get("completed_at")?,
         heartbeat_at: row.try_get("heartbeat_at")?,
+        owner_id: row.try_get("owner_id").unwrap_or(None),
     })
 }
 fn row_to_api_key(row: &sqlx::postgres::PgRow) -> anyhow::Result<ApiKey> {
@@ -1664,18 +1665,34 @@ impl Repository {
         kind: TargetKind,
         network: &str,
         address: &str,
+        owner_id: Option<Uuid>,
     ) -> anyhow::Result<Option<IndexTarget>> {
-        let row = sqlx::query(
-            "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
-             mode::text, label, owner_id, created_at, updated_at \
-             FROM index_targets \
-             WHERE kind = $1::target_kind_enum AND network = $2 AND address = $3",
-        )
-        .bind(target_kind_to_sql(&kind))
-        .bind(network)
-        .bind(address)
-        .fetch_optional(self.pool())
-        .await?;
+        let row = if let Some(oid) = owner_id {
+            sqlx::query(
+                "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+                 mode::text, label, owner_id, created_at, updated_at \
+                 FROM index_targets \
+                 WHERE kind = $1::target_kind_enum AND network = $2 AND address = $3 AND owner_id = $4",
+            )
+            .bind(target_kind_to_sql(&kind))
+            .bind(network)
+            .bind(address)
+            .bind(oid)
+            .fetch_optional(self.pool())
+            .await?
+        } else {
+            sqlx::query(
+                "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+                 mode::text, label, owner_id, created_at, updated_at \
+                 FROM index_targets \
+                 WHERE kind = $1::target_kind_enum AND network = $2 AND address = $3 AND owner_id IS NULL",
+            )
+            .bind(target_kind_to_sql(&kind))
+            .bind(network)
+            .bind(address)
+            .fetch_optional(self.pool())
+            .await?
+        };
         row.as_ref().map(row_to_index_target).transpose()
     }
 
@@ -1770,6 +1787,41 @@ impl Repository {
             query = query.bind(target_kind_to_sql(k).to_string());
         }
 
+        let rows = query.fetch_all(self.pool()).await?;
+        rows.iter().map(row_to_index_target).collect()
+    }
+
+    /// List all index targets for a given owner, ordered by created_at.
+    /// Used for tenant-scoped target listing where pagination must be applied
+    /// after filtering (not before).
+    pub async fn list_index_targets_by_owner(
+        &self,
+        owner_id: Uuid,
+        network: Option<&str>,
+        kind: Option<TargetKind>,
+    ) -> anyhow::Result<Vec<IndexTarget>> {
+        let mut sql = String::from(
+            "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+             mode::text, label, owner_id, created_at, updated_at \
+             FROM index_targets WHERE owner_id = $1",
+        );
+        let mut param_idx = 2_usize;
+        if network.is_some() {
+            sql.push_str(&format!(" AND network = ${param_idx}"));
+            param_idx += 1;
+        }
+        if kind.is_some() {
+            sql.push_str(&format!(" AND kind = ${param_idx}::target_kind_enum"));
+        }
+        sql.push_str(" ORDER BY created_at");
+
+        let mut query = sqlx::query(&sql).bind(owner_id);
+        if let Some(nw) = network {
+            query = query.bind(nw.to_string());
+        }
+        if let Some(ref k) = kind {
+            query = query.bind(target_kind_to_sql(k).to_string());
+        }
         let rows = query.fetch_all(self.pool()).await?;
         rows.iter().map(row_to_index_target).collect()
     }
@@ -4476,36 +4528,76 @@ impl Repository {
     pub async fn list_stream_subscriptions(
         &self,
         desired_status: Option<&str>,
+        owner_id: Option<Uuid>,
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<StreamSubscription>> {
-        let rows = match desired_status {
-            Some(s) => {
-                sqlx::query(
-                    "SELECT id, target_id, network, source, desired_status, actual_status, \
-                     lease_owner, heartbeat_at, cursor_state, config, error_message, \
-                     created_at, updated_at \
-                     FROM stream_subscriptions WHERE desired_status = $1 \
-                     ORDER BY created_at LIMIT $2 OFFSET $3",
-                )
-                .bind(s)
-                .bind(limit)
-                .bind(offset)
-                .fetch_all(self.pool())
-                .await?
+        let rows = if let Some(oid) = owner_id {
+            // Owner-scoped: join with index_targets to enforce ownership.
+            match desired_status {
+                Some(s) => {
+                    sqlx::query(
+                        "SELECT s.id, s.target_id, s.network, s.source, s.desired_status, s.actual_status, \
+                         s.lease_owner, s.heartbeat_at, s.cursor_state, s.config, s.error_message, \
+                         s.created_at, s.updated_at \
+                         FROM stream_subscriptions s \
+                         JOIN index_targets t ON t.id = s.target_id \
+                         WHERE s.desired_status = $1 AND t.owner_id = $2 \
+                         ORDER BY s.created_at LIMIT $3 OFFSET $4",
+                    )
+                    .bind(s)
+                    .bind(oid)
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(self.pool())
+                    .await?
+                }
+                None => {
+                    sqlx::query(
+                        "SELECT s.id, s.target_id, s.network, s.source, s.desired_status, s.actual_status, \
+                         s.lease_owner, s.heartbeat_at, s.cursor_state, s.config, s.error_message, \
+                         s.created_at, s.updated_at \
+                         FROM stream_subscriptions s \
+                         JOIN index_targets t ON t.id = s.target_id \
+                         WHERE t.owner_id = $1 \
+                         ORDER BY s.created_at LIMIT $2 OFFSET $3",
+                    )
+                    .bind(oid)
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(self.pool())
+                    .await?
+                }
             }
-            None => {
-                sqlx::query(
-                    "SELECT id, target_id, network, source, desired_status, actual_status, \
-                     lease_owner, heartbeat_at, cursor_state, config, error_message, \
-                     created_at, updated_at \
-                     FROM stream_subscriptions \
-                     ORDER BY created_at LIMIT $1 OFFSET $2",
-                )
-                .bind(limit)
-                .bind(offset)
-                .fetch_all(self.pool())
-                .await?
+        } else {
+            match desired_status {
+                Some(s) => {
+                    sqlx::query(
+                        "SELECT id, target_id, network, source, desired_status, actual_status, \
+                         lease_owner, heartbeat_at, cursor_state, config, error_message, \
+                         created_at, updated_at \
+                         FROM stream_subscriptions WHERE desired_status = $1 \
+                         ORDER BY created_at LIMIT $2 OFFSET $3",
+                    )
+                    .bind(s)
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(self.pool())
+                    .await?
+                }
+                None => {
+                    sqlx::query(
+                        "SELECT id, target_id, network, source, desired_status, actual_status, \
+                         lease_owner, heartbeat_at, cursor_state, config, error_message, \
+                         created_at, updated_at \
+                         FROM stream_subscriptions \
+                         ORDER BY created_at LIMIT $1 OFFSET $2",
+                    )
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(self.pool())
+                    .await?
+                }
             }
         };
         rows.iter().map(row_to_stream_subscription).collect()
@@ -4522,24 +4614,26 @@ impl Repository {
         format: ExportFormat,
         filters: Option<&serde_json::Value>,
         sink_config: Option<&serde_json::Value>,
+        owner_id: Option<Uuid>,
     ) -> anyhow::Result<ExportJob> {
         let id = Uuid::new_v4();
         let row = sqlx::query(
             "INSERT INTO export_jobs \
-             (id, dataset, format, filters, sink_config) \
-             VALUES ($1, $2, $3, $4, $5) \
+             (id, dataset, format, filters, sink_config, owner_id) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
              RETURNING id, dataset, format, filters, sink_config, status, \
                        worker_id, record_count, result_location, \
                        delivery_destination, error_message, \
                        dataset_version_id, dataset_version, completeness_status, \
                        completeness_coverage, last_ingestion_run_id, \
-                       created_at, updated_at, started_at, completed_at, heartbeat_at",
+                       created_at, updated_at, started_at, completed_at, heartbeat_at, owner_id",
         )
         .bind(id)
         .bind(dataset.to_string())
         .bind(format.to_string())
         .bind(filters)
         .bind(sink_config)
+        .bind(owner_id)
         .fetch_one(self.pool())
         .await?;
         row_to_export_job(&row)
@@ -4748,10 +4842,11 @@ impl Repository {
         }
     }
 
-    /// Revoke an API key by id.
-    pub async fn revoke_api_key(&self, id: Uuid) -> anyhow::Result<()> {
-        sqlx::query("UPDATE api_keys SET revoked_at = NOW() WHERE id = $1")
+    /// Revoke an API key by id, scoped to an owner.
+    pub async fn revoke_api_key(&self, id: Uuid, owner_id: Uuid) -> anyhow::Result<()> {
+        sqlx::query("UPDATE api_keys SET revoked_at = NOW() WHERE id = $1 AND owner_id = $2")
             .bind(id)
+            .bind(owner_id)
             .execute(self.pool())
             .await?;
         Ok(())
@@ -4769,6 +4864,23 @@ impl Repository {
         .fetch_all(self.pool())
         .await?;
         rows.iter().map(row_to_api_key).collect()
+    }
+
+    /// List wallet targets belonging to a specific owner (no pagination limit).
+    pub async fn list_wallet_targets_by_owner(
+        &self,
+        owner_id: Uuid,
+    ) -> anyhow::Result<Vec<IndexTarget>> {
+        let rows = sqlx::query(
+            "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+             mode::text, label, owner_id, created_at, updated_at \
+             FROM index_targets \
+             WHERE kind = 'wallet'::target_kind_enum AND owner_id = $1",
+        )
+        .bind(owner_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_index_target).collect()
     }
 
     /// Create a new materialization run with status=pending.
@@ -6919,7 +7031,7 @@ mod tests {
     fn repo_list_stream_subscriptions_is_send() {
         fn _assert_send<F: std::future::Future + Send>(_: F) {}
         fn _check(repo: &Repository) {
-            _assert_send(repo.list_stream_subscriptions(Some("active"), 10, 0));
+            _assert_send(repo.list_stream_subscriptions(Some("active"), None, 10, 0));
         }
         let _ = _check;
     }
@@ -6931,6 +7043,7 @@ mod tests {
             _assert_send(repo.enqueue_export_job(
                 DatasetName::TokenTransfers,
                 ExportFormat::Csv,
+                None,
                 None,
                 None,
             ));
@@ -7092,6 +7205,7 @@ mod tests {
             completeness_status: None,
             completeness_coverage: None,
             last_ingestion_run_id: None,
+            owner_id: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             started_at: None,

--- a/adapters/tests/migration_test.rs
+++ b/adapters/tests/migration_test.rs
@@ -681,7 +681,29 @@ async fn insert_target(pool: &PgPool, kind: &str, network: &str, address: &str) 
     id
 }
 
-/// Helper: insert a raw_transaction and return its id.
+/// Helper: insert an index_target with a specific owner and return its id.
+async fn insert_target_with_owner(
+    pool: &PgPool,
+    kind: &str,
+    network: &str,
+    address: &str,
+    owner: Uuid,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, owner_id, created_at, updated_at)
+         VALUES ($1, $2::target_kind_enum, $3, 'solana'::chain_family_enum, $4, 'both'::target_mode_enum, $5, NOW(), NOW())",
+    )
+    .bind(id)
+    .bind(kind)
+    .bind(network)
+    .bind(address)
+    .bind(owner)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
 async fn insert_raw_tx(pool: &PgPool, network: &str, tx_hash: &str) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
@@ -719,32 +741,51 @@ async fn uniqueness_index_targets_address() {
     let (pool, db_name) = create_test_db("uqaddr").await;
     run_all_migrations(&pool).await;
 
-    insert_target(&pool, "wallet", "solana-mainnet", "WaLLetABC").await;
+    let owner = Uuid::new_v4();
 
-    // Duplicate (kind, network, address) must fail.
+    insert_target_with_owner(&pool, "wallet", "solana-mainnet", "WaLLetABC", owner).await;
+
+    // Duplicate (kind, network, address, owner_id) must fail.
     let dup = sqlx::query(
-        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, created_at, updated_at)
-         VALUES ($1, 'wallet'::target_kind_enum, 'solana-mainnet', 'solana'::chain_family_enum, 'WaLLetABC', 'both'::target_mode_enum, NOW(), NOW())",
+        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, owner_id, created_at, updated_at)
+         VALUES ($1, 'wallet'::target_kind_enum, 'solana-mainnet', 'solana'::chain_family_enum, 'WaLLetABC', 'both'::target_mode_enum, $2, NOW(), NOW())",
     )
     .bind(Uuid::new_v4())
+    .bind(owner)
     .execute(&pool)
     .await;
     assert!(
         dup.is_err(),
-        "uq_index_targets_address should reject duplicate"
+        "uq_index_targets_address_owner should reject duplicate for same owner"
     );
 
-    // Different kind for same network+address is allowed.
+    // Different owner for same kind/network/address is allowed (tenant isolation).
+    let other_owner = Uuid::new_v4();
     let ok = sqlx::query(
-        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, created_at, updated_at)
-         VALUES ($1, 'account'::target_kind_enum, 'solana-mainnet', 'solana'::chain_family_enum, 'WaLLetABC', 'both'::target_mode_enum, NOW(), NOW())",
+        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, owner_id, created_at, updated_at)
+         VALUES ($1, 'wallet'::target_kind_enum, 'solana-mainnet', 'solana'::chain_family_enum, 'WaLLetABC', 'both'::target_mode_enum, $2, NOW(), NOW())",
     )
     .bind(Uuid::new_v4())
+    .bind(other_owner)
     .execute(&pool)
     .await;
     assert!(
         ok.is_ok(),
-        "different kind should be allowed for same network+address"
+        "different owner should be allowed for same network+address"
+    );
+
+    // Different kind for same network+address+owner is allowed.
+    let ok2 = sqlx::query(
+        "INSERT INTO index_targets (id, kind, network, chain_family, address, mode, owner_id, created_at, updated_at)
+         VALUES ($1, 'account'::target_kind_enum, 'solana-mainnet', 'solana'::chain_family_enum, 'WaLLetABC', 'both'::target_mode_enum, $2, NOW(), NOW())",
+    )
+    .bind(Uuid::new_v4())
+    .bind(owner)
+    .execute(&pool)
+    .await;
+    assert!(
+        ok2.is_ok(),
+        "different kind should be allowed for same network+address+owner"
     );
 
     pool.close().await;

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+sha2 = "0.10"
 spectraplex-core = { path = "../core" }
 spectraplex-adapters = { path = "../adapters" }
 axum = "0.8"

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1776,7 +1776,7 @@ async fn get_transactions(
     let offset = clamp_offset(params.offset);
     let raw_txs = state
         .repo
-        .get_wallet_transactions_v2(&wallet, limit, offset, params.from, params.to)
+        .get_wallet_transactions_v2(&wallet, owner.0, limit, offset, params.from, params.to)
         .await
         .map_err(AppError::internal)?;
     let txs: Vec<Transaction> = raw_txs
@@ -1800,7 +1800,7 @@ async fn get_ledger(
     let offset = clamp_offset(params.offset);
     let records = state
         .repo
-        .get_wallet_ledger_v2(&wallet, limit, offset, params.from, params.to)
+        .get_wallet_ledger_v2(&wallet, owner.0, limit, offset, params.from, params.to)
         .await
         .map_err(AppError::internal)?;
     let entries: Vec<LedgerEntry> = records
@@ -1862,7 +1862,14 @@ async fn export_ledger(
 
     let records = state
         .repo
-        .get_wallet_ledger_v2(&wallet, MAX_EXPORT_LIMIT, 0, params.from, params.to)
+        .get_wallet_ledger_v2(
+            &wallet,
+            owner.0,
+            MAX_EXPORT_LIMIT,
+            0,
+            params.from,
+            params.to,
+        )
         .await
         .map_err(AppError::internal)?;
     let entries: Vec<LedgerEntry> = records
@@ -1935,7 +1942,7 @@ async fn get_balances(
     check_wallet_owner(&state.repo, &wallet, &owner).await?;
     let rows = state
         .repo
-        .get_wallet_balances_v2(&wallet, params.at)
+        .get_wallet_balances_v2(&wallet, owner.0, params.at)
         .await
         .map_err(AppError::internal)?;
     let balances: Vec<AssetBalance> = rows
@@ -1959,7 +1966,7 @@ async fn get_single_transaction(
 
     let raw = state
         .repo
-        .get_wallet_transaction_by_hash_v2(&wallet, &tx_hash)
+        .get_wallet_transaction_by_hash_v2(&wallet, &tx_hash, owner.0)
         .await
         .map_err(AppError::internal)?;
 
@@ -1980,7 +1987,7 @@ async fn get_wallet_stats(
 
     let stats = state
         .repo
-        .get_wallet_stats_v2(&wallet)
+        .get_wallet_stats_v2(&wallet, owner.0)
         .await
         .map_err(AppError::internal)?;
 
@@ -2413,16 +2420,20 @@ async fn list_targets(
             .map_err(AppError::internal)?,
     };
 
-    // Apply pagination in Rust for tenant-scoped results (owner filtering is
-    // already done in SQL for tenant mode; for legacy mode it was applied via
-    // LIMIT/OFFSET in the repo query).
-    let offset_usize = offset as usize;
-    let limit_usize = limit as usize;
-    let paginated: Vec<IndexTarget> = targets
-        .into_iter()
-        .skip(offset_usize)
-        .take(limit_usize)
-        .collect();
+    // Apply pagination in Rust only for tenant-scoped results (owner filtering
+    // is done in SQL without LIMIT/OFFSET). For legacy mode, the repo query
+    // already applied LIMIT/OFFSET.
+    let paginated: Vec<IndexTarget> = if owner.0.is_some() {
+        let offset_usize = offset as usize;
+        let limit_usize = limit as usize;
+        targets
+            .into_iter()
+            .skip(offset_usize)
+            .take(limit_usize)
+            .collect()
+    } else {
+        targets
+    };
 
     Ok(Json(paginated))
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -6,7 +6,7 @@ mod stream_worker;
 mod worker;
 
 use axum::{
-    extract::{Path, Query, Request, State},
+    extract::{Extension, Path, Query, Request, State},
     http::StatusCode,
     middleware::{self, Next},
     response::{IntoResponse, Response},
@@ -39,9 +39,9 @@ use spectraplex_core::provider::{
     chain_to_network_id, NetworkContext, NetworkId, ProviderCapability, ProviderRegistry,
 };
 use spectraplex_core::v2::{
-    normalize_evm_address, normalize_solana_address, ChainFamily, DatasetCompleteness,
-    DatasetVersion, ExportJob, ExportJobStatus as DurableExportJobStatus, IndexTarget,
-    IngestionJobStatus, MaterializationRunStatus, Network, TargetKind, TargetMode,
+    normalize_evm_address, normalize_solana_address, AuthenticatedOwner, ChainFamily,
+    DatasetCompleteness, DatasetVersion, ExportJob, ExportJobStatus as DurableExportJobStatus,
+    IndexTarget, IngestionJobStatus, MaterializationRunStatus, Network, TargetKind, TargetMode,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::collections::hash_map::DefaultHasher;
@@ -456,33 +456,54 @@ async fn health_check() -> &'static str {
 
 async fn require_auth(
     State(state): State<Arc<AppState>>,
-    req: Request,
+    mut req: Request,
     next: Next,
 ) -> Result<Response, AppError> {
-    let expected = match &state.config.api_key {
-        Some(key) => key,
-        None => {
-            return Err(AppError {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                message: "API key not configured".to_string(),
-            })
-        }
-    };
-
     let header = req
         .headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "));
 
-    match header {
-        Some(token) if token.as_bytes().ct_eq(expected.as_bytes()).into() => {
-            Ok(next.run(req).await)
+    let token = match header {
+        Some(t) => t,
+        None => {
+            return Err(AppError {
+                status: StatusCode::UNAUTHORIZED,
+                message: "Missing or invalid API key".to_string(),
+            });
         }
-        _ => Err(AppError {
+    };
+
+    // 1. Try DB-backed API key first (tenant isolation).
+    let db_owner = match state.repo.validate_api_key(token).await {
+        Ok(Some(key)) => Some(key.owner_id),
+        Ok(None) => None,
+        Err(e) => {
+            error!(error = %e, "Failed to validate API key against database");
+            None
+        }
+    };
+
+    // 2. Fall back to legacy config-level key (admin/owner-less mode).
+    let legacy_ok = state
+        .config
+        .api_key
+        .as_ref()
+        .map(|k| token.as_bytes().ct_eq(k.as_bytes()).into())
+        .unwrap_or(false);
+
+    if db_owner.is_some() {
+        req.extensions_mut().insert(AuthenticatedOwner(db_owner));
+        Ok(next.run(req).await)
+    } else if legacy_ok {
+        req.extensions_mut().insert(AuthenticatedOwner(None));
+        Ok(next.run(req).await)
+    } else {
+        Err(AppError {
             status: StatusCode::UNAUTHORIZED,
             message: "Missing or invalid API key".to_string(),
-        }),
+        })
     }
 }
 
@@ -1342,6 +1363,33 @@ fn check_wallet_allowed(wallet: &str, allowed: &Option<HashSet<String>>) -> Resu
     Ok(())
 }
 
+/// Verify that the requested wallet belongs to the authenticated owner.
+/// In legacy mode (owner_id is None) this is a no-op.
+async fn check_wallet_owner(
+    repo: &Repository,
+    wallet: &str,
+    owner: &AuthenticatedOwner,
+) -> Result<(), AppError> {
+    if let Some(owner_id) = owner.0 {
+        // Look for a wallet target owned by this user.
+        let targets = repo
+            .list_index_targets_filtered(None, Some(TargetKind::Wallet), 1000, 0)
+            .await
+            .map_err(|e| AppError::internal(format!("Failed to lookup wallet ownership: {e}")))?;
+        let owned = targets.iter().any(|t| {
+            t.owner_id == Some(owner_id)
+                && t.address
+                    .as_deref()
+                    .map(|a| a.eq_ignore_ascii_case(wallet))
+                    .unwrap_or(false)
+        });
+        if !owned {
+            return Err(AppError::forbidden("Wallet not registered for this owner"));
+        }
+    }
+    Ok(())
+}
+
 /// Convert a V2 RawTransaction to a V1 Transaction for compatibility responses.
 fn raw_tx_to_compat_tx(raw: &spectraplex_core::v2::RawTransaction, wallet: &str) -> Transaction {
     let chain = if raw.network.starts_with("solana") {
@@ -1637,11 +1685,13 @@ fn ingestion_status_to_job_state(status: IngestionJobStatus) -> JobState {
 
 async fn get_transactions(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(wallet): Path<String>,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<Transaction>>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
     validate_date_range(params.from, params.to)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
@@ -1659,11 +1709,13 @@ async fn get_transactions(
 
 async fn get_ledger(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(wallet): Path<String>,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<LedgerEntry>>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
     validate_date_range(params.from, params.to)?;
     let limit = clamp_limit(params.limit);
     let offset = clamp_offset(params.offset);
@@ -1713,11 +1765,13 @@ fn csv_escape(s: &str) -> String {
 
 async fn export_ledger(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(wallet): Path<String>,
     Query(params): Query<ExportParams>,
 ) -> Result<Response, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
     validate_date_range(params.from, params.to)?;
 
     let format = params.format.as_deref().unwrap_or("json");
@@ -1793,11 +1847,13 @@ async fn export_ledger(
 
 async fn get_balances(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(wallet): Path<String>,
     Query(params): Query<BalanceParams>,
 ) -> Result<Json<Vec<AssetBalance>>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
     let rows = state
         .repo
         .get_wallet_balances_v2(&wallet, params.at)
@@ -1815,10 +1871,12 @@ async fn get_balances(
 
 async fn get_single_transaction(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path((wallet, tx_hash)): Path<(String, String)>,
 ) -> Result<Json<Transaction>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
 
     let raw = state
         .repo
@@ -1834,10 +1892,12 @@ async fn get_single_transaction(
 
 async fn get_wallet_stats(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(wallet): Path<String>,
 ) -> Result<Json<WalletStats>, AppError> {
     validate_wallet(&wallet)?;
     check_wallet_allowed(&wallet, &state.allowed_wallets)?;
+    check_wallet_owner(&state.repo, &wallet, &owner).await?;
 
     let stats = state
         .repo
@@ -2915,8 +2975,23 @@ struct TaxExportParams {
 /// GET /v1/export/tax — export wallet_ledger in tax-software-friendly CSV.
 async fn tax_export(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<TaxExportParams>,
 ) -> Result<Response, AppError> {
+    if let Some(owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped requests")
+        })?;
+        let target = state
+            .repo
+            .get_index_target(target_id)
+            .await
+            .map_err(|e| AppError::internal(format!("Failed to fetch target: {e}")))?
+            .ok_or_else(|| AppError::not_found("Target not found"))?;
+        if target.owner_id != Some(owner_id) {
+            return Err(AppError::forbidden("Target does not belong to this owner"));
+        }
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let records = state
@@ -3713,7 +3788,7 @@ mod tests {
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
         // Unconfigured API key is a server misconfiguration, not a client auth failure
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -30,6 +30,7 @@ use spectraplex_core::materializer::{
 // `#[cfg(test)]` so non-test builds don't warn about unused imports now
 // that the streaming export path (`export_stream`) uses the row-writer
 // helpers in `export_csv` directly, not the `*_to_csv` wrappers.
+use sha2::{Digest, Sha256};
 #[cfg(test)]
 use spectraplex_core::materializer::{
     BalanceSnapshot, HlPnlSummary, HlTradeHistory, PoolSnapshot, ProtocolEvent,
@@ -476,7 +477,8 @@ async fn require_auth(
     };
 
     // 1. Try DB-backed API key first (tenant isolation).
-    let db_owner = match state.repo.validate_api_key(token).await {
+    let token_hash = format!("{:x}", Sha256::digest(token));
+    let db_owner = match state.repo.validate_api_key(&token_hash).await {
         Ok(Some(key)) => Some(key.owner_id),
         Ok(None) => None,
         Err(e) => {
@@ -1371,20 +1373,46 @@ async fn check_wallet_owner(
     owner: &AuthenticatedOwner,
 ) -> Result<(), AppError> {
     if let Some(owner_id) = owner.0 {
-        // Look for a wallet target owned by this user.
         let targets = repo
-            .list_index_targets_filtered(None, Some(TargetKind::Wallet), 1000, 0)
+            .list_wallet_targets_by_owner(owner_id)
             .await
             .map_err(|e| AppError::internal(format!("Failed to lookup wallet ownership: {e}")))?;
         let owned = targets.iter().any(|t| {
-            t.owner_id == Some(owner_id)
-                && t.address
-                    .as_deref()
-                    .map(|a| a.eq_ignore_ascii_case(wallet))
-                    .unwrap_or(false)
+            t.address
+                .as_deref()
+                .map(|a| {
+                    // EVM addresses are case-insensitive; Solana addresses are case-sensitive.
+                    // Heuristic: 0x-prefixed addresses are EVM-style.
+                    if wallet.starts_with("0x") || a.starts_with("0x") {
+                        a.eq_ignore_ascii_case(wallet)
+                    } else {
+                        a == wallet
+                    }
+                })
+                .unwrap_or(false)
         });
         if !owned {
             return Err(AppError::forbidden("Wallet not registered for this owner"));
+        }
+    }
+    Ok(())
+}
+
+/// Verify that a target_id belongs to the authenticated owner.
+/// Returns Ok(()) for legacy/admin mode (owner == None).
+async fn check_target_owner(
+    repo: &Repository,
+    target_id: Uuid,
+    owner: &AuthenticatedOwner,
+) -> Result<(), AppError> {
+    if let Some(owner_id) = owner.0 {
+        let target = repo
+            .get_index_target(target_id)
+            .await
+            .map_err(AppError::internal)?
+            .ok_or_else(|| AppError::forbidden("Target not found"))?;
+        if target.owner_id != Some(owner_id) {
+            return Err(AppError::forbidden("Target not owned by this tenant"));
         }
     }
     Ok(())
@@ -1404,6 +1432,7 @@ fn raw_tx_to_compat_tx(raw: &spectraplex_core::v2::RawTransaction, wallet: &str)
 
 async fn trigger_ingest(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(payload): Json<IngestRequest>,
 ) -> Result<Json<JobStatus>, AppError> {
     validate_wallet(&payload.wallet)?;
@@ -1454,13 +1483,18 @@ async fn trigger_ingest(
         spectraplex_adapters::dual_write::chain_to_default_network(&chain_enum).to_string()
     });
 
-    let user_id = payload.user_id.unwrap_or_else(Uuid::new_v4);
+    let owner_id = owner.0.or(payload.user_id).unwrap_or_else(Uuid::new_v4);
 
     // Ensure a V2 IndexTarget exists for this wallet.
     let target_id = if payload.network.is_some() {
         match state
             .repo
-            .ensure_wallet_target_for_network(&network, &chain_enum, &payload.wallet, Some(user_id))
+            .ensure_wallet_target_for_network(
+                &network,
+                &chain_enum,
+                &payload.wallet,
+                Some(owner_id),
+            )
             .await
         {
             Ok(target) => Some(target.id),
@@ -1477,7 +1511,7 @@ async fn trigger_ingest(
     } else {
         match state
             .repo
-            .ensure_wallet_target(&chain_enum, &payload.wallet, Some(user_id))
+            .ensure_wallet_target(&chain_enum, &payload.wallet, Some(owner_id))
             .await
         {
             Ok(target) => Some(target.id),
@@ -1499,7 +1533,7 @@ async fn trigger_ingest(
         mode: "incremental",
         priority: 0,
         idempotency_key: None,
-        requested_by: Some(&user_id.to_string()),
+        requested_by: Some(&owner_id.to_string()),
         callback_url: payload.callback_url.as_deref(),
     };
 
@@ -1521,6 +1555,7 @@ const MAX_BATCH_SIZE: usize = 50;
 
 async fn trigger_batch_ingest(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(payload): Json<BatchIngestRequest>,
 ) -> Result<Json<Vec<JobStatus>>, AppError> {
     if payload.wallets.is_empty() {
@@ -1567,7 +1602,7 @@ async fn trigger_batch_ingest(
             user_id: item.user_id,
             callback_url: item.callback_url,
         });
-        match trigger_ingest(State(Arc::clone(&state)), single).await {
+        match trigger_ingest(State(Arc::clone(&state)), Extension(owner), single).await {
             Ok(Json(status)) => jobs.push(status),
             Err(e) if e.status == StatusCode::SERVICE_UNAVAILABLE => {
                 return Err(AppError::service_unavailable(format!(
@@ -1585,6 +1620,7 @@ async fn trigger_batch_ingest(
 
 async fn trigger_normalize(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(payload): Json<NormalizeRequest>,
 ) -> Result<Json<JobStatus>, AppError> {
     validate_wallet(&payload.wallet)?;
@@ -1594,6 +1630,24 @@ async fn trigger_normalize(
     })?;
     if let Some(ref url) = payload.callback_url {
         validate_callback_url(url).await?;
+    }
+    // Tenant isolation: validate the ingestion run's target belongs to the owner.
+    if let Some(_owner_id) = owner.0 {
+        let run = state
+            .repo
+            .get_ingestion_run(ingestion_run_id)
+            .await
+            .map_err(AppError::internal)?
+            .ok_or_else(|| {
+                AppError::not_found(format!("Ingestion run {} not found", ingestion_run_id))
+            })?;
+        if let Some(target_id) = run.target_id {
+            check_target_owner(&state.repo, target_id, &owner).await?;
+        } else {
+            return Err(AppError::forbidden(
+                "Cannot normalize a run without a target",
+            ));
+        }
     }
 
     // Build scope with wallet, optional network, and optional callback_url
@@ -1622,19 +1676,44 @@ async fn trigger_normalize(
 
 async fn get_job_status(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<JobStatus>, AppError> {
     // Check durable ingestion jobs in Postgres first.
     match state.repo.get_ingestion_job(job_id).await {
-        Ok(Some(job)) => Ok(Json(JobStatus {
-            id: job.id,
-            state: ingestion_status_to_job_state(job.status),
-            message: job.error_message,
-        })),
+        Ok(Some(job)) => {
+            // Tenant isolation: validate target ownership.
+            if let Some(_owner_id) = owner.0 {
+                if let Some(target_id) = job.target_id {
+                    check_target_owner(&state.repo, target_id, &owner).await?;
+                } else {
+                    return Err(AppError::forbidden("Job has no associated target"));
+                }
+            }
+            Ok(Json(JobStatus {
+                id: job.id,
+                state: ingestion_status_to_job_state(job.status),
+                message: job.error_message,
+            }))
+        }
         Ok(None) => {
             // Not an ingestion job — check materialization runs.
             match state.repo.get_materialization_run(job_id).await {
                 Ok(Some(run)) => {
+                    // Tenant isolation: validate via wallet in scope JSON.
+                    if let Some(_owner_id) = owner.0 {
+                        if let Some(scope) = run.scope {
+                            if let Some(wallet) = scope.get("wallet").and_then(|w| w.as_str()) {
+                                check_wallet_owner(&state.repo, wallet, &owner).await?;
+                            } else {
+                                return Err(AppError::forbidden(
+                                    "Materialization run has no wallet in scope",
+                                ));
+                            }
+                        } else {
+                            return Err(AppError::forbidden("Materialization run has no scope"));
+                        }
+                    }
                     let state_val = match run.status {
                         MaterializationRunStatus::Pending => JobState::Pending,
                         MaterializationRunStatus::Running => JobState::Running,
@@ -1937,6 +2016,7 @@ struct StartStreamRequest {
 
 async fn start_stream(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(payload): Json<StartStreamRequest>,
 ) -> Result<Json<StreamInfo>, AppError> {
     // Resolve chain from network (preferred) or use chain directly (compat).
@@ -2033,19 +2113,25 @@ async fn start_stream(
             let chain_enum = Chain::Hyperliquid;
             let target = state
                 .repo
-                .ensure_wallet_target_for_network(&network, &chain_enum, wallet, None)
+                .ensure_wallet_target_for_network(&network, &chain_enum, wallet, owner.0)
                 .await
                 .map_err(AppError::internal)?;
             target.id
         }
         "solana" => {
+            // Tenant isolation: global Solana gRPC streams are admin-only.
+            if owner.0.is_some() {
+                return Err(AppError::forbidden(
+                    "Tenant-scoped Solana gRPC streams are not supported; use admin mode",
+                ));
+            }
             // For global Solana gRPC streams, create a program-type target
             // keyed on the network.  The address is a sentinel so the unique
             // index on (kind, network, address) prevents duplicates.
             let sentinel = "__global_grpc_stream__";
             let target = match state
                 .repo
-                .get_index_target_by_address(TargetKind::Program, &network, sentinel)
+                .get_index_target_by_address(TargetKind::Program, &network, sentinel, None)
                 .await
                 .map_err(AppError::internal)?
             {
@@ -2111,8 +2197,26 @@ async fn start_stream(
 
 async fn stop_stream(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(stream_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    // Tenant isolation: validate subscription ownership before stopping.
+    if let Some(_owner_id) = owner.0 {
+        let sub = state
+            .repo
+            .get_stream_subscription(stream_id)
+            .await
+            .map_err(AppError::internal)?
+            .ok_or_else(|| AppError::not_found(format!("Stream {} not found", stream_id)))?;
+        if let Some(target_id) = sub.target_id {
+            check_target_owner(&state.repo, target_id, &owner).await?;
+        } else {
+            return Err(AppError::forbidden(
+                "Cannot stop a subscription without a target",
+            ));
+        }
+    }
+
     let updated = state
         .repo
         .set_stream_desired_status(stream_id, "stopped")
@@ -2134,10 +2238,11 @@ async fn stop_stream(
 
 async fn list_streams(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
 ) -> Result<Json<Vec<StreamInfo>>, AppError> {
     let subs = state
         .repo
-        .list_stream_subscriptions(Some("active"), 100, 0)
+        .list_stream_subscriptions(Some("active"), owner.0, 100, 0)
         .await
         .map_err(AppError::internal)?;
 
@@ -2212,6 +2317,7 @@ fn conflict(msg: impl Into<String>) -> AppError {
 
 async fn register_target(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(req): Json<RegisterTargetRequest>,
 ) -> Result<(StatusCode, Json<IndexTarget>), AppError> {
     // Parse kind
@@ -2250,7 +2356,7 @@ async fn register_target(
         filter_spec: req.filter_spec,
         mode,
         label: req.label,
-        owner_id: None,
+        owner_id: owner.0,
         created_at: now,
         updated_at: now,
     };
@@ -2278,6 +2384,7 @@ async fn register_target(
 
 async fn list_targets(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<TargetListParams>,
 ) -> Result<Json<Vec<IndexTarget>>, AppError> {
     let limit = clamp_limit(params.limit);
@@ -2293,17 +2400,36 @@ async fn list_targets(
         })
         .transpose()?;
 
-    let targets = state
-        .repo
-        .list_index_targets_filtered(params.network.as_deref(), kind, limit, offset)
-        .await
-        .map_err(AppError::internal)?;
+    let targets = match owner.0 {
+        Some(owner_id) => state
+            .repo
+            .list_index_targets_by_owner(owner_id, params.network.as_deref(), kind)
+            .await
+            .map_err(AppError::internal)?,
+        None => state
+            .repo
+            .list_index_targets_filtered(params.network.as_deref(), kind, limit, offset)
+            .await
+            .map_err(AppError::internal)?,
+    };
 
-    Ok(Json(targets))
+    // Apply pagination in Rust for tenant-scoped results (owner filtering is
+    // already done in SQL for tenant mode; for legacy mode it was applied via
+    // LIMIT/OFFSET in the repo query).
+    let offset_usize = offset as usize;
+    let limit_usize = limit as usize;
+    let paginated: Vec<IndexTarget> = targets
+        .into_iter()
+        .skip(offset_usize)
+        .take(limit_usize)
+        .collect();
+
+    Ok(Json(paginated))
 }
 
 async fn get_target(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(target_id): Path<Uuid>,
 ) -> Result<Json<IndexTarget>, AppError> {
     let target = state
@@ -2312,6 +2438,13 @@ async fn get_target(
         .await
         .map_err(AppError::internal)?
         .ok_or_else(|| AppError::not_found(format!("Target {} not found", target_id)))?;
+
+    if let Some(owner_id) = owner.0 {
+        if target.owner_id != Some(owner_id) {
+            return Err(AppError::forbidden("Target does not belong to this owner"));
+        }
+    }
+
     Ok(Json(target))
 }
 
@@ -2375,7 +2508,10 @@ fn validate_dataset_name(name: &str) -> Result<(), AppError> {
 
 async fn list_all_datasets(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
 ) -> Result<Json<Vec<DatasetInfo>>, AppError> {
+    // Tenant isolation: dataset metadata is global; allowed for all authenticated callers.
+    let _ = owner;
     let mut datasets = Vec::new();
     for ds in DatasetName::all() {
         let sql_name = ds.as_sql_str();
@@ -2395,8 +2531,11 @@ async fn list_all_datasets(
 
 async fn list_dataset_versions_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
 ) -> Result<Json<Vec<DatasetVersion>>, AppError> {
+    // Tenant isolation: dataset version metadata is global; allowed for all authenticated callers.
+    let _ = owner;
     validate_dataset_name(&name)?;
     let versions = state
         .repo
@@ -2408,9 +2547,17 @@ async fn list_dataset_versions_handler(
 
 async fn query_dataset_records(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
     Query(params): Query<DatasetQueryParams>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped dataset queries")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_dataset_name(&name)?;
     if !DatasetRegistry::is_queryable(&name) {
         return Err(AppError::bad_request(format!(
@@ -2737,6 +2884,7 @@ fn wallet_ledger_to_tax_csv(records: &[WalletLedgerRecord]) -> Vec<u8> {
 
 async fn create_export_job(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Json(req): Json<ExportJobRequest>,
 ) -> Result<(StatusCode, Json<ExportJobStatus>), AppError> {
     validate_dataset_name(&req.dataset)?;
@@ -2784,6 +2932,14 @@ async fn create_export_job(
             EXPORTABLE_DATASETS.join(", ")
         ))
     })?;
+    // Tenant isolation: require and validate target_id for tenant-scoped requests.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = req.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped export requests")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
+
     let job = state
         .repo
         .enqueue_export_job(
@@ -2791,6 +2947,7 @@ async fn create_export_job(
             _format,
             Some(&filters),
             sink_config_json.as_ref(),
+            owner.0,
         )
         .await
         .map_err(|e| AppError::internal(format!("Failed to enqueue export job: {e}")))?;
@@ -2873,6 +3030,7 @@ pub(crate) struct ExportMetadata {
 
 async fn get_export_job_status(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(job_id): Path<Uuid>,
 ) -> Result<Json<ExportJobStatus>, AppError> {
     let job = state
@@ -2881,13 +3039,21 @@ async fn get_export_job_status(
         .await
         .map_err(|e| AppError::internal(format!("Failed to fetch export job: {e}")))?;
     match job {
-        Some(j) => Ok(Json(export_job_to_status(&j))),
+        Some(j) => {
+            if let Some(owner_id) = owner.0 {
+                if j.owner_id != Some(owner_id) {
+                    return Err(AppError::forbidden("Export job not owned by this tenant"));
+                }
+            }
+            Ok(Json(export_job_to_status(&j)))
+        }
         None => Err(AppError::not_found("Export job not found")),
     }
 }
 
 async fn download_export(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(job_id): Path<Uuid>,
 ) -> Result<Response, AppError> {
     let job = state
@@ -2896,6 +3062,11 @@ async fn download_export(
         .await
         .map_err(|e| AppError::internal(format!("Failed to fetch export job: {e}")))?
         .ok_or_else(|| AppError::not_found("Export job not found"))?;
+    if let Some(owner_id) = owner.0 {
+        if job.owner_id != Some(owner_id) {
+            return Err(AppError::forbidden("Export job not owned by this tenant"));
+        }
+    }
 
     match job.status {
         DurableExportJobStatus::Completed => {
@@ -3033,8 +3204,16 @@ struct ForensicsParams {
 /// GET /v1/forensics/activity — wallet interaction analysis from wallet_ledger.
 async fn forensics_activity_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<ForensicsParams>,
 ) -> Result<Json<ForensicsActivity>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped analytics")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let records = state
@@ -3081,8 +3260,16 @@ struct HlAnalyticsParams {
 /// GET /v1/analytics/hl/trader — per-trader Hyperliquid PnL analytics.
 async fn hl_trader_analytics_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<HlAnalyticsParams>,
 ) -> Result<Json<TraderAnalytics>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped analytics")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let pnl_summaries = state
@@ -3125,8 +3312,16 @@ async fn hl_trader_analytics_handler(
 /// GET /v1/analytics/hl/market — per-coin Hyperliquid market analytics.
 async fn hl_market_analytics_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<HlAnalyticsParams>,
 ) -> Result<Json<MarketAnalytics>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped analytics")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let pnl_summaries = state
@@ -3176,8 +3371,16 @@ struct ProtocolAnalyticsParams {
 /// GET /v1/analytics/protocol/activity — per-protocol event activity analytics.
 async fn protocol_activity_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<ProtocolAnalyticsParams>,
 ) -> Result<Json<ProtocolActivity>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped analytics")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let events = state
@@ -3207,8 +3410,16 @@ async fn protocol_activity_handler(
 /// GET /v1/analytics/protocol/tvl — TVL analytics from pool snapshots.
 async fn protocol_tvl_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Query(params): Query<ProtocolAnalyticsParams>,
 ) -> Result<Json<TvlAnalytics>, AppError> {
+    // Tenant isolation: require target_id and validate ownership.
+    if let Some(_owner_id) = owner.0 {
+        let target_id = params.target_id.ok_or_else(|| {
+            AppError::bad_request("target_id is required for tenant-scoped analytics")
+        })?;
+        check_target_owner(&state.repo, target_id, &owner).await?;
+    }
     validate_date_range(params.time_start, params.time_end)?;
 
     let snapshots = state
@@ -3229,8 +3440,15 @@ async fn protocol_tvl_handler(
 
 async fn get_dataset_completeness_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
 ) -> Result<Json<Vec<DatasetCompleteness>>, AppError> {
+    // Tenant isolation: dataset completeness is not yet scoped by owner.
+    if owner.0.is_some() {
+        return Err(AppError::forbidden(
+            "Dataset completeness is not available for tenant-scoped requests",
+        ));
+    }
     validate_dataset_name(&name)?;
     let records = state
         .repo
@@ -3279,8 +3497,15 @@ struct DatasetCompletenessInfo {
 
 async fn get_dataset_status_handler(
     State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
 ) -> Result<Json<DatasetStatus>, AppError> {
+    // Tenant isolation: dataset status includes global completeness; not yet scoped by owner.
+    if owner.0.is_some() {
+        return Err(AppError::forbidden(
+            "Dataset status is not available for tenant-scoped requests",
+        ));
+    }
     validate_dataset_name(&name)?;
 
     let versions = state

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,6 +250,7 @@ async fn main() -> anyhow::Result<()> {
                                     spectraplex_core::v2::TargetKind::Wallet,
                                     net,
                                     wallet,
+                                    None,
                                 )
                                 .await
                                 .ok()

--- a/core/src/v2.rs
+++ b/core/src/v2.rs
@@ -560,6 +560,8 @@ pub struct ExportJob {
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
     pub heartbeat_at: Option<DateTime<Utc>>,
+    /// Tenant owner for export job isolation. `None` for legacy/admin jobs.
+    pub owner_id: Option<Uuid>,
 }
 // ---------------------------------------------------------------------------
 // API Key (Tenant Isolation)
@@ -1656,6 +1658,7 @@ mod tests {
             completeness_status: None,
             completeness_coverage: None,
             last_ingestion_run_id: None,
+            owner_id: None,
             created_at: now,
             updated_at: now,
             started_at: None,

--- a/core/src/v2.rs
+++ b/core/src/v2.rs
@@ -561,6 +561,26 @@ pub struct ExportJob {
     pub completed_at: Option<DateTime<Utc>>,
     pub heartbeat_at: Option<DateTime<Utc>>,
 }
+// ---------------------------------------------------------------------------
+// API Key (Tenant Isolation)
+// ---------------------------------------------------------------------------
+
+/// A durable API key for tenant-scoped authentication.
+/// Matches Issue #216 / Workstream G.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKey {
+    pub id: Uuid,
+    pub key_hash: String,
+    pub name: Option<String>,
+    pub owner_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Authenticated owner context injected by the auth middleware.
+/// `None` means legacy/admin mode (config-level API key).
+#[derive(Debug, Clone, Copy)]
+pub struct AuthenticatedOwner(pub Option<Uuid>);
 
 // ---------------------------------------------------------------------------
 // Materialization Run (Durable Control Plane)

--- a/migrations/20260422000001_add_api_keys_and_owner_scoping.sql
+++ b/migrations/20260422000001_add_api_keys_and_owner_scoping.sql
@@ -1,0 +1,28 @@
+-- Workstream G / Issue #216: per-user/tenant isolation at the query layer.
+--
+-- Adds api_keys table for DB-backed key authentication with owner scoping,
+-- and an index on index_targets(owner_id) to support owner-filtered queries.
+
+-- ---------------------------------------------------------------------------
+-- 1. api_keys: durable API key registry with owner scoping
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE api_keys (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_hash     TEXT NOT NULL,
+    name         TEXT,
+    owner_id     UUID NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at   TIMESTAMPTZ,
+
+    CONSTRAINT uq_api_keys_key_hash UNIQUE (key_hash)
+);
+
+CREATE INDEX idx_api_keys_owner ON api_keys(owner_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. Index for owner-scoped target lookups
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX idx_index_targets_owner ON index_targets(owner_id)
+    WHERE owner_id IS NOT NULL;

--- a/migrations/20260422000001_add_api_keys_and_owner_scoping.sql
+++ b/migrations/20260422000001_add_api_keys_and_owner_scoping.sql
@@ -26,3 +26,22 @@ CREATE INDEX idx_api_keys_owner ON api_keys(owner_id);
 
 CREATE INDEX idx_index_targets_owner ON index_targets(owner_id)
     WHERE owner_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Update index_targets unique constraint to include owner_id
+-- ---------------------------------------------------------------------------
+-- Drop the old global unique index so each tenant can register the same
+-- wallet address independently.
+DROP INDEX IF EXISTS uq_index_targets_address;
+
+-- Create a new unique index that includes owner_id. PostgreSQL treats NULLs
+-- as not equal, so multiple global targets (owner_id IS NULL) for the same
+-- address are still allowed; this is acceptable because global target creation
+-- is already idempotent via ON CONFLICT.
+CREATE UNIQUE INDEX uq_index_targets_address_owner ON index_targets(kind, network, address, owner_id) WHERE address IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 4. export_jobs: add owner_id for tenant-scoped export isolation
+-- ---------------------------------------------------------------------------
+ALTER TABLE export_jobs ADD COLUMN IF NOT EXISTS owner_id UUID;
+CREATE INDEX idx_export_jobs_owner ON export_jobs(owner_id) WHERE owner_id IS NOT NULL;


### PR DESCRIPTION
Closes #216.

Introduces DB-backed API keys with owner scoping so that authenticated callers can no longer access arbitrary wallets.

### What's new
- api_keys table with key_hash, name, owner_id, revoked_at
- Auth middleware tries DB-backed keys first, falls back to legacy config key
- AuthenticatedOwner request extension carries owner context
- register_target now stores owner_id from the authenticated context
- list_targets / get_target filter/check ownership
- Wallet endpoints verify that the wallet is registered as a target owned by the caller
- tax_export checks ownership via target_id

### Backwards compatibility
- Legacy config-level api_key continues to work (admin mode)
- Existing single-key deployments are unaffected

### Files changed
- migrations/20260422000001_add_api_keys_and_owner_scoping.sql
- core/src/v2.rs
- adapters/src/v2_repo.rs
- api/src/main.rs