### PR TITLE
feat(P0): honest smoke test and README alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ Tenant-scoped dataset queries require `target_id`:
 curl -H "Authorization: Bearer $API_KEY" \
   "http://127.0.0.1:3000/v1/datasets/token_transfers/records?target_id=<TARGET_ID>&network=solana-mainnet&limit=50"
 
-# Check dataset completeness
-curl -H "Authorization: Bearer $API_KEY" \
+# Check dataset completeness (requires legacy/admin key — not tenant-scoped)
+curl -H "Authorization: Bearer $LEGACY_KEY" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/completeness
 
-# Check dataset status (aggregated across targets)
-curl -H "Authorization: Bearer $API_KEY" \
+# Check dataset status (requires legacy/admin key — not tenant-scoped)
+curl -H "Authorization: Bearer $LEGACY_KEY" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/status
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ Ingestion jobs are durable — they persist across restarts and are claimed by b
 ### Real-Time Streaming
 
 ```bash
-# Start a Solana gRPC stream (requires SOLANA_GRPC_URL)
+# Start a Solana gRPC stream (requires SOLANA_GRPC_URL and legacy/admin key)
 curl -X POST http://127.0.0.1:3000/v1/stream/start \
-  -H "Authorization: Bearer $API_KEY" \
+  -H "Authorization: Bearer $LEGACY_KEY" \
   -H "Content-Type: application/json" \
   -d '{"chain": "solana"}'
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Operators who no longer need V1 tables can set `enable_v1_compat_writes = false`
 
 All `/v1/*` routes require `Authorization: Bearer <API_KEY>`.
 
-Tenant-scoped API keys (created via `POST /v1/api-keys`) are required for dataset queries and exports. The legacy config key (`SPECTRAPLEX_API_KEY`) can create tenant keys but does not itself support tenant-scoped endpoints.
+Tenant-scoped API keys (created via `POST /v1/api-keys`) are required for tenant isolation on dataset queries and exports. The legacy config key (`SPECTRAPLEX_API_KEY`) can also call these endpoints (without tenant isolation) and is used to bootstrap the first tenant key.
 
 ### Ingestion and Jobs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ cargo run --bin spectraplex-api
 
 # Run the smoke test (in another terminal)
 ./scripts/smoke-test.sh
+
+# Or skip provider-dependent ingestion if you don't have live RPC access:
+# ./scripts/smoke-test.sh --skip-ingest
 ```
 
 Requires Rust (stable) and PostgreSQL 15+. Docker handles Postgres if you don't have one running.
@@ -109,19 +112,21 @@ Operators who no longer need V1 tables can set `enable_v1_compat_writes = false`
 
 ## API
 
-All `/v1/*` routes require `Authorization: Bearer <SPECT...Y>`.
+All `/v1/*` routes require `Authorization: Bearer <API_KEY>`.
+
+Tenant-scoped API keys (created via `POST /v1/api-keys`) are required for dataset queries and exports. The legacy config key (`SPECTRAPLEX_API_KEY`) can create tenant keys but does not itself support tenant-scoped endpoints.
 
 ### Ingestion and Jobs
 
 ```bash
-# Trigger ingestion
+# Trigger ingestion (wallet + network; API auto-creates the target)
 curl -X POST http://127.0.0.1:3000/v1/ingest \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"chain": "solana", "wallet": "<ADDRESS>", "rpc_url": "https://api.mainnet-beta.solana.com"}'
+  -d '{"wallet": "<ADDRESS>", "network": "solana-mainnet"}'
 
 # Check job status
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+curl -H "Authorization: Bearer $API_KEY" \
   http://127.0.0.1:3000/v1/jobs/<JOB_ID>
 ```
 
@@ -132,23 +137,23 @@ Ingestion jobs are durable — they persist across restarts and are claimed by b
 ```bash
 # Start a Solana gRPC stream (requires SOLANA_GRPC_URL)
 curl -X POST http://127.0.0.1:3000/v1/stream/start \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"chain": "solana"}'
 
 # Start a Hyperliquid WebSocket stream for a wallet
 curl -X POST http://127.0.0.1:3000/v1/stream/start \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"chain": "hyperliquid", "wallet": "0x..."}'
 
 # List active streams
-curl -H "Authorization: Bearer $SPECTRAPLEX_API_KEY" \
+curl -H "Authorization: Bearer $API_KEY" \
   http://127.0.0.1:3000/v1/streams
 
 # Stop a stream
 curl -X POST http://127.0.0.1:3000/v1/stream/<STREAM_ID>/stop \
-  -H "Authorization: Bearer $SPECTRAPLEX_API_KEY"
+  -H "Authorization: Bearer $API_KEY"
 ```
 
 Stream subscriptions are durable and create `ingestion_runs` per flush batch with full Bronze lineage. Hyperliquid streams subscribe to user fills, funding, and ledger updates via WebSocket with automatic reconnection.
@@ -191,17 +196,19 @@ curl -X DELETE http://127.0.0.1:3000/v1/api-keys/<KEY_ID> \
 
 ### Query Datasets
 
+Tenant-scoped dataset queries require `target_id`:
+
 ```bash
-# Query any dataset with filters
-curl -H "Authorization: Bearer $SPECT...KEY" \
-  "http://127.0.0.1:3000/v1/datasets/token_transfers/records?network=solana-mainnet&limit=50"
+# Query a dataset (tenant-scoped)
+curl -H "Authorization: Bearer $API_KEY" \
+  "http://127.0.0.1:3000/v1/datasets/token_transfers/records?target_id=<TARGET_ID>&network=solana-mainnet&limit=50"
 
 # Check dataset completeness
-curl -H "Authorization: Bearer $SPECT...KEY" \
+curl -H "Authorization: Bearer $API_KEY" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/completeness
 
 # Check dataset status (aggregated across targets)
-curl -H "Authorization: Bearer $SPECT...KEY" \
+curl -H "Authorization: Bearer $API_KEY" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/status
 ```
 
@@ -209,15 +216,17 @@ Dataset completeness is tracked per target and network. After each materializati
 
 ### Export
 
+Tenant-scoped exports require `target_id`:
+
 ```bash
 # Create an export job (CSV or JSONL)
 curl -X POST http://127.0.0.1:3000/v1/export/dataset \
-  -H "Authorization: Bearer $SPECT...KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"dataset": "wallet_ledger", "format": "csv", "network": "solana-mainnet"}'
+  -d '{"dataset": "wallet_ledger", "format": "csv", "target_id": "<TARGET_ID>", "network": "solana-mainnet"}'
 
 # Download when ready
-curl -H "Authorization: Bearer $SPECT...KEY" \
+curl -H "Authorization: Bearer $API_KEY" \
   http://127.0.0.1:3000/v1/export/jobs/<JOB_ID>/download
 ```
 
@@ -235,9 +244,9 @@ When `callback_hmac_secret` is configured, callback payloads include an `X-Spect
 
 ```bash
 curl -X POST http://127.0.0.1:3000/v1/ingest \
-  -H "Authorization: Bearer $SPECT...KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"chain": "solana", "wallet": "<ADDRESS>", "callback_url": "https://your-app.example.com/webhook"}'
+  -d '{"wallet": "<ADDRESS>", "network": "solana-mainnet", "callback_url": "https://your-app.example.com/webhook"}'
 ```
 
 The webhook receiver can verify the signature:

--- a/scripts/smoke-config.toml
+++ b/scripts/smoke-config.toml
@@ -3,7 +3,7 @@ host = "127.0.0.1"
 database_url = "postgres://spectraplex:spectraplex@localhost:5432/spectraplex"
 pool_size = 10
 log_level = "info"
-ingest_limit = 50
+ingest_limit = 10
 export_dir = "./exports"
 
 # Legacy admin API key used to bootstrap the first tenant key.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4,16 +4,23 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Spectraplex API Smoke Test
 # ---------------------------------------------------------------------------
-# Proves the API happy path end-to-end:
+# Proves the supported API path end-to-end on a fresh local environment.
+#
+# Steps:
 #   1. Start Postgres
 #   2. Start the API server
 #   3. Create a tenant-scoped API key (using legacy admin key)
 #   4. Register a wallet target
-#   5. Enqueue ingestion
+#   5. Trigger ingestion (wallet + network)
 #   6. Poll job status
-#   7. Query wallet_ledger dataset
-#   8. Create and poll an export job
-#   9. Clean up
+#   7. Query dataset records (tenant-scoped via target_id)
+#   8. Create and poll an export job (tenant-scoped via target_id)
+#   9. Verify tenant-scoped API key lifecycle
+#   10. Clean up
+#
+# The script fails loudly on any unexpected HTTP response.
+# If live providers are unavailable, use --skip-ingest to test the API surface
+# without provider-dependent steps.
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,18 +31,65 @@ TENANT_KEY=""
 TARGET_WALLET="So11111111111111111111111111111111111111112"
 TARGET_NETWORK="solana-mainnet"
 
+SKIP_INGEST=false
+for arg in "$@"; do
+  if [[ "$arg" == "--skip-ingest" ]]; then
+    SKIP_INGEST=true
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+curl_json() {
+  local method="${1:-GET}"
+  local url="$2"
+  local auth="${3:-}"
+  local body="${4:-}"
+
+  local cmd=(curl -s -w "\n%{http_code}" -X "$method" "$url")
+  if [[ -n "$auth" ]]; then
+    cmd+=(-H "Authorization: Bearer $auth")
+  fi
+  cmd+=(-H "Content-Type: application/json")
+  if [[ -n "$body" ]]; then
+    cmd+=(-d "$body")
+  fi
+
+  local resp
+  resp=$("${cmd[@]}")
+  local http_code
+  http_code=$(echo "$resp" | tail -n1)
+  local body_lines
+  body_lines=$(echo "$resp" | sed '$d')
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    echo "ERROR: HTTP $http_code from $url" >&2
+    echo "Response: $body_lines" >&2
+    return 1
+  fi
+
+  echo "$body_lines"
+}
+
+extract_json() {
+  local json="$1"
+  local key="$2"
+  echo "$json" | python3 -c "import sys, json; print(json.load(sys.stdin)['$key'])" 2>/dev/null || true
+}
+
 echo "=== Spectraplex Smoke Test ==="
 echo ""
 
 # ---------------------------------------------------------------------------
 # 1. Start Postgres
 # ---------------------------------------------------------------------------
-echo "[1/9] Starting Postgres..."
+echo "[1/10] Starting Postgres..."
 cd "$PROJECT_DIR"
 docker-compose up -d postgres >/dev/null 2>&1 || docker compose up -d postgres >/dev/null 2>&1
-echo "       Postgres running on :5432"
+echo "       Postgres started"
 
-# Wait for Postgres to be ready
 for i in {1..30}; do
   if pg_isready -h localhost -p 5432 -U spectraplex >/dev/null 2>&1; then
     break
@@ -44,9 +98,9 @@ for i in {1..30}; do
 done
 
 # ---------------------------------------------------------------------------
-# 2. Build and start the API server in the background
+# 2. Build and start the API server
 # ---------------------------------------------------------------------------
-echo "[2/9] Building API server..."
+echo "[2/10] Building API server..."
 cd "$PROJECT_DIR"
 cargo build --bin spectraplex-api --quiet
 
@@ -55,7 +109,6 @@ export SPECTRAPLEX_CONFIG="$SCRIPT_DIR/smoke-config.toml"
 "$PROJECT_DIR/target/debug/spectraplex-api" &
 API_PID=$!
 
-# Wait for API to be ready
 for i in {1..30}; do
   if curl -sf "$API_URL/health" >/dev/null 2>&1; then
     break
@@ -64,7 +117,6 @@ for i in {1..30}; do
 done
 echo "       API running on $API_URL (PID $API_PID)"
 
-# Cleanup function
 cleanup() {
   echo ""
   echo "=== Cleaning up ==="
@@ -79,18 +131,9 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------------
 # 3. Create a tenant-scoped API key
 # ---------------------------------------------------------------------------
-echo "[3/9] Creating tenant API key..."
-CREATE_RESP=$(curl -sf -X POST "$API_URL/v1/api-keys" \
-  -H "Authorization: Bearer $LEGACY_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"smoke-test-key"}' || true)
-
-if [[ -z "$CREATE_RESP" ]]; then
-  echo "ERROR: Failed to create API key"
-  exit 1
-fi
-
-TENANT_KEY=$(echo "$CREATE_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])" 2>/dev/null || true)
+echo "[3/10] Creating tenant API key..."
+CREATE_RESP=$(curl_json POST "$API_URL/v1/api-keys" "$LEGACY_KEY" '{"name":"smoke-test-key"}')
+TENANT_KEY=$(extract_json "$CREATE_RESP" "key")
 if [[ -z "$TENANT_KEY" ]]; then
   echo "ERROR: Could not parse API key from response: $CREATE_RESP"
   exit 1
@@ -100,100 +143,88 @@ echo "       Created tenant key: ${TENANT_KEY:0:12}..."
 # ---------------------------------------------------------------------------
 # 4. Register a wallet target
 # ---------------------------------------------------------------------------
-echo "[4/9] Registering wallet target..."
-TARGET_RESP=$(curl -sf -X POST "$API_URL/v1/targets" \
-  -H "Authorization: Bearer $TENANT_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"kind\":\"wallet\",\"network\":\"$TARGET_NETWORK\",\"address\":\"$TARGET_WALLET\",\"mode\":\"both\"}" || true)
-
-if [[ -z "$TARGET_RESP" ]]; then
-  echo "ERROR: Failed to register target"
+echo "[4/10] Registering wallet target..."
+TARGET_RESP=$(curl_json POST "$API_URL/v1/targets" "$TENANT_KEY" \
+  "{\"kind\":\"wallet\",\"network\":\"$TARGET_NETWORK\",\"address\":\"$TARGET_WALLET\",\"mode\":\"both\"}")
+TARGET_ID=$(extract_json "$TARGET_RESP" "id")
+if [[ -z "$TARGET_ID" ]]; then
+  echo "ERROR: Could not parse target ID from response: $TARGET_RESP"
   exit 1
 fi
-TARGET_ID=$(echo "$TARGET_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null || true)
 echo "       Registered target: $TARGET_ID"
 
 # ---------------------------------------------------------------------------
-# 5. Enqueue ingestion
+# 5. Trigger ingestion
 # ---------------------------------------------------------------------------
-echo "[5/9] Enqueuing ingestion job..."
-INGEST_RESP=$(curl -sf -X POST "$API_URL/v1/ingest" \
-  -H "Authorization: Bearer $TENANT_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"target_id\":\"$TARGET_ID\",\"start_slot\":0,\"end_slot\":10}" || true)
-
-if [[ -z "$INGEST_RESP" ]]; then
-  echo "WARNING: Ingest endpoint did not return a response (may be expected without live provider)"
+echo "[5/10] Triggering ingestion..."
+if [[ "$SKIP_INGEST" == true ]]; then
+  echo "       SKIPPED (--skip-ingest): skipping provider-dependent ingestion"
   JOB_ID=""
 else
-  JOB_ID=$(echo "$INGEST_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('job_id',''))" 2>/dev/null || true)
-  echo "       Ingest job enqueued: ${JOB_ID:-(no job id)}"
+  INGEST_RESP=$(curl_json POST "$API_URL/v1/ingest" "$TENANT_KEY" \
+    "{\"wallet\":\"$TARGET_WALLET\",\"network\":\"$TARGET_NETWORK\"}")
+  JOB_ID=$(extract_json "$INGEST_RESP" "id")
+  if [[ -z "$JOB_ID" ]]; then
+    echo "ERROR: Could not parse job ID from ingest response: $INGEST_RESP"
+    exit 1
+  fi
+  echo "       Ingest job enqueued: $JOB_ID"
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Poll job status (briefly)
+# 6. Poll job status
 # ---------------------------------------------------------------------------
-echo "[6/9] Polling job status..."
+echo "[6/10] Polling job status..."
 if [[ -n "$JOB_ID" ]]; then
-  for i in {1..5}; do
-    JOB_STATUS=$(curl -sf "$API_URL/v1/jobs/$JOB_ID" \
-      -H "Authorization: Bearer $TENANT_KEY" || true)
-    if [[ -n "$JOB_STATUS" ]]; then
-      STATUS=$(echo "$JOB_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo "unknown")
-      echo "       Job status: $STATUS"
-      if [[ "$STATUS" == "completed" || "$STATUS" == "failed" ]]; then
-        break
-      fi
+  for i in {1..10}; do
+    JOB_STATUS=$(curl_json GET "$API_URL/v1/jobs/$JOB_ID" "$TENANT_KEY")
+    STATUS=$(echo "$JOB_STATUS" | python3 -c "import sys, json; print(json.load(sys.stdin).get('state','unknown'))" 2>/dev/null || echo "unknown")
+    echo "       Job status: $STATUS"
+    if [[ "$STATUS" == "completed" || "$STATUS" == "failed" ]]; then
+      break
     fi
     sleep 2
   done
 else
-  echo "       Skipped (no job id)"
+  echo "       Skipped (no job ID)"
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Query wallet_ledger dataset
+# 7. Query dataset records (tenant-scoped via target_id)
 # ---------------------------------------------------------------------------
-echo "[7/9] Querying wallet_ledger dataset..."
-LEDGER_RESP=$(curl -sf "$API_URL/v1/datasets/wallet_ledger/records?wallet=$TARGET_WALLET&limit=10" \
-  -H "Authorization: Bearer $TENANT_KEY" || true)
+echo "[7/10] Querying token_transfers dataset (tenant-scoped)..."
+DATASET_RESP=$(curl_json GET "$API_URL/v1/datasets/token_transfers/records?target_id=$TARGET_ID&limit=10" "$TENANT_KEY")
+RECORD_COUNT=$(echo "$DATASET_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('records',[])))" 2>/dev/null || echo "0")
+echo "       Records returned: $RECORD_COUNT"
 
-if [[ -n "$LEDGER_RESP" ]]; then
-  RECORD_COUNT=$(echo "$LEDGER_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('records',[])))" 2>/dev/null || echo "0")
-  echo "       Ledger records returned: $RECORD_COUNT"
-else
-  echo "       No ledger records (expected for empty/test wallet)"
+# ---------------------------------------------------------------------------
+# 8. Create an export job (tenant-scoped via target_id)
+# ---------------------------------------------------------------------------
+echo "[8/10] Creating dataset export job (tenant-scoped)..."
+EXPORT_RESP=$(curl_json POST "$API_URL/v1/export/dataset" "$TENANT_KEY" \
+  "{\"dataset\":\"token_transfers\",\"format\":\"jsonl\",\"target_id\":\"$TARGET_ID\",\"network\":\"$TARGET_NETWORK\",\"sink\":{\"type\":\"local_file\",\"path\":\"smoke-export.jsonl\"}}")
+EXPORT_JOB_ID=$(extract_json "$EXPORT_RESP" "id")
+if [[ -z "$EXPORT_JOB_ID" ]]; then
+  echo "ERROR: Could not parse export job ID from response: $EXPORT_RESP"
+  exit 1
 fi
+echo "       Export job created: $EXPORT_JOB_ID"
 
 # ---------------------------------------------------------------------------
-# 8. Create an export job
+# 9. Verify API key lifecycle
 # ---------------------------------------------------------------------------
-echo "[8/9] Creating dataset export job..."
-EXPORT_RESP=$(curl -sf -X POST "$API_URL/v1/export/dataset" \
-  -H "Authorization: Bearer $TENANT_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"dataset\":\"wallet_ledger\",\"format\":\"csv\",\"wallet\":\"$TARGET_WALLET\",\"sink\":{\"type\":\"file\"}}" || true)
-
-if [[ -n "$EXPORT_RESP" ]]; then
-  EXPORT_JOB_ID=$(echo "$EXPORT_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
-  echo "       Export job created: ${EXPORT_JOB_ID:-(no id)}"
-else
-  echo "       Export endpoint did not return a response"
-fi
+echo "[9/10] Verifying API key lifecycle..."
+LIST_RESP=$(curl_json GET "$API_URL/v1/api-keys" "$TENANT_KEY")
+KEY_COUNT=$(echo "$LIST_RESP" | python3 -c "import sys, json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+echo "       Listed $KEY_COUNT active key(s)"
 
 # ---------------------------------------------------------------------------
-# 9. Verify tenant-scoped API key listing and revocation
+# 10. Verify target is listable
 # ---------------------------------------------------------------------------
-echo "[9/9] Verifying API key lifecycle..."
-LIST_RESP=$(curl -sf "$API_URL/v1/api-keys" \
-  -H "Authorization: Bearer $TENANT_KEY" || true)
-
-if [[ -n "$LIST_RESP" ]]; then
-  KEY_COUNT=$(echo "$LIST_RESP" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
-  echo "       Listed $KEY_COUNT active key(s)"
-else
-  echo "       Could not list keys"
-fi
+echo "[10/10] Verifying target listing..."
+TARGETS_RESP=$(curl_json GET "$API_URL/v1/targets?limit=10" "$TENANT_KEY")
+TARGET_COUNT=$(echo "$TARGETS_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('targets', d if isinstance(d, list) else []))))" 2>/dev/null || echo "0")
+echo "       Listed $TARGET_COUNT target(s)"
 
 echo ""
 echo "=== Smoke test completed successfully ==="
@@ -201,8 +232,13 @@ echo ""
 echo "Summary:"
 echo "  - Tenant API key created and usable"
 echo "  - Target registration works"
-echo "  - Ingestion enqueue works"
-echo "  - Job status polling works"
-echo "  - Dataset queries work"
-echo "  - Export job creation works"
+if [[ "$SKIP_INGEST" == true ]]; then
+  echo "  - Ingestion SKIPPED (--skip-ingest)"
+else
+  echo "  - Ingestion enqueue works"
+  echo "  - Job status polling works"
+fi
+echo "  - Tenant-scoped dataset queries work (target_id required)"
+echo "  - Tenant-scoped export job creation works (target_id required)"
 echo "  - API key listing works"
+echo "  - Target listing works"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,15 +6,29 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Proves the supported API path end-to-end on a fresh local environment.
 #
+# What this verifies:
+#   - API server boots and responds to health checks
+#   - Tenant API key creation and authentication work
+#   - Target registration works
+#   - Ingestion can be enqueued and its job status polled
+#   - Tenant-scoped dataset queries accept target_id and return data (if materialized)
+#   - Tenant-scoped export jobs can be created with a sink config
+#   - API key and target listing work
+#
+# What this does NOT verify (these run in background workers):
+#   - Actual RPC ingestion completion against live providers
+#   - Silver/Gold materialization (async, may take minutes)
+#   - Export job completion and file delivery (async worker process)
+#
 # Steps:
 #   1. Start Postgres
 #   2. Start the API server
 #   3. Create a tenant-scoped API key (using legacy admin key)
 #   4. Register a wallet target
 #   5. Trigger ingestion (wallet + network)
-#   6. Poll job status
+#   6. Poll job status (terminal state check)
 #   7. Query dataset records (tenant-scoped via target_id)
-#   8. Create and poll an export job (tenant-scoped via target_id)
+#   8. Create an export job (tenant-scoped via target_id)
 #   9. Verify tenant-scoped API key lifecycle
 #   10. Clean up
 #
@@ -48,7 +62,7 @@ curl_json() {
   local auth="${3:-}"
   local body="${4:-}"
 
-  local cmd=(curl -s -w "\n%{http_code}" -X "$method" "$url")
+  local cmd=(curl -sS -w "\n%{http_code}" -X "$method" "$url")
   if [[ -n "$auth" ]]; then
     cmd+=(-H "Authorization: Bearer $auth")
   fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -194,7 +194,7 @@ fi
 # ---------------------------------------------------------------------------
 echo "[7/10] Querying token_transfers dataset (tenant-scoped)..."
 DATASET_RESP=$(curl_json GET "$API_URL/v1/datasets/token_transfers/records?target_id=$TARGET_ID&limit=10" "$TENANT_KEY")
-RECORD_COUNT=$(echo "$DATASET_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('records',[])))" 2>/dev/null || echo "0")
+RECORD_COUNT=$(echo "$DATASET_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d) if isinstance(d, list) else len(d.get('records',[])))" 2>/dev/null || echo "0")
 echo "       Records returned: $RECORD_COUNT"
 
 # ---------------------------------------------------------------------------
@@ -202,7 +202,7 @@ echo "       Records returned: $RECORD_COUNT"
 # ---------------------------------------------------------------------------
 echo "[8/10] Creating dataset export job (tenant-scoped)..."
 EXPORT_RESP=$(curl_json POST "$API_URL/v1/export/dataset" "$TENANT_KEY" \
-  "{\"dataset\":\"token_transfers\",\"format\":\"jsonl\",\"target_id\":\"$TARGET_ID\",\"network\":\"$TARGET_NETWORK\",\"sink\":{\"type\":\"local_file\",\"path\":\"smoke-export.jsonl\"}}")
+  "{\"dataset\":\"token_transfers\",\"format\":\"jsonl\",\"target_id\":\"$TARGET_ID\",\"network\":\"$TARGET_NETWORK\",\"sink\":{\"sink_type\":\"local_file\",\"file_path\":\"smoke-export.jsonl\"}}")
 EXPORT_JOB_ID=$(extract_json "$EXPORT_RESP" "id")
 if [[ -z "$EXPORT_JOB_ID" ]]; then
   echo "ERROR: Could not parse export job ID from response: $EXPORT_RESP"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -185,6 +185,14 @@ if [[ -n "$JOB_ID" ]]; then
     fi
     sleep 2
   done
+  if [[ "$STATUS" == "failed" ]]; then
+    echo "ERROR: Ingest job $JOB_ID failed"
+    exit 1
+  fi
+  if [[ "$STATUS" != "completed" ]]; then
+    echo "ERROR: Ingest job $JOB_ID did not complete within poll window (last status: $STATUS)"
+    exit 1
+  fi
 else
   echo "       Skipped (no job ID)"
 fi
@@ -223,7 +231,7 @@ echo "       Listed $KEY_COUNT active key(s)"
 # ---------------------------------------------------------------------------
 echo "[10/10] Verifying target listing..."
 TARGETS_RESP=$(curl_json GET "$API_URL/v1/targets?limit=10" "$TENANT_KEY")
-TARGET_COUNT=$(echo "$TARGETS_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('targets', d if isinstance(d, list) else []))))" 2>/dev/null || echo "0")
+TARGET_COUNT=$(echo "$TARGETS_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('targets', d if isinstance(d, list) else [])))" 2>/dev/null || echo "0")
 echo "       Listed $TARGET_COUNT target(s)"
 
 echo ""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -190,7 +190,7 @@ fi
 # ---------------------------------------------------------------------------
 echo "[6/10] Polling job status..."
 if [[ -n "$JOB_ID" ]]; then
-  for i in {1..10}; do
+  for i in {1..30}; do
     JOB_STATUS=$(curl_json GET "$API_URL/v1/jobs/$JOB_ID" "$TENANT_KEY")
     STATUS=$(echo "$JOB_STATUS" | python3 -c "import sys, json; print(json.load(sys.stdin).get('state','unknown'))" 2>/dev/null || echo "unknown")
     echo "       Job status: $STATUS"
@@ -245,7 +245,7 @@ echo "       Listed $KEY_COUNT active key(s)"
 # ---------------------------------------------------------------------------
 echo "[10/10] Verifying target listing..."
 TARGETS_RESP=$(curl_json GET "$API_URL/v1/targets?limit=10" "$TENANT_KEY")
-TARGET_COUNT=$(echo "$TARGETS_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d.get('targets', d if isinstance(d, list) else [])))" 2>/dev/null || echo "0")
+TARGET_COUNT=$(echo "$TARGETS_RESP" | python3 -c "import sys, json; d=json.load(sys.stdin); print(len(d) if isinstance(d, list) else len(d.get('targets',[])))" 2>/dev/null || echo "0")
 echo "       Listed $TARGET_COUNT target(s)"
 
 echo ""


### PR DESCRIPTION
Implements P0 from the updated MVP plan: makes the supported API path honest and provable.

**Changes:**
- Rewrite smoke-test.sh with fail-loud curl helper, correct API shapes, and tenant-scoped target_id usage
- Fix all README curl examples (broken auth headers, wrong request shapes, missing target_id notes)
- Add --skip-ingest flag for provider-less environments

Closes P0 of the honest MVP readiness plan.