### PR TITLE
P1: Make Status and Provenance Usable — Gold completeness + export provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,27 +174,39 @@ curl -X DELETE http://127.0.0.1:3000/v1/api-keys/<KEY_ID> \
 
 ```bash
 # Query any dataset with filters
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+curl -H "Authorization: Bearer $SPECT...KEY" \
   "http://127.0.0.1:3000/v1/datasets/token_transfers/records?network=solana-mainnet&limit=50"
 
 # Check dataset completeness
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+curl -H "Authorization: Bearer $SPECT...KEY" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/completeness
+
+# Check dataset status (aggregated across targets)
+curl -H "Authorization: Bearer $SPECT...KEY" \
+  http://127.0.0.1:3000/v1/datasets/token_transfers/status
 ```
+
+Dataset completeness is tracked per target and network. After each materialization run, the system upserts a completeness record with coverage bounds (timestamp or block range), record count, and status (`complete`, `partial`, `backfilling`, or `gap`).
 
 ### Export
 
 ```bash
 # Create an export job (CSV or JSONL)
 curl -X POST http://127.0.0.1:3000/v1/export/dataset \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Authorization: Bearer $SPECT...KEY" \
   -H "Content-Type: application/json" \
   -d '{"dataset": "wallet_ledger", "format": "csv", "network": "solana-mainnet"}'
 
 # Download when ready
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+curl -H "Authorization: Bearer $SPECT...KEY" \
   http://127.0.0.1:3000/v1/export/jobs/<JOB_ID>/download
 ```
+
+Export jobs write two files to the configured export directory:
+- `{job_id}.csv` or `{job_id}.jsonl` — the data artifact
+- `{job_id}.provenance.json` — sidecar with dataset version, completeness status, coverage bounds, and record count
+
+The provenance file is useful for downstream pipelines that need to know whether the export is complete or partial before processing.
 
 Export jobs are durable with heartbeat-based worker execution. Supported sinks: `local_file` and `webhook`.
 

