### PR TITLE
feat: make tenant status and export provenance usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Operators who no longer need V1 tables can set `enable_v1_compat_writes = false`
 
 All `/v1/*` routes require `Authorization: Bearer <API_KEY>`.
 
-Tenant-scoped API keys (created via `POST /v1/api-keys`) are required for tenant isolation on dataset queries and exports. The legacy config key (`SPECTRAPLEX_API_KEY`) can also call these endpoints (without tenant isolation) and is used to bootstrap the first tenant key.
+Tenant-scoped API keys (created via `POST /v1/api-keys`) are required for tenant isolation on dataset queries, dataset status/completeness, and exports. The legacy config key (`SPECTRAPLEX_API_KEY`) can also call these endpoints (without tenant isolation) and is used to bootstrap the first tenant key.
 
 ### Ingestion and Jobs
 
@@ -200,15 +200,15 @@ Tenant-scoped dataset queries require `target_id`:
 
 ```bash
 # Query a dataset (tenant-scoped)
-curl -H "Authorization: Bearer $API_KEY" \
+curl -H "Authorization: Bearer ***" \
   "http://127.0.0.1:3000/v1/datasets/token_transfers/records?target_id=<TARGET_ID>&network=solana-mainnet&limit=50"
 
-# Check dataset completeness (requires legacy/admin key — not tenant-scoped)
-curl -H "Authorization: Bearer $LEGACY_KEY" \
+# Check dataset completeness for your tenant's targets
+curl -H "Authorization: Bearer ***" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/completeness
 
-# Check dataset status (requires legacy/admin key — not tenant-scoped)
-curl -H "Authorization: Bearer $LEGACY_KEY" \
+# Check dataset status for your tenant's targets
+curl -H "Authorization: Bearer ***" \
   http://127.0.0.1:3000/v1/datasets/token_transfers/status
 ```
 

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -2703,6 +2703,28 @@ impl Repository {
         rows.iter().map(row_to_dataset_completeness).collect()
     }
 
