### PR TITLE
P1: Target-Scoped Gold Lineage + P2: Target-Centric Ingest

### DIFF
--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -3254,7 +3254,13 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<BalanceSnapshot>> {
         let target_address = if let Some(tid) = target_id {
-            self.get_index_target(tid).await?.and_then(|t| t.address)
+            match self.get_index_target(tid).await? {
+                Some(t) => match t.address {
+                    Some(addr) if !addr.is_empty() => Some(addr),
+                    _ => return Ok(Vec::new()),
+                },
+                None => return Ok(Vec::new()),
+            }
         } else {
             None
         };
@@ -3308,7 +3314,13 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<HlPnlSummary>> {
         let target_address = if let Some(tid) = target_id {
-            self.get_index_target(tid).await?.and_then(|t| t.address)
+            match self.get_index_target(tid).await? {
+                Some(t) => match t.address {
+                    Some(addr) if !addr.is_empty() => Some(addr),
+                    _ => return Ok(Vec::new()),
+                },
+                None => return Ok(Vec::new()),
+            }
         } else {
             None
         };
@@ -3325,7 +3337,7 @@ impl Repository {
             network,
             time_start,
             time_end,
-            "period_start",
+            "period_end",
             limit,
             offset,
         )?;
@@ -3361,7 +3373,13 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<HlTradeHistory>> {
         let target_address = if let Some(tid) = target_id {
-            self.get_index_target(tid).await?.and_then(|t| t.address)
+            match self.get_index_target(tid).await? {
+                Some(t) => match t.address {
+                    Some(addr) if !addr.is_empty() => Some(addr),
+                    _ => return Ok(Vec::new()),
+                },
+                None => return Ok(Vec::new()),
+            }
         } else {
             None
         };
@@ -3377,7 +3395,7 @@ impl Repository {
             network,
             time_start,
             time_end,
-            "opened_at",
+            "closed_at",
             limit,
             offset,
         )?;
@@ -3415,7 +3433,13 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<ProtocolEvent>> {
         let target_address = if let Some(tid) = target_id {
-            self.get_index_target(tid).await?.and_then(|t| t.address)
+            match self.get_index_target(tid).await? {
+                Some(t) => match t.address {
+                    Some(addr) if !addr.is_empty() => Some(addr),
+                    _ => return Ok(Vec::new()),
+                },
+                None => return Ok(Vec::new()),
+            }
         } else {
             None
         };
@@ -3467,7 +3491,13 @@ impl Repository {
         offset: i64,
     ) -> anyhow::Result<Vec<PoolSnapshot>> {
         let target_address = if let Some(tid) = target_id {
-            self.get_index_target(tid).await?.and_then(|t| t.address)
+            match self.get_index_target(tid).await? {
+                Some(t) => match t.address {
+                    Some(addr) if !addr.is_empty() => Some(addr),
+                    _ => return Ok(Vec::new()),
+                },
+                None => return Ok(Vec::new()),
+            }
         } else {
             None
         };

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1394,6 +1394,81 @@ pub fn build_dataset_filter_query(
     Ok((sql, args))
 }
 
+/// Build a filter query for dataset tables that do NOT have `raw_transaction_id`.
+///
+/// Target scoping is done by filtering on a direct address column (e.g.
+/// `wallet_address`, `protocol_address`). Time filtering is applied directly
+/// to the dataset table's own time column instead of joining `raw_transactions`.
+///
+/// This fixes the generic filter builder for Gold tables like `balance_history`,
+/// `hl_pnl_summary`, `hl_trade_history`, `protocol_events`, and `pool_snapshots`
+/// that lack a `raw_transaction_id` column (P1).
+#[allow(clippy::too_many_arguments)]
+pub fn build_dataset_filter_query_direct(
+    select_cols: &str,
+    table_name: &str,
+    order_col: &str,
+    target_address: Option<&str>,
+    target_address_col: &str,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    time_col: &str,
+    limit: i64,
+    offset: i64,
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let limit = limit.min(MAX_QUERY_LIMIT);
+    let mut sql = format!("SELECT {select_cols} FROM {table_name} dt");
+    let mut args = sqlx::postgres::PgArguments::default();
+    let mut n: usize = 0;
+    let mut wheres: Vec<String> = Vec::new();
+
+    if let Some(addr) = target_address {
+        n += 1;
+        wheres.push(format!("dt.{target_address_col} = ${n}"));
+        use sqlx::Arguments;
+        args.add(addr.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    if let Some(net) = network {
+        n += 1;
+        wheres.push(format!("dt.network = ${n}"));
+        use sqlx::Arguments;
+        args.add(net.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    if let Some(start) = time_start {
+        n += 1;
+        wheres.push(format!("dt.{time_col} >= ${n}"));
+        use sqlx::Arguments;
+        args.add(start).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    if let Some(end) = time_end {
+        n += 1;
+        wheres.push(format!("dt.{time_col} <= ${n}"));
+        use sqlx::Arguments;
+        args.add(end).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+
+    if !wheres.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&wheres.join(" AND "));
+    }
+
+    n += 1;
+    let lim_n = n;
+    n += 1;
+    let off_n = n;
+    sql.push_str(&format!(
+        " ORDER BY {order_col} DESC, dt.id DESC LIMIT ${lim_n} OFFSET ${off_n}"
+    ));
+    use sqlx::Arguments;
+    args.add(limit).map_err(|e| anyhow::anyhow!("{e}"))?;
+    args.add(offset).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    Ok((sql, args))
+}
+
 /// Build a batch INSERT for `raw_evm_traces` with ON CONFLICT DO NOTHING.
 pub fn build_raw_evm_trace_insert(
     traces: &[RawEvmTrace],
@@ -3178,16 +3253,23 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<BalanceSnapshot>> {
+        let target_address = if let Some(tid) = target_id {
+            self.get_index_target(tid).await?.and_then(|t| t.address)
+        } else {
+            None
+        };
         let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, dt.timestamp, \
                     dt.balance, dt.tx_hash, dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query(
+        let (sql, args) = build_dataset_filter_query_direct(
             cols,
             DatasetName::BalanceHistory.physical_table(),
             "dt.timestamp",
-            target_id,
+            target_address.as_deref(),
+            "wallet_address",
             network,
             time_start,
             time_end,
+            "timestamp",
             limit,
             offset,
         )?;
@@ -3225,18 +3307,25 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<HlPnlSummary>> {
+        let target_address = if let Some(tid) = target_id {
+            self.get_index_target(tid).await?.and_then(|t| t.address)
+        } else {
+            None
+        };
         let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.period_start, \
                     dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
                     dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                     dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query(
+        let (sql, args) = build_dataset_filter_query_direct(
             cols,
             DatasetName::HlPnlSummary.physical_table(),
             "dt.period_end",
-            target_id,
+            target_address.as_deref(),
+            "wallet_address",
             network,
             time_start,
             time_end,
+            "period_start",
             limit,
             offset,
         )?;
@@ -3271,17 +3360,24 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<HlTradeHistory>> {
+        let target_address = if let Some(tid) = target_id {
+            self.get_index_target(tid).await?.and_then(|t| t.address)
+        } else {
+            None
+        };
         let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.side, dt.entry_price, \
                     dt.exit_price, dt.size, dt.opened_at, dt.closed_at, dt.realized_pnl, \
                     dt.fees, dt.num_fills, dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query(
+        let (sql, args) = build_dataset_filter_query_direct(
             cols,
             DatasetName::HlTradeHistory.physical_table(),
             "dt.closed_at",
-            target_id,
+            target_address.as_deref(),
+            "wallet_address",
             network,
             time_start,
             time_end,
+            "opened_at",
             limit,
             offset,
         )?;
@@ -3318,17 +3414,24 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<ProtocolEvent>> {
+        let target_address = if let Some(tid) = target_id {
+            self.get_index_target(tid).await?.and_then(|t| t.address)
+        } else {
+            None
+        };
         let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, dt.event_type, \
                     dt.event_details, dt.pool_address, dt.raw_event_id, dt.timestamp, \
                     dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query(
+        let (sql, args) = build_dataset_filter_query_direct(
             cols,
             DatasetName::ProtocolEvents.physical_table(),
             "dt.timestamp",
-            target_id,
+            target_address.as_deref(),
+            "protocol_address",
             network,
             time_start,
             time_end,
+            "timestamp",
             limit,
             offset,
         )?;
@@ -3363,18 +3466,25 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<PoolSnapshot>> {
+        let target_address = if let Some(tid) = target_id {
+            self.get_index_target(tid).await?.and_then(|t| t.address)
+        } else {
+            None
+        };
         let cols = "dt.id, dt.network, dt.pool_address, dt.protocol_address, dt.protocol_name, \
                     dt.token0_address, dt.token0_symbol, dt.token1_address, dt.token1_symbol, \
                     dt.reserve0, dt.reserve1, dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                     dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query(
+        let (sql, args) = build_dataset_filter_query_direct(
             cols,
             DatasetName::PoolSnapshots.physical_table(),
             "dt.snapshot_timestamp",
-            target_id,
+            target_address.as_deref(),
+            "pool_address",
             network,
             time_start,
             time_end,
+            "snapshot_timestamp",
             limit,
             offset,
         )?;
@@ -6779,6 +6889,145 @@ mod tests {
         // Time filtering joins raw_transactions and uses rt.timestamp
         assert!(sql.contains("rt.timestamp >="));
         assert!(sql.contains("rt.timestamp <="));
+    }
+
+    // -- P1: build_dataset_filter_query_direct for tables without raw_transaction_id --
+
+    #[test]
+    fn dataset_filter_query_direct_no_filters() {
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.id, dt.wallet_address",
+            DatasetName::BalanceHistory.physical_table(),
+            "dt.timestamp",
+            None,
+            "wallet_address",
+            None,
+            None,
+            None,
+            "timestamp",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(sql.starts_with("SELECT dt.id, dt.wallet_address FROM balance_history dt"));
+        assert!(!sql.contains("JOIN"));
+        assert!(!sql.contains("WHERE"));
+        assert!(sql.contains("ORDER BY dt.timestamp DESC, dt.id DESC"));
+        assert!(sql.contains("LIMIT $1 OFFSET $2"));
+    }
+
+    #[test]
+    fn dataset_filter_query_direct_target_address_only() {
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.id",
+            DatasetName::BalanceHistory.physical_table(),
+            "dt.timestamp",
+            Some("0xABC"),
+            "wallet_address",
+            None,
+            None,
+            None,
+            "timestamp",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(!sql.contains("JOIN"));
+        assert!(sql.contains("WHERE dt.wallet_address = $1"));
+        assert!(sql.contains("LIMIT $2 OFFSET $3"));
+    }
+
+    #[test]
+    fn dataset_filter_query_direct_network_only() {
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.id",
+            DatasetName::ProtocolEvents.physical_table(),
+            "dt.timestamp",
+            None,
+            "protocol_address",
+            Some("ethereum-mainnet"),
+            None,
+            None,
+            "timestamp",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(!sql.contains("JOIN"));
+        assert!(sql.contains("WHERE dt.network = $1"));
+        assert!(sql.contains("LIMIT $2 OFFSET $3"));
+    }
+
+    #[test]
+    fn dataset_filter_query_direct_time_window_only() {
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.id",
+            DatasetName::HlPnlSummary.physical_table(),
+            "dt.period_end",
+            None,
+            "wallet_address",
+            None,
+            Some(1700000000),
+            Some(1700100000),
+            "period_start",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(!sql.contains("JOIN"));
+        assert!(sql.contains("dt.period_start >= $1"));
+        assert!(sql.contains("dt.period_start <= $2"));
+        assert!(sql.contains("LIMIT $3 OFFSET $4"));
+    }
+
+    #[test]
+    fn dataset_filter_query_direct_all_filters() {
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.id",
+            DatasetName::PoolSnapshots.physical_table(),
+            "dt.snapshot_timestamp",
+            Some("pool123"),
+            "pool_address",
+            Some("solana-mainnet"),
+            Some(1000),
+            Some(2000),
+            "snapshot_timestamp",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(!sql.contains("JOIN"));
+        assert!(sql.contains("dt.pool_address = $1"));
+        assert!(sql.contains("dt.network = $2"));
+        assert!(sql.contains("dt.snapshot_timestamp >= $3"));
+        assert!(sql.contains("dt.snapshot_timestamp <= $4"));
+        assert!(sql.contains("LIMIT $5 OFFSET $6"));
+    }
+
+    #[test]
+    fn dataset_filter_query_direct_no_raw_tx_join_for_gold() {
+        // Regression test: Gold tables like balance_history must NOT join
+        // target_matches or raw_transactions since they lack raw_transaction_id.
+        let (sql, _) = build_dataset_filter_query_direct(
+            "dt.*",
+            DatasetName::BalanceHistory.physical_table(),
+            "dt.timestamp",
+            Some("0xWallet"),
+            "wallet_address",
+            Some("solana-mainnet"),
+            Some(1700000000),
+            Some(1700100000),
+            "timestamp",
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(!sql.contains("target_matches"));
+        assert!(!sql.contains("raw_transactions"));
+        assert!(sql.contains("dt.wallet_address = $1"));
+        assert!(sql.contains("dt.network = $2"));
+        assert!(sql.contains("dt.timestamp >= $3"));
+        assert!(sql.contains("dt.timestamp <= $4"));
     }
 
     #[test]

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -3432,16 +3432,22 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<ProtocolEvent>> {
-        let target_address = if let Some(tid) = target_id {
+        let (target_address, target_address_col) = if let Some(tid) = target_id {
             match self.get_index_target(tid).await? {
                 Some(t) => match t.address {
-                    Some(addr) if !addr.is_empty() => Some(addr),
+                    Some(addr) if !addr.is_empty() => {
+                        let col = match t.kind {
+                            TargetKind::Pool => "pool_address",
+                            _ => "protocol_address",
+                        };
+                        (Some(addr), col)
+                    }
                     _ => return Ok(Vec::new()),
                 },
                 None => return Ok(Vec::new()),
             }
         } else {
-            None
+            (None, "protocol_address")
         };
         let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, dt.event_type, \
                     dt.event_details, dt.pool_address, dt.raw_event_id, dt.timestamp, \
@@ -3451,7 +3457,7 @@ impl Repository {
             DatasetName::ProtocolEvents.physical_table(),
             "dt.timestamp",
             target_address.as_deref(),
-            "protocol_address",
+            target_address_col,
             network,
             time_start,
             time_end,

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -389,6 +389,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/targets", post(register_target))
         .route("/v1/targets", get(list_targets))
         .route("/v1/targets/{target_id}", get(get_target))
+        .route(
+            "/v1/targets/{target_id}/ingest",
+            post(trigger_target_ingest),
+        )
         .route("/v1/api-keys", post(create_api_key_handler))
         .route("/v1/api-keys", get(list_api_keys_handler))
         .route("/v1/api-keys/{key_id}", delete(revoke_api_key_handler))
@@ -552,6 +556,22 @@ struct IngestRequest {
     wallet: String,
     user_id: Option<Uuid>,
     callback_url: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct TargetIngestRequest {
+    /// Ingestion mode: "incremental" (default) or "backfill".
+    #[serde(default = "default_ingest_mode")]
+    mode: String,
+    /// Job priority (higher = sooner). Defaults to 0.
+    #[serde(default)]
+    priority: i32,
+    /// Optional callback URL for job completion/failure notifications.
+    callback_url: Option<String>,
+}
+
+fn default_ingest_mode() -> String {
+    "incremental".to_string()
 }
 
 #[derive(Deserialize)]
@@ -2462,6 +2482,65 @@ async fn get_target(
     Ok(Json(target))
 }
 
+async fn trigger_target_ingest(
+    State(state): State<Arc<AppState>>,
+    Extension(owner): Extension<AuthenticatedOwner>,
+    Path(target_id): Path<Uuid>,
+    Json(payload): Json<TargetIngestRequest>,
+) -> Result<Json<JobStatus>, AppError> {
+    // Look up the target.
+    let target = state
+        .repo
+        .get_index_target(target_id)
+        .await
+        .map_err(AppError::internal)?
+        .ok_or_else(|| AppError::not_found(format!("Target {target_id} not found")))?;
+
+    // Ownership check.
+    if let Some(owner_id) = owner.0 {
+        if target.owner_id != Some(owner_id) {
+            return Err(AppError::forbidden("Target does not belong to this owner"));
+        }
+    }
+
+    // Validate callback URL if provided.
+    if let Some(ref url) = payload.callback_url {
+        validate_callback_url(url).await?;
+    }
+
+    let owner_id = owner.0.unwrap_or_else(Uuid::new_v4);
+
+    // Enqueue the ingestion job scoped to this target.
+    let params = EnqueueIngestionJobParams {
+        target_id: Some(target_id),
+        network: &target.network,
+        mode: &payload.mode,
+        priority: payload.priority,
+        idempotency_key: None,
+        requested_by: Some(&owner_id.to_string()),
+        callback_url: payload.callback_url.as_deref(),
+    };
+
+    let job = state
+        .repo
+        .enqueue_ingestion_job(&params)
+        .await
+        .map_err(AppError::internal)?;
+
+    info!(
+        job_id = %job.id,
+        target_id = %target_id,
+        network = %target.network,
+        "Target-centric ingestion job enqueued"
+    );
+
+    Ok(Json(JobStatus {
+        id: job.id,
+        state: JobState::Pending,
+        message: Some("Job queued".to_string()),
+    }))
+}
+
 // ---------------------------------------------------------------------------
 // API key management handlers
 // ---------------------------------------------------------------------------
@@ -3762,6 +3841,10 @@ mod tests {
             .route("/v1/targets", post(register_target))
             .route("/v1/targets", get(list_targets))
             .route("/v1/targets/{target_id}", get(get_target))
+            .route(
+                "/v1/targets/{target_id}/ingest",
+                post(trigger_target_ingest),
+            )
             .route("/v1/api-keys", post(create_api_key_handler))
             .route("/v1/api-keys", get(list_api_keys_handler))
             .route("/v1/api-keys/{key_id}", delete(revoke_api_key_handler))
@@ -5887,6 +5970,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_target_ingest_requires_auth() {
+        let app = test_router();
+        let target_id = Uuid::new_v4();
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/v1/targets/{}/ingest", target_id))
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
     async fn test_list_networks_requires_auth() {
         let app = test_router();
         let req = axum::http::Request::builder()
@@ -7388,6 +7485,17 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn compat_target_ingest_routed() {
+        let id = Uuid::new_v4();
+        assert_post_routed(
+            test_router(),
+            &format!("/v1/targets/{}/ingest", id),
+            r#"{}"#,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2503,13 +2503,39 @@ async fn trigger_target_ingest(
         }
     }
 
+    // The current ingestion worker only supports wallet-style backfill
+    // (fetch_history(wallet, ...)). Reject non-wallet targets until
+    // connector-specific ingestion paths are implemented.
+    if target.kind != TargetKind::Wallet {
+        return Err(AppError::bad_request(format!(
+            "Ingestion for target kind {:?} is not yet supported",
+            target.kind
+        )));
+    }
+
+    // Preflight: ensure the target's network is actually configured in the
+    // provider registry (same gate as /v1/ingest).
+    if NetworkContext::from_registry(
+        &state.provider_registry,
+        &NetworkId::new(target.network.clone()),
+    )
+    .is_none()
+    {
+        return Err(AppError::bad_request(format!(
+            "network '{}' is not configured",
+            target.network
+        )));
+    }
+
     // Validate target is suitable for ingestion (must have an address).
     let target_address = target
         .address
         .ok_or_else(|| AppError::bad_request("Target has no address and cannot be ingested"))?;
 
-    // For wallet targets, enforce the allowed_wallets operator guard.
+    // For wallet targets, enforce the allowed_wallets operator guard and
+    // validate wallet address format (same gate as /v1/ingest).
     if target.kind == TargetKind::Wallet {
+        validate_wallet(&target_address)?;
         check_wallet_allowed(&target_address, &state.allowed_wallets)?;
     }
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2503,6 +2503,23 @@ async fn trigger_target_ingest(
         }
     }
 
+    // Validate target is suitable for ingestion (must have an address).
+    let target_address = target
+        .address
+        .ok_or_else(|| AppError::bad_request("Target has no address and cannot be ingested"))?;
+
+    // For wallet targets, enforce the allowed_wallets operator guard.
+    if target.kind == TargetKind::Wallet {
+        check_wallet_allowed(&target_address, &state.allowed_wallets)?;
+    }
+
+    // Validate ingestion mode.
+    if !matches!(payload.mode.as_str(), "incremental" | "backfill") {
+        return Err(AppError::bad_request(
+            "mode must be 'incremental' or 'backfill'",
+        ));
+    }
+
     // Validate callback URL if provided.
     if let Some(ref url) = payload.callback_url {
         validate_callback_url(url).await?;


### PR DESCRIPTION
## P1: Target-Scoped Gold Lineage

Gold tables (balance_history, wallet_ledger, hl_pnl_summary, hl_trade_history, protocol_events, pool_snapshots) lack raw_transaction_id, so the generic build_dataset_filter_query cannot join target_matches or raw_transactions for them.

- Adds build_dataset_filter_query_direct() that filters directly on target_address_col / network / timestamp_col without any JOINs.
- Switches all 6 Gold query/export methods to use the direct builder.
- Adds 6 unit tests covering: no filters, target only, network only, time window only, all filters, and the no-JOIN regression.

## P2: Target-Centric Ingest

The ingestion worker pipeline already operates target-centrically. The missing piece was a public API entry point that accepts a target_id.

- Adds TargetIngestRequest with optional mode, priority, and callback_url.
- Adds trigger_target_ingest handler that looks up the target, verifies ownership, validates the callback URL, and enqueues an ingestion job scoped to that target's network.
- Registers POST /v1/targets/:id/ingest on both app and test routers.
- Adds auth and routing tests.

## Verification
- cargo test --workspace: all pass
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt: applied