--- a/adapters/src/dual_write.rs
+++ b/adapters/src/dual_write.rs
@@ -36,6 +36,10 @@ pub struct BronzeSilverResult {
     pub last_raw_transaction_id: Option<uuid::Uuid>,
     /// The latest raw_transaction timestamp in the input batch.
     pub last_timestamp: Option<i64>,
+    /// Coverage start (min timestamp) across all raw transactions.
+    pub coverage_start: Option<i64>,
+    /// Coverage end (max timestamp) across all raw transactions.
+    pub coverage_end: Option<i64>,
     /// Gold wallet_ledger records successfully written.
     pub gold_wallet_ledger_written: usize,
     /// Gold balance_history records successfully written.
@@ -1281,6 +1285,8 @@ impl Repository {
         let mut result = BronzeSilverResult {
             last_raw_transaction_id: raw_txs.iter().max_by_key(|r| r.timestamp).map(|r| r.id),
             last_timestamp: raw_txs.iter().map(|r| r.timestamp).max(),
+            coverage_start: raw_txs.iter().map(|r| r.timestamp).min(),
+            coverage_end: raw_txs.iter().map(|r| r.timestamp).max(),
             ..Default::default()
         };
 

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -349,7 +349,9 @@ async fn execute_export_job(
                 {
                     let err_msg = format!("Failed to write provenance sidecar: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                    best_effort_unlink(&final_path, job_id).await;
+                    if !lease_lost.is_cancelled() {
+                        best_effort_unlink(&final_path, job_id).await;
+                    }
                     let _ = update_or_abort(
                         repo,
                         job_id,
@@ -366,6 +368,17 @@ async fn execute_export_job(
                         prov_lri,
                     )
                     .await;
+                    heartbeat_cancel.cancel();
+                    return;
+                }
+
+                // Guard sink delivery with a lease check: a reclaimed worker
+                // must not deliver stale output to the sink.
+                if lease_lost.is_cancelled() {
+                    warn!(
+                        job_id = %job_id,
+                        "Lease lost before sink delivery — skipping delivery"
+                    );
                     heartbeat_cancel.cancel();
                     return;
                 }
@@ -548,7 +561,9 @@ async fn execute_export_job(
                 {
                     let err_msg = format!("Failed to write provenance sidecar: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                    best_effort_unlink(&final_path, job_id).await;
+                    if !lease_lost.is_cancelled() {
+                        best_effort_unlink(&final_path, job_id).await;
+                    }
                     let _ = update_or_abort(
                         repo,
                         job_id,

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -344,6 +344,7 @@ async fn execute_export_job(
                     prov_cs,
                     prov_cc,
                     prov_lri,
+                    &lease_lost,
                 )
                 .await
                 {
@@ -556,6 +557,7 @@ async fn execute_export_job(
                     prov_cs,
                     prov_cc,
                     prov_lri,
+                    &lease_lost,
                 )
                 .await
                 {
@@ -719,6 +721,7 @@ async fn write_provenance_file(
     completeness_status: Option<&str>,
     completeness_coverage: Option<&serde_json::Value>,
     last_ingestion_run_id: Option<Uuid>,
+    lease_lost: &CancellationToken,
 ) -> std::io::Result<()> {
     let prov = serde_json::json!({
         "export_job_id": job_id,
@@ -746,6 +749,15 @@ async fn write_provenance_file(
     file.write_all(prov.to_string().as_bytes()).await?;
     file.flush().await?;
     drop(file);
+
+    if lease_lost.is_cancelled() {
+        tokio::fs::remove_file(&temp_path).await.ok();
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "lease lost before provenance publish",
+        ));
+    }
+
     tokio::fs::rename(&temp_path, path).await?;
     Ok(())
 }

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -721,6 +721,7 @@ async fn update_or_abort(
 }
 
 /// Write a provenance sidecar JSON file next to the export artifact.
+#[allow(clippy::too_many_arguments)]
 async fn write_provenance_file(
     path: &str,
     job_id: Uuid,
@@ -764,8 +765,7 @@ async fn write_provenance_file(
 
     if lease_lost.is_cancelled() {
         tokio::fs::remove_file(&temp_path).await.ok();
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "lease lost before provenance publish",
         ));
     }

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -28,6 +28,7 @@ use spectraplex_adapters::repo::Repository;
 use spectraplex_core::config::AppConfig;
 use spectraplex_core::materializer::{DeliveryMetadata, ExportFormat, SinkConfig};
 use spectraplex_core::v2::ExportJob;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -328,6 +329,25 @@ async fn execute_export_job(
                     return;
                 }
 
+                // Write provenance sidecar file alongside the export artifact.
+                let prov_path = format!("{}/{}.provenance.json", exports_dir, job_id);
+                if let Err(e) = write_provenance_file(
+                    &prov_path,
+                    job_id,
+                    &job.dataset.to_string(),
+                    format,
+                    record_count,
+                    prov_dv_id,
+                    prov_dv,
+                    prov_cs,
+                    prov_cc,
+                    prov_lri,
+                )
+                .await
+                {
+                    warn!(job_id = %job_id, error = %e, "Failed to write provenance file (non-fatal)");
+                }
+
                 // Deliver to the sink from the already-streamed file.
                 // `deliver_from_file` avoids loading the full artifact
                 // into memory (fixes PR #238 [P2] sink-OOM concern):
@@ -486,6 +506,25 @@ async fn execute_export_job(
                     return;
                 }
 
+                // Write provenance sidecar file alongside the export artifact.
+                let prov_path = format!("{}/{}.provenance.json", exports_dir, job_id);
+                if let Err(e) = write_provenance_file(
+                    &prov_path,
+                    job_id,
+                    &job.dataset.to_string(),
+                    format,
+                    record_count,
+                    prov_dv_id,
+                    prov_dv,
+                    prov_cs,
+                    prov_cc,
+                    prov_lri,
+                )
+                .await
+                {
+                    warn!(job_id = %job_id, error = %e, "Failed to write provenance file (non-fatal)");
+                }
+
                 info!(
                     job_id = %job_id,
                     record_count,
@@ -606,6 +645,38 @@ async fn update_or_abort(
             Err(())
         }
     }
+}
+
+/// Write a provenance sidecar JSON file next to the export artifact.
+async fn write_provenance_file(
+    path: &str,
+    job_id: Uuid,
+    dataset: &str,
+    format: spectraplex_core::materializer::ExportFormat,
+    record_count: usize,
+    dataset_version_id: Option<Uuid>,
+    dataset_version: Option<i32>,
+    completeness_status: Option<&str>,
+    completeness_coverage: Option<&serde_json::Value>,
+    last_ingestion_run_id: Option<Uuid>,
+) -> std::io::Result<()> {
+    let prov = serde_json::json!({
+        "export_job_id": job_id,
+        "dataset": dataset,
+        "format": format.to_string(),
+        "record_count": record_count,
+        "exported_at": chrono::Utc::now().to_rfc3339(),
+        "dataset_version_id": dataset_version_id,
+        "dataset_version": dataset_version,
+        "completeness_status": completeness_status,
+        "completeness_coverage": completeness_coverage,
+        "last_ingestion_run_id": last_ingestion_run_id,
+    });
+
+    let mut file = tokio::fs::File::create(path).await?;
+    file.write_all(prov.to_string().as_bytes()).await?;
+    file.flush().await?;
+    Ok(())
 }
 
 /// Parse the filters JSON value from an export job into individual query

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -305,6 +305,15 @@ async fn execute_export_job(
                 // artifact. rename is atomic within the same
                 // filesystem; the exports_dir is a single dir so this
                 // holds.
+                if lease_lost.is_cancelled() {
+                    warn!(
+                        job_id = %job_id,
+                        "Lease lost before artifact rename — discarding temp"
+                    );
+                    best_effort_unlink(&temp_path, job_id).await;
+                    heartbeat_cancel.cancel();
+                    return;
+                }
                 if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
                     let err_msg = format!("Failed to publish export artifact: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
@@ -350,9 +359,6 @@ async fn execute_export_job(
                 {
                     let err_msg = format!("Failed to write provenance sidecar: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                    if !lease_lost.is_cancelled() {
-                        best_effort_unlink(&final_path, job_id).await;
-                    }
                     let _ = update_or_abort(
                         repo,
                         job_id,
@@ -518,6 +524,15 @@ async fn execute_export_job(
                 // the lease-confirming `delivering` update above, so a
                 // stale worker never publishes over the new owner's
                 // artifact.
+                if lease_lost.is_cancelled() {
+                    warn!(
+                        job_id = %job_id,
+                        "Lease lost before artifact rename — discarding temp"
+                    );
+                    best_effort_unlink(&temp_path, job_id).await;
+                    heartbeat_cancel.cancel();
+                    return;
+                }
                 if let Err(e) = tokio::fs::rename(&temp_path, &final_path).await {
                     let err_msg = format!("Failed to publish export artifact: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
@@ -563,9 +578,6 @@ async fn execute_export_job(
                 {
                     let err_msg = format!("Failed to write provenance sidecar: {e}");
                     error!(job_id = %job_id, error = %err_msg, "Export job failed");
-                    if !lease_lost.is_cancelled() {
-                        best_effort_unlink(&final_path, job_id).await;
-                    }
                     let _ = update_or_abort(
                         repo,
                         job_id,

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -335,6 +335,7 @@ async fn execute_export_job(
                 if let Err(e) = write_provenance_file(
                     &prov_path,
                     job_id,
+                    worker_id,
                     job.dataset.as_sql_str(),
                     format,
                     record_count,
@@ -533,6 +534,7 @@ async fn execute_export_job(
                 if let Err(e) = write_provenance_file(
                     &prov_path,
                     job_id,
+                    worker_id,
                     job.dataset.as_sql_str(),
                     format,
                     record_count,
@@ -595,15 +597,14 @@ async fn execute_export_job(
                         // Lease was taken between the `delivering`
                         // transition and the `completed` transition
                         // (narrow window — our lease-holding update to
-                        // `delivering` just succeeded). Pull the
-                        // published artifact and provenance back so the
-                        // new owner does not serve our output via `/download`.
+                        // `delivering` just succeeded). Do NOT unlink
+                        // canonical paths here: a reclaiming worker may
+                        // have already published new output, and deleting
+                        // final_path/prov_path would race against it.
                         warn!(
                             job_id = %job_id,
-                            "Lease lost at final update — unpublishing artifact and provenance"
+                            "Lease lost at final update — leaving artifact/provenance for new owner"
                         );
-                        best_effort_unlink(&final_path, job_id).await;
-                        best_effort_unlink(&prov_path, job_id).await;
                     }
                 }
             }
@@ -694,6 +695,7 @@ async fn update_or_abort(
 async fn write_provenance_file(
     path: &str,
     job_id: Uuid,
+    worker_id: &str,
     dataset: &str,
     format: spectraplex_core::materializer::ExportFormat,
     record_count: usize,
@@ -716,9 +718,15 @@ async fn write_provenance_file(
         "last_ingestion_run_id": last_ingestion_run_id,
     });
 
-    // Atomic write: temp file -> rename so crashes or partial writes never
-    // leave a truncated sidecar next to the artifact.
-    let temp_path = format!("{}.tmp", path);
+    // Atomic write with attempt-scoped temp path so concurrent/reclaimed
+    // workers cannot clobber each other's sidecar temp.
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    worker_id.hash(&mut h);
+    let tag = format!("{:016x}", h.finish());
+    let temp_path = format!("{}.{}.tmp", path, tag);
+
     let mut file = tokio::fs::File::create(&temp_path).await?;
     file.write_all(prov.to_string().as_bytes()).await?;
     file.flush().await?;

--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -330,11 +330,12 @@ async fn execute_export_job(
                 }
 
                 // Write provenance sidecar file alongside the export artifact.
+                // Provenance is required for a complete export; failure fails the job.
                 let prov_path = format!("{}/{}.provenance.json", exports_dir, job_id);
                 if let Err(e) = write_provenance_file(
                     &prov_path,
                     job_id,
-                    &job.dataset.to_string(),
+                    job.dataset.as_sql_str(),
                     format,
                     record_count,
                     prov_dv_id,
@@ -345,7 +346,27 @@ async fn execute_export_job(
                 )
                 .await
                 {
-                    warn!(job_id = %job_id, error = %e, "Failed to write provenance file (non-fatal)");
+                    let err_msg = format!("Failed to write provenance sidecar: {e}");
+                    error!(job_id = %job_id, error = %err_msg, "Export job failed");
+                    best_effort_unlink(&final_path, job_id).await;
+                    let _ = update_or_abort(
+                        repo,
+                        job_id,
+                        "failed",
+                        Some(record_count as i32),
+                        Some(&result_location),
+                        Some(&err_msg),
+                        worker_id,
+                        None,
+                        prov_dv_id,
+                        prov_dv,
+                        prov_cs,
+                        prov_cc,
+                        prov_lri,
+                    )
+                    .await;
+                    heartbeat_cancel.cancel();
+                    return;
                 }
 
                 // Deliver to the sink from the already-streamed file.
@@ -507,11 +528,12 @@ async fn execute_export_job(
                 }
 
                 // Write provenance sidecar file alongside the export artifact.
+                // Provenance is required for a complete export; failure fails the job.
                 let prov_path = format!("{}/{}.provenance.json", exports_dir, job_id);
                 if let Err(e) = write_provenance_file(
                     &prov_path,
                     job_id,
-                    &job.dataset.to_string(),
+                    job.dataset.as_sql_str(),
                     format,
                     record_count,
                     prov_dv_id,
@@ -522,7 +544,27 @@ async fn execute_export_job(
                 )
                 .await
                 {
-                    warn!(job_id = %job_id, error = %e, "Failed to write provenance file (non-fatal)");
+                    let err_msg = format!("Failed to write provenance sidecar: {e}");
+                    error!(job_id = %job_id, error = %err_msg, "Export job failed");
+                    best_effort_unlink(&final_path, job_id).await;
+                    let _ = update_or_abort(
+                        repo,
+                        job_id,
+                        "failed",
+                        Some(record_count as i32),
+                        Some(&result_location),
+                        Some(&err_msg),
+                        worker_id,
+                        None,
+                        prov_dv_id,
+                        prov_dv,
+                        prov_cs,
+                        prov_cc,
+                        prov_lri,
+                    )
+                    .await;
+                    heartbeat_cancel.cancel();
+                    return;
                 }
 
                 info!(
@@ -554,13 +596,14 @@ async fn execute_export_job(
                         // transition and the `completed` transition
                         // (narrow window — our lease-holding update to
                         // `delivering` just succeeded). Pull the
-                        // published artifact back so the new owner does
-                        // not serve our output via `/download`.
+                        // published artifact and provenance back so the
+                        // new owner does not serve our output via `/download`.
                         warn!(
                             job_id = %job_id,
-                            "Lease lost at final update — unpublishing artifact"
+                            "Lease lost at final update — unpublishing artifact and provenance"
                         );
                         best_effort_unlink(&final_path, job_id).await;
+                        best_effort_unlink(&prov_path, job_id).await;
                     }
                 }
             }
@@ -673,9 +716,14 @@ async fn write_provenance_file(
         "last_ingestion_run_id": last_ingestion_run_id,
     });
 
-    let mut file = tokio::fs::File::create(path).await?;
+    // Atomic write: temp file -> rename so crashes or partial writes never
+    // leave a truncated sidecar next to the artifact.
+    let temp_path = format!("{}.tmp", path);
+    let mut file = tokio::fs::File::create(&temp_path).await?;
     file.write_all(prov.to_string().as_bytes()).await?;
     file.flush().await?;
+    drop(file);
+    tokio::fs::rename(&temp_path, path).await?;
     Ok(())
 }
 

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -11,6 +11,7 @@ use crate::fire_callback;
 use spectraplex_adapters::dual_write::BronzeSilverResult;
 use spectraplex_adapters::repo::Repository;
 use spectraplex_core::config::AppConfig;
+use spectraplex_core::v2::{CompletenessStatus, DatasetCompleteness};
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -214,6 +215,36 @@ async fn worker_tick(
                                 // under non-authoritative scope values.
                                 let wm_resolved = match task_repo.get_ingestion_run(irun_id).await {
                                     Ok(Some(irun)) => {
+                                        // Upsert dataset completeness for each materialized dataset.
+                                        for (dataset_name, ds_count) in &silver_result.per_dataset {
+                                            let status = if silver_result.all_succeeded() {
+                                                CompletenessStatus::Complete
+                                            } else {
+                                                CompletenessStatus::Partial
+                                            };
+                                            let dc = DatasetCompleteness {
+                                                id: Uuid::new_v4(),
+                                                target_id: irun.target_id.unwrap_or_else(Uuid::new_v4),
+                                                dataset_name: dataset_name.clone(),
+                                                dataset_version_id: None,
+                                                network: irun.network.clone(),
+                                                status,
+                                                coverage_start: silver_result.coverage_start,
+                                                coverage_end: silver_result.coverage_end,
+                                                block_start: None,
+                                                block_end: None,
+                                                last_ingestion_run_id: Some(irun_id),
+                                                records_count: *ds_count as i64,
+                                                gap_ranges: None,
+                                                notes: None,
+                                                created_at: chrono::Utc::now(),
+                                                updated_at: chrono::Utc::now(),
+                                            };
+                                            if let Err(e) = task_repo.upsert_dataset_completeness(&dc).await {
+                                                warn!(run_id = %run_id, dataset = %dataset_name, error = %e, "Failed to upsert dataset completeness (non-fatal)");
+                                            }
+                                        }
+
                                         let w = if let Some(tid) = irun.target_id {
                                             task_repo
                                                 .get_index_target(tid)

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -224,7 +224,9 @@ async fn worker_tick(
                                             };
                                             let dc = DatasetCompleteness {
                                                 id: Uuid::new_v4(),
-                                                target_id: irun.target_id.unwrap_or_else(Uuid::new_v4),
+                                                target_id: irun
+                                                    .target_id
+                                                    .unwrap_or_else(Uuid::new_v4),
                                                 dataset_name: dataset_name.clone(),
                                                 dataset_version_id: None,
                                                 network: irun.network.clone(),
@@ -240,7 +242,9 @@ async fn worker_tick(
                                                 created_at: chrono::Utc::now(),
                                                 updated_at: chrono::Utc::now(),
                                             };
-                                            if let Err(e) = task_repo.upsert_dataset_completeness(&dc).await {
+                                            if let Err(e) =
+                                                task_repo.upsert_dataset_completeness(&dc).await
+                                            {
                                                 warn!(run_id = %run_id, dataset = %dataset_name, error = %e, "Failed to upsert dataset completeness (non-fatal)");
                                             }
                                         }


### PR DESCRIPTION
## Summary

Implements Phase P1 from the MVP plan: dataset completeness tracking and export provenance sidecars.

## Changes

- **adapters/src/dual_write.rs**: BronzeSilverResult now carries coverage_start/coverage_end from raw tx timestamps
- **api/src/materialize_worker.rs**: Upserts DatasetCompleteness per dataset after successful materialization runs (Complete/Partial status, coverage bounds, record counts)
- **api/src/export_worker.rs**: Writes {job_id}.provenance.json sidecar alongside export artifact with completeness metadata
- **README.md**: Added completeness docs, provenance explanation, and dataset status endpoint examples

## Acceptance

- [x] cargo check passes
- [x] cargo test --workspace passes (237 tests)
- [x] fmt clean

## Plan

P0 ✓ | **P1 in review** | P2 | P3 | P4