+    /// List completeness records for a dataset restricted to a specific owner.
+    pub async fn list_completeness_by_dataset_and_owner(
+        &self,
+        dataset_name: &str,
+        owner_id: Uuid,
+    ) -> anyhow::Result<Vec<DatasetCompleteness>> {
+        let rows = sqlx::query(
+            "SELECT dc.id, dc.target_id, dc.dataset_name, dc.dataset_version_id, dc.network, dc.status, \
+             dc.coverage_start, dc.coverage_end, dc.block_start, dc.block_end, \
+             dc.last_ingestion_run_id, dc.records_count, dc.gap_ranges, dc.notes, dc.created_at, dc.updated_at \
+             FROM dataset_completeness dc \
+             JOIN index_targets it ON it.id = dc.target_id \
+             WHERE dc.dataset_name = $1 AND it.owner_id = $2 \
+             ORDER BY dc.target_id, dc.network",
+        )
+        .bind(dataset_name)
+        .bind(owner_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_dataset_completeness).collect()
+    }
+
     /// List completeness records for a dataset with optional target and network filters.
     pub async fn list_completeness_filtered(
         &self,

--- a/adapters/tests/operational_hardening_test.rs
+++ b/adapters/tests/operational_hardening_test.rs
@@ -14,7 +14,10 @@ use spectraplex_adapters::repo::Repository;
 
 use spectraplex_core::materializer::{DatasetName, ExportFormat};
 use spectraplex_core::models::{Chain, Transaction};
-use spectraplex_core::v2::{ChainFamily, IndexTarget, TargetKind, TargetMode};
+use spectraplex_core::v2::{
+    ChainFamily, CompletenessStatus, DatasetCompleteness, DatasetVersion, DatasetVersionStatus,
+    IndexTarget, TargetKind, TargetMode,
+};
 
 // ---------------------------------------------------------------------------
 // Helper: ephemeral database per test (reused from ingestion_compat_test.rs)
@@ -263,6 +266,92 @@ async fn tenant_isolation_prevents_cross_target_access() {
     // Admin (no owner filter) sees both
     let admin_targets = repo.list_index_targets(100, 0).await.unwrap();
     assert_eq!(admin_targets.len(), 2);
+
+    _pool.close().await;
+    drop_test_db(&db_name).await;
+}
+
+#[tokio::test]
+async fn tenant_scoped_dataset_completeness_is_filtered_by_owner() {
+    require_pg!();
+    let (repo, _pool, db_name) = setup_test_repo("tenant_complete").await;
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let now = Utc::now();
+
+    let target_a = make_target(
+        TargetKind::Wallet,
+        ChainFamily::Solana,
+        "solana-mainnet",
+        Some("tenant_a_wallet"),
+        Some(tenant_a),
+    );
+    repo.create_index_target(&target_a).await.unwrap();
+
+    let target_b = make_target(
+        TargetKind::Wallet,
+        ChainFamily::Solana,
+        "solana-mainnet",
+        Some("tenant_b_wallet"),
+        Some(tenant_b),
+    );
+    repo.create_index_target(&target_b).await.unwrap();
+
+    let version = DatasetVersion {
+        id: Uuid::new_v4(),
+        dataset_name: "token_transfers".to_string(),
+        version: 1,
+        parser_hash: Some("parser-v1".to_string()),
+        created_at: now,
+        notes: Some("tenant completeness test".to_string()),
+        status: DatasetVersionStatus::Active,
+    };
+    repo.create_dataset_version(&version).await.unwrap();
+
+    for (target_id, records_count) in [(target_a.id, 11_i64), (target_b.id, 22_i64)] {
+        let dc = DatasetCompleteness {
+            id: Uuid::new_v4(),
+            target_id,
+            dataset_name: "token_transfers".to_string(),
+            dataset_version_id: Some(version.id),
+            network: "solana-mainnet".to_string(),
+            status: CompletenessStatus::Complete,
+            coverage_start: Some(1_700_000_000),
+            coverage_end: Some(1_700_000_123),
+            block_start: None,
+            block_end: None,
+            last_ingestion_run_id: None,
+            records_count,
+            gap_ranges: None,
+            notes: None,
+            created_at: now,
+            updated_at: now,
+        };
+        repo.upsert_dataset_completeness(&dc).await.unwrap();
+    }
+
+    let tenant_a_records = repo
+        .list_completeness_by_dataset_and_owner("token_transfers", tenant_a)
+        .await
+        .unwrap();
+    assert_eq!(tenant_a_records.len(), 1);
+    assert_eq!(tenant_a_records[0].target_id, target_a.id);
+    assert_eq!(tenant_a_records[0].records_count, 11);
+
+    let tenant_b_records = repo
+        .list_completeness_by_dataset_and_owner("token_transfers", tenant_b)
+        .await
+        .unwrap();
+    assert_eq!(tenant_b_records.len(), 1);
+    assert_eq!(tenant_b_records[0].target_id, target_b.id);
+    assert_eq!(tenant_b_records[0].records_count, 22);
+
+    let admin_records = repo
+        .list_completeness_by_dataset("token_transfers")
+        .await
+        .unwrap();
+    assert_eq!(admin_records.len(), 2);
 
     _pool.close().await;
     drop_test_db(&db_name).await;

--- a/api/src/export_stream.rs
+++ b/api/src/export_stream.rs
@@ -108,8 +108,41 @@ pub(crate) async fn fetch_export_metadata(
         .await
         .unwrap_or_default();
 
+    let has_unknown_version = completeness_records
+        .iter()
+        .any(|record| record.dataset_version_id.is_none());
+    let mut version_ids = completeness_records
+        .iter()
+        .filter_map(|c| c.dataset_version_id)
+        .collect::<Vec<_>>();
+    version_ids.sort_unstable();
+    version_ids.dedup();
+
+    let completeness_version = if completeness_records.is_empty() || has_unknown_version {
+        None
+    } else {
+        match version_ids.as_slice() {
+            [version_id] => repo
+                .get_dataset_version_by_id(*version_id)
+                .await
+                .ok()
+                .flatten(),
+            _ => None,
+        }
+    };
+
+    let preferred_version = if completeness_records.is_empty() {
+        active_version
+    } else if completeness_version.is_some() {
+        completeness_version
+    } else if version_ids.is_empty() {
+        active_version
+    } else {
+        None
+    };
+
     let mut meta = ExportMetadata::default();
-    if let Some(ref dv) = active_version {
+    if let Some(ref dv) = preferred_version {
         meta.dataset_version_id = Some(dv.id);
         meta.dataset_version = Some(dv.version);
     }
@@ -379,4 +412,317 @@ pub(crate) async fn write_export_to_file(
     );
 
     Ok((total, meta))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use spectraplex_core::v2::{
+        ChainFamily, CompletenessStatus, DatasetCompleteness, DatasetVersion, DatasetVersionStatus,
+        IndexTarget, TargetKind, TargetMode,
+    };
+    use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+    use sqlx::{Connection, PgConnection};
+    use std::str::FromStr;
+
+    fn base_url() -> String {
+        std::env::var("TEST_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/postgres".to_string())
+    }
+
+    async fn pg_is_available() -> bool {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            PgConnection::connect(&base_url()),
+        )
+        .await;
+        match result {
+            Ok(Ok(conn)) => {
+                drop(conn);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    macro_rules! require_pg {
+        () => {
+            if !pg_is_available().await {
+                eprintln!(
+                    "SKIPPED: PostgreSQL not available at {} — set TEST_DATABASE_URL or start PostgreSQL",
+                    base_url()
+                );
+                return;
+            }
+        };
+    }
+
+    async fn create_test_db(prefix: &str) -> (PgPool, String) {
+        let db_name = format!("spx_export_{}_{}", prefix, Uuid::new_v4().simple());
+
+        let mut conn = PgConnection::connect(&base_url())
+            .await
+            .expect("Cannot connect to base Postgres URL — is PostgreSQL running?");
+
+        sqlx::query(&format!("CREATE DATABASE \"{db_name}\""))
+            .execute(&mut conn)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to create test database {db_name}: {e}"));
+
+        conn.close().await.ok();
+
+        let opts = PgConnectOptions::from_str(&base_url())
+            .expect("bad base url")
+            .database(&db_name);
+
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect_with(opts)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to connect to test database {db_name}: {e}"));
+
+        (pool, db_name)
+    }
+
+    async fn drop_test_db(db_name: &str) {
+        let mut conn = PgConnection::connect(&base_url()).await.ok();
+        if let Some(ref mut c) = conn {
+            let _ = sqlx::query(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            ))
+            .execute(&mut *c)
+            .await;
+
+            let _ = sqlx::query(&format!("DROP DATABASE IF EXISTS \"{db_name}\""))
+                .execute(&mut *c)
+                .await;
+        }
+    }
+
+    async fn setup_test_repo(prefix: &str) -> (Repository, PgPool, String) {
+        let (pool, db_name) = create_test_db(prefix).await;
+        sqlx::migrate!("../migrations")
+            .run(&pool)
+            .await
+            .expect("Migrations failed");
+        let repo = Repository::new(pool.clone());
+        (repo, pool, db_name)
+    }
+
+    fn make_target(owner_id: Option<Uuid>) -> IndexTarget {
+        let now = Utc::now();
+        IndexTarget {
+            id: Uuid::new_v4(),
+            kind: TargetKind::Wallet,
+            network: "solana-mainnet".to_string(),
+            chain_family: ChainFamily::Solana,
+            address: Some(format!("wallet_{}", Uuid::new_v4().simple())),
+            filter_spec: None,
+            mode: TargetMode::Backfill,
+            label: None,
+            owner_id,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_export_metadata_prefers_target_completeness_dataset_version() {
+        require_pg!();
+        let (repo, pool, db_name) = setup_test_repo("provenance").await;
+        let now = Utc::now();
+        let target = make_target(None);
+        repo.create_index_target(&target).await.unwrap();
+
+        let old_version = DatasetVersion {
+            id: Uuid::new_v4(),
+            dataset_name: "wallet_ledger".to_string(),
+            version: 1,
+            parser_hash: Some("wallet-ledger-v1".to_string()),
+            created_at: now,
+            notes: Some("older target data".to_string()),
+            status: DatasetVersionStatus::Superseded,
+        };
+        repo.create_dataset_version(&old_version).await.unwrap();
+
+        let active_version = DatasetVersion {
+            id: Uuid::new_v4(),
+            dataset_name: "wallet_ledger".to_string(),
+            version: 2,
+            parser_hash: Some("wallet-ledger-v2".to_string()),
+            created_at: now,
+            notes: Some("active registry version".to_string()),
+            status: DatasetVersionStatus::Active,
+        };
+        repo.create_dataset_version(&active_version).await.unwrap();
+
+        let completeness = DatasetCompleteness {
+            id: Uuid::new_v4(),
+            target_id: target.id,
+            dataset_name: "wallet_ledger".to_string(),
+            dataset_version_id: Some(old_version.id),
+            network: "solana-mainnet".to_string(),
+            status: CompletenessStatus::Complete,
+            coverage_start: Some(1_700_000_000),
+            coverage_end: Some(1_700_000_123),
+            block_start: None,
+            block_end: None,
+            last_ingestion_run_id: None,
+            records_count: 42,
+            gap_ranges: None,
+            notes: None,
+            created_at: now,
+            updated_at: now,
+        };
+        repo.upsert_dataset_completeness(&completeness)
+            .await
+            .unwrap();
+
+        let meta = fetch_export_metadata(
+            &repo,
+            "wallet_ledger",
+            Some(target.id),
+            Some("solana-mainnet"),
+        )
+        .await;
+
+        assert_eq!(meta.dataset_version_id, Some(old_version.id));
+        assert_eq!(meta.dataset_version, Some(1));
+        assert_eq!(meta.completeness_status.as_deref(), Some("complete"));
+        assert_eq!(meta.last_ingestion_run_id, None);
+
+        pool.close().await;
+        drop_test_db(&db_name).await;
+    }
+
+    #[tokio::test]
+    async fn fetch_export_metadata_omits_dataset_version_when_completeness_versions_conflict() {
+        require_pg!();
+        let (repo, pool, db_name) = setup_test_repo("provenance_conflict").await;
+        let now = Utc::now();
+        let target_a = make_target(None);
+        let target_b = make_target(None);
+        repo.create_index_target(&target_a).await.unwrap();
+        repo.create_index_target(&target_b).await.unwrap();
+
+        let version_one = DatasetVersion {
+            id: Uuid::new_v4(),
+            dataset_name: "wallet_ledger".to_string(),
+            version: 1,
+            parser_hash: Some("wallet-ledger-v1".to_string()),
+            created_at: now,
+            notes: Some("older target data".to_string()),
+            status: DatasetVersionStatus::Superseded,
+        };
+        repo.create_dataset_version(&version_one).await.unwrap();
+
+        let version_two = DatasetVersion {
+            id: Uuid::new_v4(),
+            dataset_name: "wallet_ledger".to_string(),
+            version: 2,
+            parser_hash: Some("wallet-ledger-v2".to_string()),
+            created_at: now,
+            notes: Some("active registry version".to_string()),
+            status: DatasetVersionStatus::Active,
+        };
+        repo.create_dataset_version(&version_two).await.unwrap();
+
+        for (target_id, dataset_version_id, records_count) in [
+            (target_a.id, Some(version_one.id), 10_i64),
+            (target_b.id, Some(version_two.id), 20_i64),
+        ] {
+            let completeness = DatasetCompleteness {
+                id: Uuid::new_v4(),
+                target_id,
+                dataset_name: "wallet_ledger".to_string(),
+                dataset_version_id,
+                network: "solana-mainnet".to_string(),
+                status: CompletenessStatus::Complete,
+                coverage_start: Some(1_700_000_000),
+                coverage_end: Some(1_700_000_123),
+                block_start: None,
+                block_end: None,
+                last_ingestion_run_id: None,
+                records_count,
+                gap_ranges: None,
+                notes: None,
+                created_at: now,
+                updated_at: now,
+            };
+            repo.upsert_dataset_completeness(&completeness)
+                .await
+                .unwrap();
+        }
+
+        let meta =
+            fetch_export_metadata(&repo, "wallet_ledger", None, Some("solana-mainnet")).await;
+
+        assert_eq!(meta.dataset_version_id, None);
+        assert_eq!(meta.dataset_version, None);
+        assert_eq!(meta.completeness_status.as_deref(), Some("complete"));
+
+        pool.close().await;
+        drop_test_db(&db_name).await;
+    }
+
+    #[tokio::test]
+    async fn fetch_export_metadata_omits_dataset_version_when_completeness_is_mixed_known_and_unknown(
+    ) {
+        require_pg!();
+        let (repo, pool, db_name) = setup_test_repo("provenance_mixed_null").await;
+        let now = Utc::now();
+        let target_a = make_target(None);
+        let target_b = make_target(None);
+        repo.create_index_target(&target_a).await.unwrap();
+        repo.create_index_target(&target_b).await.unwrap();
+
+        let version_one = DatasetVersion {
+            id: Uuid::new_v4(),
+            dataset_name: "wallet_ledger".to_string(),
+            version: 1,
+            parser_hash: Some("wallet-ledger-v1".to_string()),
+            created_at: now,
+            notes: Some("older target data".to_string()),
+            status: DatasetVersionStatus::Active,
+        };
+        repo.create_dataset_version(&version_one).await.unwrap();
+
+        for (target_id, dataset_version_id, records_count) in [
+            (target_a.id, Some(version_one.id), 10_i64),
+            (target_b.id, None, 20_i64),
+        ] {
+            let completeness = DatasetCompleteness {
+                id: Uuid::new_v4(),
+                target_id,
+                dataset_name: "wallet_ledger".to_string(),
+                dataset_version_id,
+                network: "solana-mainnet".to_string(),
+                status: CompletenessStatus::Complete,
+                coverage_start: Some(1_700_000_000),
+                coverage_end: Some(1_700_000_123),
+                block_start: None,
+                block_end: None,
+                last_ingestion_run_id: None,
+                records_count,
+                gap_ranges: None,
+                notes: None,
+                created_at: now,
+                updated_at: now,
+            };
+            repo.upsert_dataset_completeness(&completeness)
+                .await
+                .unwrap();
+        }
+
+        let meta =
+            fetch_export_metadata(&repo, "wallet_ledger", None, Some("solana-mainnet")).await;
+
+        assert_eq!(meta.dataset_version_id, None);
+        assert_eq!(meta.dataset_version, None);
+        assert_eq!(meta.completeness_status.as_deref(), Some("complete"));
+
+        pool.close().await;
+        drop_test_db(&db_name).await;
+    }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -3693,18 +3693,19 @@ async fn get_dataset_completeness_handler(
     Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
 ) -> Result<Json<Vec<DatasetCompleteness>>, AppError> {
-    // Tenant isolation: dataset completeness is not yet scoped by owner.
-    if owner.0.is_some() {
-        return Err(AppError::forbidden(
-            "Dataset completeness is not available for tenant-scoped requests",
-        ));
-    }
     validate_dataset_name(&name)?;
-    let records = state
-        .repo
-        .list_completeness_by_dataset(&name)
-        .await
-        .map_err(AppError::internal)?;
+    let records = match owner.0 {
+        Some(owner_id) => state
+            .repo
+            .list_completeness_by_dataset_and_owner(&name, owner_id)
+            .await
+            .map_err(AppError::internal)?,
+        None => state
+            .repo
+            .list_completeness_by_dataset(&name)
+            .await
+            .map_err(AppError::internal)?,
+    };
     Ok(Json(records))
 }
 
@@ -3750,12 +3751,6 @@ async fn get_dataset_status_handler(
     Extension(owner): Extension<AuthenticatedOwner>,
     Path(name): Path<String>,
 ) -> Result<Json<DatasetStatus>, AppError> {
-    // Tenant isolation: dataset status includes global completeness; not yet scoped by owner.
-    if owner.0.is_some() {
-        return Err(AppError::forbidden(
-            "Dataset status is not available for tenant-scoped requests",
-        ));
-    }
     validate_dataset_name(&name)?;
 
     let versions = state
@@ -3764,11 +3759,18 @@ async fn get_dataset_status_handler(
         .await
         .map_err(AppError::internal)?;
 
-    let completeness_records = state
-        .repo
-        .list_completeness_by_dataset(&name)
-        .await
-        .map_err(AppError::internal)?;
+    let completeness_records = match owner.0 {
+        Some(owner_id) => state
+            .repo
+            .list_completeness_by_dataset_and_owner(&name, owner_id)
+            .await
+            .map_err(AppError::internal)?,
+        None => state
+            .repo
+            .list_completeness_by_dataset(&name)
+            .await
+            .map_err(AppError::internal)?,
+    };
 
     let version_infos: Vec<DatasetVersionInfo> = versions
         .iter()
@@ -6269,6 +6271,38 @@ mod tests {
         // Route exists (not 404); may fail with 500 due to fake DB pool
         assert_ne!(response.status(), StatusCode::NOT_FOUND);
         assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_dataset_completeness_allows_tenant_scoped_requests() {
+        let state = test_state();
+        let owner_id = Uuid::new_v4();
+
+        let err = get_dataset_completeness_handler(
+            State(state),
+            Extension(AuthenticatedOwner(Some(owner_id))),
+            Path("token_transfers".to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_dataset_status_allows_tenant_scoped_requests() {
+        let state = test_state();
+        let owner_id = Uuid::new_v4();
+
+        let err = get_dataset_status_handler(
+            State(state),
+            Extension(AuthenticatedOwner(Some(owner_id))),
+            Path("token_transfers".to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/design/V2_AUTHORITY_AND_ETL_IMPLEMENTATION_PLAN.md
+++ b/design/V2_AUTHORITY_AND_ETL_IMPLEMENTATION_PLAN.md
@@ -1,12 +1,12 @@
 # V2 Authority And ETL Implementation Plan
 
-Status: **Active, updated after merged PRs through #244; narrowed to MVP readiness**
-Date: 2026-04-22
-Codebase: `c52625d` (`c52625dbebc38eb03358cd0d74d7481175d3c1cf`)
-Previous snapshot: 2026-04-21 / `4df29a8`
+Status: **Active, updated after merged PRs through #247; re-scoped to honest MVP readiness**
+Date: 2026-04-23
+Codebase: `bd56127` (`bd56127f5e6b7e34a643d28420bf1f38e7db8b7a`)
+Previous snapshot: 2026-04-22 / `c52625d`
 Audience: follow-on implementation agent(s)
 
-This document supersedes the 2026-04-21 version at
+This document supersedes the 2026-04-22 version at
 `design/V2_AUTHORITY_AND_ETL_IMPLEMENTATION_PLAN.md`. Since that snapshot, the
 following PRs landed:
 
@@ -15,26 +15,49 @@ following PRs landed:
 - #242: add HMAC signing to callbacks
 - #243: replace String fields with typed enums on `IngestionRun` and `ExportJob`
 - #244: per-user/tenant isolation at the query layer
+- #245: prove the API happy path
+- #246: make status and provenance usable
+- #247: freeze compatibility story, operational hardening, and integrator UX
 
-The result is that most of the original authority/ETL architecture work is no
-longer planning work. The active plan should now focus on proving a usable MVP
-path, closing the remaining compatibility edges, and documenting the workflow.
+Most of the original authority/ETL architecture work is now merged. The active
+plan is no longer "design V2"; it is to make the claimed supported path true,
+limit the MVP to what is actually supportable, and close the gaps that still
+prevent Spectraplex from being an honest general-purpose indexer MVP.
 
 ## 1. Current Conclusion
 
-V2 is now the authoritative API/runtime path for ingestion, streaming,
-normalization, dataset query, and export. Bronze-driven materialization writes
-Silver and all planned Gold datasets from V2 records. The old no-run API
-normalize fallback is gone.
+The repo is now close to a wallet-first API MVP with general-purpose V2
+building blocks, but it is not yet an honest "general-purpose blockchain
+indexer MVP" in the sense the README and recent plan snapshots imply.
 
-The remaining work is not another broad architecture pass. The minimum viable
-path is:
+What is already true:
 
-1. prove one reliable operator workflow end to end,
-2. make the remaining V1 compatibility surfaces explicit and non-blocking,
-3. make tenant-scoped status/completeness and export provenance usable enough,
-4. add the smallest possible docs/smoke tests so a team member can run it
-   without reading internal Rust code.
+- V2 Bronze, target registry, network/provider registry, durable jobs,
+  streaming subscriptions, materialization runs, and export jobs exist.
+- Bronze-driven Silver and Gold materialization exists for the planned dataset
+  set.
+- Tenant-scoped auth and owner checks exist at the API layer.
+
+What is not yet true enough to call the general-purpose MVP ready:
+
+- The public ingest/runtime path is still wallet-shaped. The API and worker
+  runtime still rely on the legacy wallet-oriented `ChainIngestor` flow and
+  only convert to V2 records after fetch. The general `Connector` abstraction
+  exists but is not yet the supported runtime contract.
+- Generic target-scoped dataset query/export is structurally fragile for some
+  Gold datasets. The shared dataset filter builder assumes the queried table
+  has `raw_transaction_id`, but several Gold tables do not, so target-scoped
+  Gold query/export must be treated as suspect until fixed.
+- The checked-in smoke test does not currently prove the supported path. It
+  uses stale request/response shapes, omits required tenant `target_id` on
+  dataset/export calls, and tolerates failures while still printing success.
+- Tenant users still cannot inspect dataset completeness/status for their own
+  targets.
+- The docs currently overstate readiness relative to the code's actual
+  supported path.
+
+The next phase should therefore focus on making the advertised path true, not
+on another broad architecture rewrite.
 
 ## 2. Workstream Status
 
@@ -43,11 +66,11 @@ path is:
 | A. Canonical registries and type cleanup | **Done for MVP** | `DatasetRegistry` is the canonical dataset registry. `DatasetName` covers Silver and Gold public names and physical table mapping. Future work is maintenance only. |
 | B. First-class network and provider configuration | **Done for MVP** | Structured provider config, `ProviderRegistry`, `NetworkContext`, and explicit `network` handling are in place. Legacy singleton config remains as compatibility. |
 | C. Durable control plane | **Done for MVP** | Ingestion jobs, export jobs, stream subscriptions, materialization runs, leases, heartbeat, reclaim, and restart-oriented worker loops are DB-backed. |
-| D. V2-authoritative ingestion and streaming | **Done for API MVP** | API backfill and stream flows write V2 Bronze/checkpoints/runs first and auto-enqueue materialization. Internal connectors still emit V1-shaped `Transaction` values before conversion. |
-| E. Bronze -> Silver -> Gold pipeline | **Done for planned dataset coverage; hardening remains** | Bronze-native normalize writes Silver and all planned Gold datasets: `wallet_ledger`, `balance_history`, `hl_pnl_summary`, `hl_trade_history`, `protocol_events`, `pool_snapshots`. Gold completeness/provenance still needs MVP-level cleanup. |
-| F. Compatibility cutover and V1 de-emphasis | **Done for MVP** | `/v1/normalize` requires `ingestion_run_id` and the worker fails closed without it. Wallet API reads are V2-backed. V1 compat writes are gated by `enable_v1_compat_writes` config (default true). CLI normalize is labeled as legacy compatibility. |
-| G. Integrator UX improvements | **Done for MVP** | Per-tenant API keys and owner-scoped query checks landed. Quickstart, curl examples, HMAC verification example, and supported-path docs are in README. SDKs and dashboards are still pending. |
-| H. Verification and operational hardening | **Done for MVP** | Smoke path proven (P0). Status/provenance usable (P1). Restart/reclaim, idempotency, tenant isolation, and export lifecycle tests added (P3). CLI/V1 compatibility story frozen with config gating (P2). |
+| D. V2-authoritative ingestion and streaming | **Partial** | Runtime writes V2 Bronze/checkpoints/runs first, but the supported ingest path is still wallet-shaped and still executes through the legacy wallet-oriented adapter flow rather than the general `Connector` contract. |
+| E. Bronze -> Silver -> Gold pipeline | **Partial for MVP** | Dataset coverage exists, but target-scoped query/export lineage for some Gold tables is not yet trustworthy because the shared query path assumes `raw_transaction_id` exists on the queried table. |
+| F. Compatibility cutover and V1 de-emphasis | **Partial** | `/v1/normalize` requires `ingestion_run_id`, wallet reads are V2-backed, and compat writes are gated. But V1-shaped adapter flow and compat projection are still part of the supported runtime path. |
+| G. Integrator UX improvements | **Partial** | Per-tenant API keys and owner-scoped handlers landed, but tenant-scoped dataset completeness/status is still unavailable and the README/smoke path currently overstate readiness. |
+| H. Verification and operational hardening | **Partial** | Restart/reclaim and lease hardening improved materially, but the checked-in smoke path is not yet an honest supported-path proof and target-scoped Gold query/export still needs direct verification. |
 
 ## 3. Milestone Status
 
@@ -55,11 +78,11 @@ path is:
 |---|---|---|
 | 1. Canonical naming and provider model | **Done** | No longer a planning blocker. |
 | 2. Durable control plane runtime | **Done** | Durable ingestion/export/stream/materialization state is in Postgres. |
-| 3. V2-authoritative backfill ingest | **Done for API** | Backfill worker writes V2 Bronze first, then compatibility projection. |
-| 4. V2-authoritative streams | **Done for API** | Stream flushes create `ingestion_runs`, write V2 Bronze/checkpoints, and enqueue materialization. |
-| 5. Bronze-driven materialization pipeline | **Done for planned coverage** | PR #241 completed all listed Gold datasets. Remaining work is correctness/provenance hardening, not missing coverage. |
+| 3. V2-authoritative backfill ingest | **Partial** | V2 writes are authoritative, but the supported public ingest path is still wallet-centric and not yet target-centric across the intended target model. |
+| 4. V2-authoritative streams | **Partial** | Durable streams exist, but the stable supported stream story is still narrow and not yet a broad target-driven runtime surface. |
+| 5. Bronze-driven materialization pipeline | **Partial for MVP** | Coverage is present, but correctness, target lineage, and export/query trustworthiness still need cleanup before Gold can be treated as broadly usable. |
 | 6. V2-backed reads and compatibility cutover | **Partial** | V2-backed reads and no-run normalize removal are done. V1 compatibility writes and CLI V1 paths remain. |
-| 7. Integrator polish and operational hardening | **MVP subset active** | Do quickstart/smoke/provenance first. SDKs and broader project UX can wait. |
+| 7. Integrator polish and operational hardening | **Partial** | Recent PRs moved this forward materially, but the documented happy path still needs to become a real, trustworthy, end-to-end operator workflow. |
 
 ## 4. Previously Open Medium-Severity Issues
 
@@ -113,12 +136,16 @@ Caveats that should stay visible:
 
 - The legacy config-level API key is still admin/ownerless and bypasses tenant
   scoping by design.
-- `/v1/datasets/:name/completeness` and `/v1/datasets/:name/status` are not yet
-  tenant-scoped; tenant requests are rejected instead of returning global
-  completeness.
+- `/v1/datasets/:name/completeness` and `/v1/datasets/:name/status` now return
+  owner-filtered completeness rows for tenant-scoped requests, but dataset
+  version metadata remains global by design.
 - Some Gold tables do not carry `owner_id` directly. Isolation is enforced via
   target ownership checks and target-scoped queries, not database row-level
   ownership on every Gold row.
+- The shared Gold dataset query/export path still needs explicit validation and
+  likely schema/query cleanup. The current generic filter builder assumes the
+  queried table exposes `raw_transaction_id`, which is not universally true
+  across Gold tables.
 
 ## 5. Gold Materialization Coverage
 
@@ -146,6 +173,11 @@ Registry/query/export status:
 
 Remaining Gold work for MVP:
 
+- Fix target-scoped Gold query/export lineage. The current generic dataset
+  query builder assumes `dt.raw_transaction_id` exists on the queried table,
+  but that is not true for every Gold dataset. Either add durable target/raw
+  lineage to those tables or replace the shared query path with
+  dataset-specific joins that are actually valid.
 - Add or fix Gold `dataset_completeness` updates. Current Bronze-native
   completeness upserts are still Silver-oriented.
 - Confirm export provenance for Gold datasets reports useful version and
@@ -170,8 +202,9 @@ Remaining Gold work for MVP:
 
 ### Still Present
 
-- API ingestion and stream workers still convert V1-shaped adapter output with
-  `v1_tx_to_v2_raw()` before V2 persistence.
+- API ingestion and stream workers still depend on the legacy wallet-oriented
+  adapter flow and convert V1-shaped adapter output with `v1_tx_to_v2_raw()`
+  before V2 persistence.
 - API workers still perform best-effort V1 compatibility writes using
   `save_transactions()` and V1 checkpoints.
 - `adapters/src/dual_write.rs::materialize_silver_datasets()` still exists for
@@ -181,159 +214,185 @@ Remaining Gold work for MVP:
   calls `materialize_silver_datasets()`.
 - V1 tables and parser-version names remain for compatibility and tests.
 
-MVP decision: do not block shipping on deleting all V1 code. For the first
-usable release, make the API workflow the supported path and label CLI
-normalize/legacy V1 projection as compatibility. Then remove or gate the
-remaining compatibility writes once the API smoke path is proven.
+MVP decision: do not block shipping on deleting all V1 code. But also do not
+pretend the runtime is fully target-centric yet. For the first usable release,
+make the API workflow the supported path, label CLI normalize/legacy V1
+projection as compatibility, and only de-emphasize the remaining V1 path after
+the supported API workflow is actually proven and documented.
 
 ## 7. Active MVP Plan
 
 ### MVP Target
 
-A team member should be able to:
+For this next phase, "general-purpose MVP" should mean:
 
-1. configure Postgres and providers,
+1. a team member can configure Postgres and providers,
 2. create or use a tenant-scoped API key,
-3. register a wallet target,
-4. enqueue ingestion,
-5. observe job/materialization status,
-6. query `wallet_ledger`, `balance_history`, and at least one chain-specific
-   Silver dataset,
-7. export a dataset to CSV or JSONL,
-8. repeat the flow after an API restart without losing jobs.
+3. register and ingest at least one supported target from a published support
+   matrix,
+4. observe job and materialization status,
+5. query and export at least one Silver dataset and one Gold dataset scoped to
+   that target,
+6. repeat the flow after an API restart without losing jobs or operational
+   truth.
 
-This is enough to be "actually usable" before SDKs, dashboards, or broader
-project/org management.
+This should not require every target kind to be production-grade. The MVP only
+needs a small stable matrix, for example:
 
-### P0: Prove The API Happy Path
+- Solana wallet
+- Hyperliquid wallet or market
+- EVM contract or topic_filter
 
-Deliver one checked-in or temporary smoke workflow:
+Wallet-derived Gold datasets remain first-class for the first usable release.
+For non-wallet targets, the MVP bar is successful Bronze/Silver ingestion plus
+scoped query/export on the supported path.
 
-- seed/create a tenant API key,
-- register a wallet target,
-- enqueue ingest for one supported network,
-- wait for ingestion and auto-materialization,
-- query `wallet_ledger` and `balance_history`,
-- create and download a dataset export,
-- show callback signing headers when `callback_hmac_secret` is configured.
+### P0: Make The Supported Path Honest And Provable
 
-Prefer a short shell script plus README quickstart over a large new framework.
-The script can be local-only and can assume `docker-compose up -d`.
+Fix the checked-in smoke path and README so they reflect the real API:
+
+- update the smoke script to use current request/response shapes,
+- require it to fail on unexpected HTTP responses instead of swallowing them,
+- include tenant `target_id` where the current tenant-scoped API requires it,
+- prove ingest -> status -> materialize -> query -> export -> download using a
+  deterministic path.
+
+If a live provider-backed smoke test is too flaky, prefer a deterministic
+fixture-backed path over a best-effort mainnet script that can print success on
+broken requests.
 
 Acceptance criteria:
 
-- a fresh local DB can run the flow,
+- a fresh local environment can run the documented path successfully,
 - failures are visible and actionable,
-- no one needs to read `api/src/main.rs` to operate the MVP.
+- the README no longer overclaims what the smoke path proves.
 
-### P1: Make Status And Provenance Usable
+### P1: Fix Target-Scoped Gold Query And Export Lineage
 
-Fix the status surfaces that a user will naturally inspect:
+Make target-scoped Gold reads actually trustworthy:
 
-- add tenant-scoped dataset status/completeness or document an explicit
-  admin-only status endpoint for MVP,
-- upsert Gold `dataset_completeness` when Gold records are written,
-- make export job provenance useful for Gold datasets,
-- ensure dataset version IDs are present for Gold rows written by the pipeline.
+- audit every Gold dataset exposed through generic query/export,
+- fix the shared filter path or replace it with dataset-specific query builders
+  where the generic `raw_transaction_id` join assumption is invalid,
+- add tests that prove tenant-scoped target queries and exports return only the
+  requested target's rows for supported Gold datasets.
 
 Acceptance criteria:
 
-- dataset export status does not imply unknown/stale completeness for newly
-  materialized Gold data,
+- target-scoped Gold query/export works correctly for all datasets labeled
+  supported in the MVP matrix,
+- no supported Gold endpoint depends on an invalid `raw_transaction_id` join.
+
+### P2: Make Ingest Target-Centric, Not Just Wallet-Centric
+
+Move the supported ingest/runtime path toward the actual target model:
+
+- add a supported target-centric ingest entry point, such as
+  `POST /v1/targets/:id/ingest` or an equivalent `target_id`-driven ingest
+  request,
+- route supported target kinds through the V2 `Connector` abstraction rather
+  than only the legacy wallet-oriented `ChainIngestor` path,
+- keep the wallet path first-class, but stop treating it as the only real
+  supported ingestion surface.
+
+Acceptance criteria:
+
+- at least one non-wallet target type is supported end-to-end through the
+  public API path,
+- the supported path is described in terms of targets, not just wallets.
+
+### P3: Make Tenant Status And Provenance Usable
+
+Fix the status surfaces that real users will inspect:
+
+- add tenant-scoped dataset completeness/status or add a target-specific status
+  endpoint that tenants can safely use,
+- ensure Gold `dataset_completeness` is updated when Gold records are written,
+- ensure export provenance for supported Gold datasets reflects useful version
+  and completeness information.
+
+Acceptance criteria:
+
 - tenant users can inspect their own target's materialization state without
-  seeing global state.
+  seeing global state,
+- completed exports carry provenance a downstream integrator can actually use.
 
-### P2: Freeze The Supported Compatibility Story
+### P4: Publish A Real Support Matrix And Correctness Fixtures
 
-Make the supported path unambiguous:
+Make the MVP boundaries explicit:
 
-- document API ingestion + auto-materialization as the supported MVP path,
-- mark CLI `normalize` as legacy compatibility unless it is moved to the
-  Bronze-native `ingestion_run_id` flow,
-- add a config flag or documented operational switch for best-effort V1
-  compatibility writes if operators need to disable them,
-- keep V1 reads/writes only where they support rollback or compatibility.
-
-Acceptance criteria:
-
-- a user cannot accidentally choose the stale V1 normalize path thinking it is
-  the recommended V2 pipeline,
-- disabling optional V1 projection is either proven safe for the MVP path or
-  clearly documented as not yet supported.
-
-### P3: Add Minimal Operational Hardening
-
-Focus on the exact MVP path:
-
-- restart/reclaim test for ingestion -> materialization -> export,
-- idempotency check for re-running materialization on the same ingestion run,
-- one export test covering a Gold dataset,
-- one tenant isolation test covering a forbidden target query/export.
+- publish a support matrix that labels target kinds and dataset flows as
+  `stable`, `beta`, or `experimental`,
+- add representative correctness fixtures for the supported matrix,
+- validate Gold semantics that downstream consumers are likely to rely on
+  (`balance_history`, HL PnL/trade grouping, `pool_snapshots`).
 
 Acceptance criteria:
 
-- duplicate worker claims do not duplicate visible Gold/export side effects,
-- tenant-scoped API keys cannot query or export another target.
+- operators can tell which paths are actually supported,
+- tests cover the supported target matrix instead of only internal helpers.
 
-### P4: Minimal Integrator UX
+### P5: Keep The Compatibility Story Explicit
 
-Do the smallest useful documentation work:
+Keep V1 compatibility bounded and understandable:
 
-- quickstart for local Postgres + API,
-- curl examples for target registration, ingest, job polling, dataset query,
-  and export,
-- callback HMAC verification example,
-- a short "supported MVP path vs legacy compatibility path" note.
+- document API ingestion + auto-materialization as the supported path,
+- keep CLI `normalize` labeled as legacy compatibility unless it is moved onto
+  the Bronze-native flow,
+- retain the V1 compat-write flag and document when disabling it is safe.
 
-Do not prioritize SDK generation, dashboard work, enterprise project/org
-management, or broad target presets before the MVP flow is proven.
+Acceptance criteria:
+
+- a user cannot accidentally choose a legacy path believing it is the
+  recommended V2 flow,
+- optional V1 projection is clearly described as compatibility, not authority.
 
 ## 8. Updated First PRs
 
-The old suggested first PRs are no longer correct. The following are the best
-next slices:
+The old suggested first PRs are no longer correct. The best next slices are:
 
-1. **MVP smoke workflow and docs**
-   - Add a local quickstart and smoke script for the API path.
-   - Include tenant API key setup, target registration, ingest, query, export,
-     and optional callback signing.
+1. **Honest supported-path smoke and README alignment**
+   - Fix the smoke script so it uses the real API contract and fails loudly.
+   - Align README curl examples with the current tenant-scoped API.
 
-2. **Gold status/provenance cleanup**
-   - Upsert Gold completeness for all six Gold datasets.
-   - Ensure export provenance is populated for Gold exports.
-   - Make tenant-scoped dataset status/completeness available or explicitly
-     admin-only with a documented replacement.
+2. **Target-scoped Gold query/export lineage**
+   - Fix or replace the generic Gold query/export path where `raw_transaction_id`
+     is assumed but not actually present.
+   - Add focused tests for supported Gold datasets.
 
-3. **CLI/V1 compatibility clarification**
-   - Either route CLI normalize through Bronze-native `ingestion_run_id`
-     materialization or label it as legacy.
-   - Add a compatibility-write flag if operators need to run API ingestion
-     without V1 projection.
+3. **Target-centric ingest API/runtime**
+   - Add a supported `target_id`-driven ingest path.
+   - Move supported non-wallet target kinds onto the `Connector` path.
 
-4. **Focused hardening tests**
-   - Add restart/reclaim and idempotency coverage for the MVP path.
-   - Add one cross-tenant forbidden query/export test.
+4. **Tenant status/completeness**
+   - Add safe tenant-visible status surfaces for owned targets.
+   - Wire Gold completeness/provenance through those surfaces.
 
-5. **Gold semantic validation**
-   - Validate `balance_history` seeding, HL PnL/trade grouping, and
-     `pool_snapshots` semantics against representative fixtures.
-   - Treat protocol TVL as limited until pool token/reserve derivation is
-     validated.
+5. **Support matrix and correctness fixtures**
+   - Publish the MVP support matrix.
+   - Add representative fixtures for Solana wallet, Hyperliquid wallet/market,
+     and EVM contract/topic flows.
 
 ## 9. Definition Of Done For MVP
 
 The MVP is ready when:
 
-- the documented API path runs successfully on a fresh local environment,
+- the documented API path runs successfully on a fresh local environment
+  without ignored failures,
 - ingestion, materialization, query, and export survive an API restart,
-- all six Gold datasets are materialized from Silver during the API path,
+- at least one non-wallet target type is supported end to end through the
+  public API path,
+- supported target-scoped Gold query/export paths are correct for the datasets
+  labeled stable in the support matrix,
 - wallet and dataset reads are tenant-scoped for DB-backed API keys,
 - users can see enough status/provenance to trust a completed job/export,
+- the support matrix is explicit and matches what the code actually proves,
 - V1 compatibility behavior is documented and does not surprise operators.
 
 Out of scope for MVP:
 
 - deleting all V1 tables/code,
+- production-grade support for every target kind on every chain,
 - full SDK generation,
 - dashboard/frontend work,
 - enterprise org/billing management,


### PR DESCRIPTION
## Summary
- allow tenant-scoped dataset completeness and status endpoints to return owner-filtered rows instead of fail-closing
- add owner-scoped completeness repo queries and regression coverage for tenant filtering
- improve export provenance version selection so target-scoped exports prefer the materialized completeness version and mixed-version exports omit misleading version metadata
- update README examples to reflect tenant-visible status/completeness

## Test Plan
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace