### PR TITLE
fix: route gold exports through direct filters

### DIFF
--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1495,13 +1495,13 @@ fn direct_export_filter_spec_for_dataset(dataset: &str) -> Option<DirectExportFi
             table: DatasetName::HlPnlSummary.physical_table(),
             order_col: "dt.period_end",
             target_address_col: "wallet_address",
-            time_col: "period_start",
+            time_col: "period_end",
         }),
         "hl_trade_history" => Some(DirectExportFilterSpec {
             table: DatasetName::HlTradeHistory.physical_table(),
             order_col: "dt.closed_at",
             target_address_col: "wallet_address",
-            time_col: "opened_at",
+            time_col: "closed_at",
         }),
         "protocol_events" => Some(DirectExportFilterSpec {
             table: DatasetName::ProtocolEvents.physical_table(),
@@ -3871,16 +3871,15 @@ impl Repository {
     /// the disk-write rate rather than buffering whole pages in RAM.
     ///
     /// Returns the total number of records sent.
-    async fn direct_export_target_address(
+    async fn direct_export_target(
         &self,
         target_id: Option<Uuid>,
-    ) -> anyhow::Result<Option<String>> {
+    ) -> anyhow::Result<Option<IndexTarget>> {
         match target_id {
             Some(tid) => Ok(self
                 .get_index_target(tid)
                 .await?
-                .and_then(|t| t.address)
-                .filter(|addr| !addr.is_empty())),
+                .filter(|target| target.address.as_ref().is_some_and(|addr| !addr.is_empty()))),
             None => Ok(None),
         }
     }
@@ -4066,7 +4065,8 @@ impl Repository {
                 let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, \
                             dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
                             dt.created_at";
-                let target_address = self.direct_export_target_address(target_id).await?;
+                let target = self.direct_export_target(target_id).await?;
+                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
                 if target_id.is_some() && target_address.is_none() {
                     0
                 } else {
@@ -4074,7 +4074,7 @@ impl Repository {
                         &mut tx,
                         cols,
                         direct_export_filter_spec_for_dataset("balance_history").unwrap(),
-                        target_address.as_deref(),
+                        target_address,
                         network,
                         time_start,
                         time_end,
@@ -4093,7 +4093,8 @@ impl Repository {
                             dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
                             dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                             dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
-                let target_address = self.direct_export_target_address(target_id).await?;
+                let target = self.direct_export_target(target_id).await?;
+                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
                 if target_id.is_some() && target_address.is_none() {
                     0
                 } else {
@@ -4101,7 +4102,7 @@ impl Repository {
                         &mut tx,
                         cols,
                         direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap(),
-                        target_address.as_deref(),
+                        target_address,
                         network,
                         time_start,
                         time_end,
@@ -4120,7 +4121,8 @@ impl Repository {
                             dt.entry_price, dt.exit_price, dt.size, dt.opened_at, dt.closed_at, \
                             dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
                             dt.created_at";
-                let target_address = self.direct_export_target_address(target_id).await?;
+                let target = self.direct_export_target(target_id).await?;
+                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
                 if target_id.is_some() && target_address.is_none() {
                     0
                 } else {
@@ -4128,7 +4130,7 @@ impl Repository {
                         &mut tx,
                         cols,
                         direct_export_filter_spec_for_dataset("hl_trade_history").unwrap(),
-                        target_address.as_deref(),
+                        target_address,
                         network,
                         time_start,
                         time_end,
@@ -4146,15 +4148,21 @@ impl Repository {
                 let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, \
                             dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
                             dt.timestamp, dt.dataset_version_id, dt.created_at";
-                let target_address = self.direct_export_target_address(target_id).await?;
+                let target = self.direct_export_target(target_id).await?;
+                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
                 if target_id.is_some() && target_address.is_none() {
                     0
                 } else {
+                    let mut spec =
+                        direct_export_filter_spec_for_dataset("protocol_events").unwrap();
+                    if target.as_ref().is_some_and(|t| t.kind == TargetKind::Pool) {
+                        spec.target_address_col = "pool_address";
+                    }
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
-                        direct_export_filter_spec_for_dataset("protocol_events").unwrap(),
-                        target_address.as_deref(),
+                        spec,
+                        target_address,
                         network,
                         time_start,
                         time_end,
@@ -4174,7 +4182,8 @@ impl Repository {
                             dt.token1_address, dt.token1_symbol, dt.reserve0, dt.reserve1, \
                             dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                             dt.dataset_version_id, dt.created_at";
-                let target_address = self.direct_export_target_address(target_id).await?;
+                let target = self.direct_export_target(target_id).await?;
+                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
                 if target_id.is_some() && target_address.is_none() {
                     0
                 } else {
@@ -4182,7 +4191,7 @@ impl Repository {
                         &mut tx,
                         cols,
                         direct_export_filter_spec_for_dataset("pool_snapshots").unwrap(),
-                        target_address.as_deref(),
+                        target_address,
                         network,
                         time_start,
                         time_end,

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1224,25 +1224,21 @@ impl ExportRecordBatch {
 /// query and before every send so lease-loss (heartbeat reporting the
 /// export job was reclaimed) aborts promptly.
 #[allow(clippy::too_many_arguments)]
-async fn stream_paged_in_tx<T, R, B>(
+async fn stream_paged_with_builder_in_tx<T, R, B, Q>(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    cols: &str,
     table: &str,
-    order_col: &str,
-    target_id: Option<Uuid>,
-    network: Option<&str>,
-    time_start: Option<i64>,
-    time_end: Option<i64>,
     page_size: i64,
     hard_cap: i64,
     cancel: &tokio_util::sync::CancellationToken,
     tx_out: &tokio::sync::mpsc::Sender<ExportRecordBatch>,
+    mut build_page_query: Q,
     row_fn: R,
     batch_fn: B,
 ) -> anyhow::Result<usize>
 where
     R: Fn(&sqlx::postgres::PgRow) -> anyhow::Result<T>,
     B: Fn(Vec<T>) -> ExportRecordBatch,
+    Q: FnMut(i64) -> anyhow::Result<(String, sqlx::postgres::PgArguments)>,
 {
     let mut offset: i64 = 0;
     let mut total: usize = 0;
@@ -1251,9 +1247,7 @@ where
             anyhow::bail!("export snapshot cancelled (lease lost or worker shutdown)");
         }
 
-        let (sql, args) = build_dataset_filter_query(
-            cols, table, order_col, target_id, network, time_start, time_end, page_size, offset,
-        )?;
+        let (sql, args) = build_page_query(offset)?;
 
         let rows = sqlx::query_with(&sql, args).fetch_all(&mut **tx).await?;
         let n = rows.len();
@@ -1308,6 +1302,93 @@ where
         }
     }
     Ok(total)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_paged_in_tx<T, R, B>(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    cols: &str,
+    table: &str,
+    order_col: &str,
+    target_id: Option<Uuid>,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    page_size: i64,
+    hard_cap: i64,
+    cancel: &tokio_util::sync::CancellationToken,
+    tx_out: &tokio::sync::mpsc::Sender<ExportRecordBatch>,
+    row_fn: R,
+    batch_fn: B,
+) -> anyhow::Result<usize>
+where
+    R: Fn(&sqlx::postgres::PgRow) -> anyhow::Result<T>,
+    B: Fn(Vec<T>) -> ExportRecordBatch,
+{
+    stream_paged_with_builder_in_tx(
+        tx,
+        table,
+        page_size,
+        hard_cap,
+        cancel,
+        tx_out,
+        |offset| {
+            build_dataset_filter_query(
+                cols, table, order_col, target_id, network, time_start, time_end, page_size, offset,
+            )
+        },
+        row_fn,
+        batch_fn,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_paged_direct_in_tx<T, R, B>(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    cols: &str,
+    spec: DirectExportFilterSpec,
+    target_address: Option<&str>,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    page_size: i64,
+    hard_cap: i64,
+    cancel: &tokio_util::sync::CancellationToken,
+    tx_out: &tokio::sync::mpsc::Sender<ExportRecordBatch>,
+    row_fn: R,
+    batch_fn: B,
+) -> anyhow::Result<usize>
+where
+    R: Fn(&sqlx::postgres::PgRow) -> anyhow::Result<T>,
+    B: Fn(Vec<T>) -> ExportRecordBatch,
+{
+    stream_paged_with_builder_in_tx(
+        tx,
+        spec.table,
+        page_size,
+        hard_cap,
+        cancel,
+        tx_out,
+        |offset| {
+            build_dataset_filter_query_direct(
+                cols,
+                spec.table,
+                spec.order_col,
+                target_address,
+                spec.target_address_col,
+                network,
+                time_start,
+                time_end,
+                spec.time_col,
+                page_size,
+                offset,
+            )
+        },
+        row_fn,
+        batch_fn,
+    )
+    .await
 }
 
 /// Build a filtered SELECT query for a Silver dataset table.
@@ -1392,6 +1473,50 @@ pub fn build_dataset_filter_query(
     args.add(offset).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok((sql, args))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DirectExportFilterSpec {
+    table: &'static str,
+    order_col: &'static str,
+    target_address_col: &'static str,
+    time_col: &'static str,
+}
+
+fn direct_export_filter_spec_for_dataset(dataset: &str) -> Option<DirectExportFilterSpec> {
+    match dataset {
+        "balance_history" => Some(DirectExportFilterSpec {
+            table: DatasetName::BalanceHistory.physical_table(),
+            order_col: "dt.timestamp",
+            target_address_col: "wallet_address",
+            time_col: "timestamp",
+        }),
+        "hl_pnl_summary" => Some(DirectExportFilterSpec {
+            table: DatasetName::HlPnlSummary.physical_table(),
+            order_col: "dt.period_end",
+            target_address_col: "wallet_address",
+            time_col: "period_start",
+        }),
+        "hl_trade_history" => Some(DirectExportFilterSpec {
+            table: DatasetName::HlTradeHistory.physical_table(),
+            order_col: "dt.closed_at",
+            target_address_col: "wallet_address",
+            time_col: "opened_at",
+        }),
+        "protocol_events" => Some(DirectExportFilterSpec {
+            table: DatasetName::ProtocolEvents.physical_table(),
+            order_col: "dt.timestamp",
+            target_address_col: "protocol_address",
+            time_col: "timestamp",
+        }),
+        "pool_snapshots" => Some(DirectExportFilterSpec {
+            table: DatasetName::PoolSnapshots.physical_table(),
+            order_col: "dt.snapshot_timestamp",
+            target_address_col: "pool_address",
+            time_col: "snapshot_timestamp",
+        }),
+        _ => None,
+    }
 }
 
 /// Build a filter query for dataset tables that do NOT have `raw_transaction_id`.
@@ -3746,6 +3871,20 @@ impl Repository {
     /// the disk-write rate rather than buffering whole pages in RAM.
     ///
     /// Returns the total number of records sent.
+    async fn direct_export_target_address(
+        &self,
+        target_id: Option<Uuid>,
+    ) -> anyhow::Result<Option<String>> {
+        match target_id {
+            Some(tid) => Ok(self
+                .get_index_target(tid)
+                .await?
+                .and_then(|t| t.address)
+                .filter(|addr| !addr.is_empty())),
+            None => Ok(None),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn stream_export_snapshot(
         &self,
@@ -3927,91 +4066,107 @@ impl Repository {
                 let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, \
                             dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
                             dt.created_at";
-                stream_paged_in_tx(
-                    &mut tx,
-                    cols,
-                    DatasetName::BalanceHistory.physical_table(),
-                    "dt.timestamp",
-                    target_id,
-                    network,
-                    time_start,
-                    time_end,
-                    page_size,
-                    hard_cap,
-                    &cancel,
-                    &tx_out,
-                    row_to_balance_snapshot,
-                    ExportRecordBatch::BalanceHistory,
-                )
-                .await?
+                let target_address = self.direct_export_target_address(target_id).await?;
+                if target_id.is_some() && target_address.is_none() {
+                    0
+                } else {
+                    stream_paged_direct_in_tx(
+                        &mut tx,
+                        cols,
+                        direct_export_filter_spec_for_dataset("balance_history").unwrap(),
+                        target_address.as_deref(),
+                        network,
+                        time_start,
+                        time_end,
+                        page_size,
+                        hard_cap,
+                        &cancel,
+                        &tx_out,
+                        row_to_balance_snapshot,
+                        ExportRecordBatch::BalanceHistory,
+                    )
+                    .await?
+                }
             }
             "hl_pnl_summary" => {
                 let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.period_start, \
                             dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
                             dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                             dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
-                stream_paged_in_tx(
-                    &mut tx,
-                    cols,
-                    DatasetName::HlPnlSummary.physical_table(),
-                    "dt.period_end",
-                    target_id,
-                    network,
-                    time_start,
-                    time_end,
-                    page_size,
-                    hard_cap,
-                    &cancel,
-                    &tx_out,
-                    row_to_hl_pnl_summary,
-                    ExportRecordBatch::HlPnlSummary,
-                )
-                .await?
+                let target_address = self.direct_export_target_address(target_id).await?;
+                if target_id.is_some() && target_address.is_none() {
+                    0
+                } else {
+                    stream_paged_direct_in_tx(
+                        &mut tx,
+                        cols,
+                        direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap(),
+                        target_address.as_deref(),
+                        network,
+                        time_start,
+                        time_end,
+                        page_size,
+                        hard_cap,
+                        &cancel,
+                        &tx_out,
+                        row_to_hl_pnl_summary,
+                        ExportRecordBatch::HlPnlSummary,
+                    )
+                    .await?
+                }
             }
             "hl_trade_history" => {
                 let cols = "dt.id, dt.wallet_address, dt.coin, dt.network, dt.side, \
                             dt.entry_price, dt.exit_price, dt.size, dt.opened_at, dt.closed_at, \
                             dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
                             dt.created_at";
-                stream_paged_in_tx(
-                    &mut tx,
-                    cols,
-                    DatasetName::HlTradeHistory.physical_table(),
-                    "dt.closed_at",
-                    target_id,
-                    network,
-                    time_start,
-                    time_end,
-                    page_size,
-                    hard_cap,
-                    &cancel,
-                    &tx_out,
-                    row_to_hl_trade_history,
-                    ExportRecordBatch::HlTradeHistory,
-                )
-                .await?
+                let target_address = self.direct_export_target_address(target_id).await?;
+                if target_id.is_some() && target_address.is_none() {
+                    0
+                } else {
+                    stream_paged_direct_in_tx(
+                        &mut tx,
+                        cols,
+                        direct_export_filter_spec_for_dataset("hl_trade_history").unwrap(),
+                        target_address.as_deref(),
+                        network,
+                        time_start,
+                        time_end,
+                        page_size,
+                        hard_cap,
+                        &cancel,
+                        &tx_out,
+                        row_to_hl_trade_history,
+                        ExportRecordBatch::HlTradeHistory,
+                    )
+                    .await?
+                }
             }
             "protocol_events" => {
                 let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, \
                             dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
                             dt.timestamp, dt.dataset_version_id, dt.created_at";
-                stream_paged_in_tx(
-                    &mut tx,
-                    cols,
-                    DatasetName::ProtocolEvents.physical_table(),
-                    "dt.timestamp",
-                    target_id,
-                    network,
-                    time_start,
-                    time_end,
-                    page_size,
-                    hard_cap,
-                    &cancel,
-                    &tx_out,
-                    row_to_protocol_event,
-                    ExportRecordBatch::ProtocolEvents,
-                )
-                .await?
+                let target_address = self.direct_export_target_address(target_id).await?;
+                if target_id.is_some() && target_address.is_none() {
+                    0
+                } else {
+                    stream_paged_direct_in_tx(
+                        &mut tx,
+                        cols,
+                        direct_export_filter_spec_for_dataset("protocol_events").unwrap(),
+                        target_address.as_deref(),
+                        network,
+                        time_start,
+                        time_end,
+                        page_size,
+                        hard_cap,
+                        &cancel,
+                        &tx_out,
+                        row_to_protocol_event,
+                        ExportRecordBatch::ProtocolEvents,
+                    )
+                    .await?
+                }
             }
             "pool_snapshots" => {
                 let cols = "dt.id, dt.network, dt.pool_address, dt.protocol_address, \
@@ -4019,23 +4174,27 @@ impl Repository {
                             dt.token1_address, dt.token1_symbol, dt.reserve0, dt.reserve1, \
                             dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                             dt.dataset_version_id, dt.created_at";
-                stream_paged_in_tx(
-                    &mut tx,
-                    cols,
-                    DatasetName::PoolSnapshots.physical_table(),
-                    "dt.snapshot_timestamp",
-                    target_id,
-                    network,
-                    time_start,
-                    time_end,
-                    page_size,
-                    hard_cap,
-                    &cancel,
-                    &tx_out,
-                    row_to_pool_snapshot,
-                    ExportRecordBatch::PoolSnapshots,
-                )
-                .await?
+                let target_address = self.direct_export_target_address(target_id).await?;
+                if target_id.is_some() && target_address.is_none() {
+                    0
+                } else {
+                    stream_paged_direct_in_tx(
+                        &mut tx,
+                        cols,
+                        direct_export_filter_spec_for_dataset("pool_snapshots").unwrap(),
+                        target_address.as_deref(),
+                        network,
+                        time_start,
+                        time_end,
+                        page_size,
+                        hard_cap,
+                        &cancel,
+                        &tx_out,
+                        row_to_pool_snapshot,
+                        ExportRecordBatch::PoolSnapshots,
+                    )
+                    .await?
+                }
             }
             other => {
                 // Rolling back the snapshot transaction on unknown dataset
@@ -7086,6 +7245,42 @@ mod tests {
         assert!(sql.contains("dt.network = $2"));
         assert!(sql.contains("dt.timestamp >= $3"));
         assert!(sql.contains("dt.timestamp <= $4"));
+    }
+
+    #[test]
+    fn stream_export_gold_tables_without_raw_tx_use_direct_filter_specs() {
+        for dataset in [
+            "balance_history",
+            "hl_pnl_summary",
+            "hl_trade_history",
+            "protocol_events",
+            "pool_snapshots",
+        ] {
+            let spec = direct_export_filter_spec_for_dataset(dataset)
+                .unwrap_or_else(|| panic!("{dataset} should use direct export filtering"));
+            let (sql, _) = build_dataset_filter_query_direct(
+                "dt.id",
+                spec.table,
+                spec.order_col,
+                Some("target-address"),
+                spec.target_address_col,
+                Some("solana-mainnet"),
+                Some(1000),
+                Some(2000),
+                spec.time_col,
+                50,
+                0,
+            )
+            .unwrap();
+            assert!(
+                !sql.contains("target_matches"),
+                "{dataset} must not join target_matches"
+            );
+            assert!(
+                !sql.contains("raw_transactions"),
+                "{dataset} must not join raw_transactions"
+            );
+        }
     }
 
     #[test]

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1554,6 +1554,7 @@ fn protocol_target_addresses(
 fn direct_export_filter_for_target(
     target: Option<&IndexTarget>,
     default_col: &'static str,
+    allowed_kinds: &[TargetKind],
     pool_col: Option<&'static str>,
     protocol_col: Option<&'static str>,
     network: Option<&str>,
@@ -1561,23 +1562,41 @@ fn direct_export_filter_for_target(
     let Some(target) = target else {
         return Ok(None);
     };
+    if !allowed_kinds.contains(&target.kind) {
+        return Ok(None);
+    }
 
     if target.kind == TargetKind::Protocol {
         let Some(protocol_col) = protocol_col else {
             return Ok(None);
         };
-        let values = protocol_target_addresses(target, network)?;
+        let mut values = protocol_target_addresses(target, network)?;
+        if values.is_empty() {
+            if let Some(addr) = target
+                .address
+                .as_ref()
+                .map(|addr| addr.trim())
+                .filter(|addr| !addr.is_empty())
+            {
+                values.push(addr.to_owned());
+            }
+        }
         return Ok((!values.is_empty()).then_some(DirectExportTargetFilter {
             values,
             col: protocol_col,
         }));
     }
 
-    let Some(addr) = target.address.as_ref().filter(|addr| !addr.is_empty()) else {
+    let Some(addr) = target
+        .address
+        .as_ref()
+        .map(|addr| addr.trim())
+        .filter(|addr| !addr.is_empty())
+    else {
         return Ok(None);
     };
     Ok(Some(DirectExportTargetFilter {
-        values: vec![addr.clone()],
+        values: vec![addr.to_owned()],
         col: if target.kind == TargetKind::Pool {
             pool_col.unwrap_or(default_col)
         } else {
@@ -4170,6 +4189,7 @@ impl Repository {
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
                     spec.target_address_col,
+                    &[TargetKind::Wallet],
                     None,
                     None,
                     network,
@@ -4205,6 +4225,7 @@ impl Repository {
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
                     spec.target_address_col,
+                    &[TargetKind::Wallet],
                     None,
                     None,
                     network,
@@ -4240,6 +4261,7 @@ impl Repository {
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
                     spec.target_address_col,
+                    &[TargetKind::Wallet],
                     None,
                     None,
                     network,
@@ -4274,6 +4296,7 @@ impl Repository {
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
                     spec.target_address_col,
+                    &[TargetKind::Protocol, TargetKind::Pool],
                     Some("pool_address"),
                     Some("protocol_address"),
                     network,
@@ -4310,6 +4333,7 @@ impl Repository {
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
                     spec.target_address_col,
+                    &[TargetKind::Protocol, TargetKind::Pool],
                     Some("pool_address"),
                     Some("protocol_address"),
                     network,
@@ -7442,6 +7466,7 @@ mod tests {
         let filter = direct_export_filter_for_target(
             Some(&target),
             "protocol_address",
+            &[TargetKind::Protocol],
             None,
             Some("protocol_address"),
             Some("ethereum"),
@@ -7457,6 +7482,54 @@ mod tests {
     }
 
     #[test]
+    fn direct_export_filter_for_protocol_target_falls_back_to_canonical_address() {
+        let mut target = make_index_target();
+        target.kind = TargetKind::Protocol;
+        target.chain_family = ChainFamily::Evm;
+        target.network = "ethereum-mainnet".to_string();
+        target.address = Some("0xCanonicalProtocol".to_string());
+        target.filter_spec = Some(serde_json::json!({
+            "name": "uniswap_v3",
+            "addresses": {}
+        }));
+
+        let filter = direct_export_filter_for_target(
+            Some(&target),
+            "protocol_address",
+            &[TargetKind::Protocol],
+            None,
+            Some("protocol_address"),
+            Some("ethereum"),
+        )
+        .unwrap()
+        .expect("protocol target address should be usable when addresses map is empty");
+
+        assert_eq!(filter.values, vec!["0xCanonicalProtocol".to_string()]);
+        assert_eq!(filter.col, "protocol_address");
+    }
+
+    #[test]
+    fn direct_export_filter_rejects_target_kind_without_dataset_scope() {
+        let mut target = make_index_target();
+        target.kind = TargetKind::Pool;
+        target.chain_family = ChainFamily::Evm;
+        target.network = "ethereum-mainnet".to_string();
+        target.address = Some("0xPool".to_string());
+
+        let filter = direct_export_filter_for_target(
+            Some(&target),
+            "wallet_address",
+            &[TargetKind::Wallet],
+            None,
+            None,
+            Some("ethereum"),
+        )
+        .unwrap();
+
+        assert!(filter.is_none());
+    }
+
+    #[test]
     fn direct_export_filter_for_pool_target_uses_pool_column_override() {
         let mut target = make_index_target();
         target.kind = TargetKind::Pool;
@@ -7467,6 +7540,7 @@ mod tests {
         let filter = direct_export_filter_for_target(
             Some(&target),
             "protocol_address",
+            &[TargetKind::Pool],
             Some("pool_address"),
             Some("protocol_address"),
             Some("ethereum"),
@@ -7486,6 +7560,7 @@ mod tests {
         let filter = direct_export_filter_for_target(
             Some(&target),
             "wallet_address",
+            &[TargetKind::Wallet],
             None,
             None,
             Some("ethereum"),

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -4,6 +4,7 @@
 //! `Repository` value they already hold for V1 wallet-scoped queries.
 
 use chrono::{DateTime, Utc};
+use spectraplex_core::connector::ProtocolFilterSpec;
 
 /// V2-backed wallet statistics returned by `get_wallet_stats_v2`.
 pub struct WalletStatsV2 {
@@ -1348,7 +1349,7 @@ async fn stream_paged_direct_in_tx<T, R, B>(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     cols: &str,
     spec: DirectExportFilterSpec,
-    target_address: Option<&str>,
+    target_filter: Option<&DirectExportTargetFilter>,
     network: Option<&str>,
     time_start: Option<i64>,
     time_end: Option<i64>,
@@ -1375,8 +1376,8 @@ where
                 cols,
                 spec.table,
                 spec.order_col,
-                target_address,
-                spec.target_address_col,
+                target_filter.map(|f| f.value.as_str()),
+                target_filter.map_or(spec.target_address_col, |f| f.col),
                 network,
                 time_start,
                 time_end,
@@ -1517,6 +1518,50 @@ fn direct_export_filter_spec_for_dataset(dataset: &str) -> Option<DirectExportFi
         }),
         _ => None,
     }
+}
+
+struct DirectExportTargetFilter {
+    value: String,
+    col: &'static str,
+}
+
+fn protocol_target_name(target: &IndexTarget) -> anyhow::Result<Option<String>> {
+    let Some(filter_spec) = target.filter_spec.as_ref() else {
+        return Ok(None);
+    };
+    let spec: ProtocolFilterSpec = serde_json::from_value(filter_spec.clone())?;
+    Ok((!spec.name.is_empty()).then_some(spec.name))
+}
+
+fn direct_export_filter_for_target(
+    target: Option<&IndexTarget>,
+    default_col: &'static str,
+    pool_col: Option<&'static str>,
+) -> anyhow::Result<Option<DirectExportTargetFilter>> {
+    let Some(target) = target else {
+        return Ok(None);
+    };
+
+    if target.kind == TargetKind::Protocol {
+        return Ok(
+            protocol_target_name(target)?.map(|name| DirectExportTargetFilter {
+                value: name,
+                col: "protocol_name",
+            }),
+        );
+    }
+
+    let Some(addr) = target.address.as_ref().filter(|addr| !addr.is_empty()) else {
+        return Ok(None);
+    };
+    Ok(Some(DirectExportTargetFilter {
+        value: addr.clone(),
+        col: if target.kind == TargetKind::Pool {
+            pool_col.unwrap_or(default_col)
+        } else {
+            default_col
+        },
+    }))
 }
 
 /// Build a filter query for dataset tables that do NOT have `raw_transaction_id`.
@@ -3876,10 +3921,7 @@ impl Repository {
         target_id: Option<Uuid>,
     ) -> anyhow::Result<Option<IndexTarget>> {
         match target_id {
-            Some(tid) => Ok(self
-                .get_index_target(tid)
-                .await?
-                .filter(|target| target.address.as_ref().is_some_and(|addr| !addr.is_empty()))),
+            Some(tid) => self.get_index_target(tid).await,
             None => Ok(None),
         }
     }
@@ -4066,15 +4108,20 @@ impl Repository {
                             dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
                             dt.created_at";
                 let target = self.direct_export_target(target_id).await?;
-                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
-                if target_id.is_some() && target_address.is_none() {
+                let spec = direct_export_filter_spec_for_dataset("balance_history").unwrap();
+                let target_filter = direct_export_filter_for_target(
+                    target.as_ref(),
+                    spec.target_address_col,
+                    None,
+                )?;
+                if target_id.is_some() && target_filter.is_none() {
                     0
                 } else {
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
-                        direct_export_filter_spec_for_dataset("balance_history").unwrap(),
-                        target_address,
+                        spec,
+                        target_filter.as_ref(),
                         network,
                         time_start,
                         time_end,
@@ -4094,15 +4141,20 @@ impl Repository {
                             dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                             dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
                 let target = self.direct_export_target(target_id).await?;
-                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
-                if target_id.is_some() && target_address.is_none() {
+                let spec = direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap();
+                let target_filter = direct_export_filter_for_target(
+                    target.as_ref(),
+                    spec.target_address_col,
+                    None,
+                )?;
+                if target_id.is_some() && target_filter.is_none() {
                     0
                 } else {
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
-                        direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap(),
-                        target_address,
+                        spec,
+                        target_filter.as_ref(),
                         network,
                         time_start,
                         time_end,
@@ -4122,15 +4174,20 @@ impl Repository {
                             dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
                             dt.created_at";
                 let target = self.direct_export_target(target_id).await?;
-                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
-                if target_id.is_some() && target_address.is_none() {
+                let spec = direct_export_filter_spec_for_dataset("hl_trade_history").unwrap();
+                let target_filter = direct_export_filter_for_target(
+                    target.as_ref(),
+                    spec.target_address_col,
+                    None,
+                )?;
+                if target_id.is_some() && target_filter.is_none() {
                     0
                 } else {
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
-                        direct_export_filter_spec_for_dataset("hl_trade_history").unwrap(),
-                        target_address,
+                        spec,
+                        target_filter.as_ref(),
                         network,
                         time_start,
                         time_end,
@@ -4149,20 +4206,20 @@ impl Repository {
                             dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
                             dt.timestamp, dt.dataset_version_id, dt.created_at";
                 let target = self.direct_export_target(target_id).await?;
-                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
-                if target_id.is_some() && target_address.is_none() {
+                let spec = direct_export_filter_spec_for_dataset("protocol_events").unwrap();
+                let target_filter = direct_export_filter_for_target(
+                    target.as_ref(),
+                    spec.target_address_col,
+                    Some("pool_address"),
+                )?;
+                if target_id.is_some() && target_filter.is_none() {
                     0
                 } else {
-                    let mut spec =
-                        direct_export_filter_spec_for_dataset("protocol_events").unwrap();
-                    if target.as_ref().is_some_and(|t| t.kind == TargetKind::Pool) {
-                        spec.target_address_col = "pool_address";
-                    }
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
                         spec,
-                        target_address,
+                        target_filter.as_ref(),
                         network,
                         time_start,
                         time_end,
@@ -4183,15 +4240,20 @@ impl Repository {
                             dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                             dt.dataset_version_id, dt.created_at";
                 let target = self.direct_export_target(target_id).await?;
-                let target_address = target.as_ref().and_then(|t| t.address.as_deref());
-                if target_id.is_some() && target_address.is_none() {
+                let spec = direct_export_filter_spec_for_dataset("pool_snapshots").unwrap();
+                let target_filter = direct_export_filter_for_target(
+                    target.as_ref(),
+                    spec.target_address_col,
+                    Some("pool_address"),
+                )?;
+                if target_id.is_some() && target_filter.is_none() {
                     0
                 } else {
                     stream_paged_direct_in_tx(
                         &mut tx,
                         cols,
-                        direct_export_filter_spec_for_dataset("pool_snapshots").unwrap(),
-                        target_address,
+                        spec,
+                        target_filter.as_ref(),
                         network,
                         time_start,
                         time_end,
@@ -7290,6 +7352,57 @@ mod tests {
                 "{dataset} must not join raw_transactions"
             );
         }
+    }
+
+    #[test]
+    fn direct_export_filter_for_protocol_target_uses_protocol_name_column() {
+        let mut target = make_index_target();
+        target.kind = TargetKind::Protocol;
+        target.chain_family = ChainFamily::Evm;
+        target.network = "ethereum-mainnet".to_string();
+        target.address = None;
+        target.filter_spec = Some(serde_json::json!({
+            "name": "uniswap_v3",
+            "addresses": {}
+        }));
+
+        let filter = direct_export_filter_for_target(Some(&target), "protocol_address", None)
+            .unwrap()
+            .expect("protocol filter_spec name should produce a direct export filter");
+
+        assert_eq!(filter.value, "uniswap_v3");
+        assert_eq!(filter.col, "protocol_name");
+    }
+
+    #[test]
+    fn direct_export_filter_for_pool_target_uses_pool_column_override() {
+        let mut target = make_index_target();
+        target.kind = TargetKind::Pool;
+        target.chain_family = ChainFamily::Evm;
+        target.network = "ethereum-mainnet".to_string();
+        target.address = Some("0xPool".to_string());
+
+        let filter = direct_export_filter_for_target(
+            Some(&target),
+            "protocol_address",
+            Some("pool_address"),
+        )
+        .unwrap()
+        .expect("pool address should produce a direct export filter");
+
+        assert_eq!(filter.value, "0xPool");
+        assert_eq!(filter.col, "pool_address");
+    }
+
+    #[test]
+    fn direct_export_filter_for_requested_target_without_scope_is_none() {
+        let mut target = make_index_target();
+        target.address = None;
+
+        let filter =
+            direct_export_filter_for_target(Some(&target), "wallet_address", None).unwrap();
+
+        assert!(filter.is_none());
     }
 
     #[test]

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1372,11 +1372,11 @@ where
         cancel,
         tx_out,
         |offset| {
-            build_dataset_filter_query_direct(
+            build_dataset_filter_query_direct_values(
                 cols,
                 spec.table,
                 spec.order_col,
-                target_filter.map(|f| f.value.as_str()),
+                target_filter.map(|f| f.values.as_slice()),
                 target_filter.map_or(spec.target_address_col, |f| f.col),
                 network,
                 time_start,
@@ -1521,41 +1521,63 @@ fn direct_export_filter_spec_for_dataset(dataset: &str) -> Option<DirectExportFi
 }
 
 struct DirectExportTargetFilter {
-    value: String,
+    values: Vec<String>,
     col: &'static str,
 }
 
-fn protocol_target_name(target: &IndexTarget) -> anyhow::Result<Option<String>> {
+fn protocol_target_addresses(
+    target: &IndexTarget,
+    network: Option<&str>,
+) -> anyhow::Result<Vec<String>> {
     let Some(filter_spec) = target.filter_spec.as_ref() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let spec: ProtocolFilterSpec = serde_json::from_value(filter_spec.clone())?;
-    Ok((!spec.name.is_empty()).then_some(spec.name))
+    let requested_network = network.unwrap_or(target.network.as_str());
+    let mut addrs: Vec<String> = spec
+        .addresses
+        .get(requested_network)
+        .map(|entries| {
+            entries
+                .iter()
+                .map(|entry| entry.address.trim())
+                .filter(|addr| !addr.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+    addrs.sort();
+    addrs.dedup();
+    Ok(addrs)
 }
 
 fn direct_export_filter_for_target(
     target: Option<&IndexTarget>,
     default_col: &'static str,
     pool_col: Option<&'static str>,
+    protocol_col: Option<&'static str>,
+    network: Option<&str>,
 ) -> anyhow::Result<Option<DirectExportTargetFilter>> {
     let Some(target) = target else {
         return Ok(None);
     };
 
     if target.kind == TargetKind::Protocol {
-        return Ok(
-            protocol_target_name(target)?.map(|name| DirectExportTargetFilter {
-                value: name,
-                col: "protocol_name",
-            }),
-        );
+        let Some(protocol_col) = protocol_col else {
+            return Ok(None);
+        };
+        let values = protocol_target_addresses(target, network)?;
+        return Ok((!values.is_empty()).then_some(DirectExportTargetFilter {
+            values,
+            col: protocol_col,
+        }));
     }
 
     let Some(addr) = target.address.as_ref().filter(|addr| !addr.is_empty()) else {
         return Ok(None);
     };
     Ok(Some(DirectExportTargetFilter {
-        value: addr.clone(),
+        values: vec![addr.clone()],
         col: if target.kind == TargetKind::Pool {
             pool_col.unwrap_or(default_col)
         } else {
@@ -1574,11 +1596,11 @@ fn direct_export_filter_for_target(
 /// `hl_pnl_summary`, `hl_trade_history`, `protocol_events`, and `pool_snapshots`
 /// that lack a `raw_transaction_id` column (P1).
 #[allow(clippy::too_many_arguments)]
-pub fn build_dataset_filter_query_direct(
+fn build_dataset_filter_query_direct_values(
     select_cols: &str,
     table_name: &str,
     order_col: &str,
-    target_address: Option<&str>,
+    target_values: Option<&[String]>,
     target_address_col: &str,
     network: Option<&str>,
     time_start: Option<i64>,
@@ -1593,12 +1615,18 @@ pub fn build_dataset_filter_query_direct(
     let mut n: usize = 0;
     let mut wheres: Vec<String> = Vec::new();
 
-    if let Some(addr) = target_address {
+    if let Some(values) = target_values.filter(|values| !values.is_empty()) {
         n += 1;
-        wheres.push(format!("dt.{target_address_col} = ${n}"));
         use sqlx::Arguments;
-        args.add(addr.to_string())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if values.len() == 1 {
+            wheres.push(format!("dt.{target_address_col} = ${n}"));
+            args.add(values[0].clone())
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+        } else {
+            wheres.push(format!("dt.{target_address_col} = ANY(${n})"));
+            args.add(values.to_vec())
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+        }
     }
     if let Some(net) = network {
         n += 1;
@@ -1637,6 +1665,36 @@ pub fn build_dataset_filter_query_direct(
     args.add(offset).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     Ok((sql, args))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_dataset_filter_query_direct(
+    select_cols: &str,
+    table_name: &str,
+    order_col: &str,
+    target_address: Option<&str>,
+    target_address_col: &str,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    time_col: &str,
+    limit: i64,
+    offset: i64,
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let values = target_address.map(|addr| vec![addr.to_string()]);
+    build_dataset_filter_query_direct_values(
+        select_cols,
+        table_name,
+        order_col,
+        values.as_deref(),
+        target_address_col,
+        network,
+        time_start,
+        time_end,
+        time_col,
+        limit,
+        offset,
+    )
 }
 
 /// Build a batch INSERT for `raw_evm_traces` with ON CONFLICT DO NOTHING.
@@ -4113,6 +4171,8 @@ impl Repository {
                     target.as_ref(),
                     spec.target_address_col,
                     None,
+                    None,
+                    network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4146,6 +4206,8 @@ impl Repository {
                     target.as_ref(),
                     spec.target_address_col,
                     None,
+                    None,
+                    network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4179,6 +4241,8 @@ impl Repository {
                     target.as_ref(),
                     spec.target_address_col,
                     None,
+                    None,
+                    network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4211,6 +4275,8 @@ impl Repository {
                     target.as_ref(),
                     spec.target_address_col,
                     Some("pool_address"),
+                    Some("protocol_address"),
+                    network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4245,6 +4311,8 @@ impl Repository {
                     target.as_ref(),
                     spec.target_address_col,
                     Some("pool_address"),
+                    Some("protocol_address"),
+                    network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -7355,7 +7423,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_export_filter_for_protocol_target_uses_protocol_name_column() {
+    fn direct_export_filter_for_protocol_target_uses_protocol_addresses() {
         let mut target = make_index_target();
         target.kind = TargetKind::Protocol;
         target.chain_family = ChainFamily::Evm;
@@ -7363,15 +7431,29 @@ mod tests {
         target.address = None;
         target.filter_spec = Some(serde_json::json!({
             "name": "uniswap_v3",
-            "addresses": {}
+            "addresses": {
+                "ethereum": [
+                    { "address": "0xProtocolB", "role": "pool", "label": "b" },
+                    { "address": "0xProtocolA", "role": "pool", "label": "a" }
+                ]
+            }
         }));
 
-        let filter = direct_export_filter_for_target(Some(&target), "protocol_address", None)
-            .unwrap()
-            .expect("protocol filter_spec name should produce a direct export filter");
+        let filter = direct_export_filter_for_target(
+            Some(&target),
+            "protocol_address",
+            None,
+            Some("protocol_address"),
+            Some("ethereum"),
+        )
+        .unwrap()
+        .expect("protocol filter_spec addresses should produce a direct export filter");
 
-        assert_eq!(filter.value, "uniswap_v3");
-        assert_eq!(filter.col, "protocol_name");
+        assert_eq!(
+            filter.values,
+            vec!["0xProtocolA".to_string(), "0xProtocolB".to_string()]
+        );
+        assert_eq!(filter.col, "protocol_address");
     }
 
     #[test]
@@ -7386,11 +7468,13 @@ mod tests {
             Some(&target),
             "protocol_address",
             Some("pool_address"),
+            Some("protocol_address"),
+            Some("ethereum"),
         )
         .unwrap()
-        .expect("pool address should produce a direct export filter");
+        .expect("pool targets should prefer the pool column when provided");
 
-        assert_eq!(filter.value, "0xPool");
+        assert_eq!(filter.values, vec!["0xPool".to_string()]);
         assert_eq!(filter.col, "pool_address");
     }
 
@@ -7399,8 +7483,14 @@ mod tests {
         let mut target = make_index_target();
         target.address = None;
 
-        let filter =
-            direct_export_filter_for_target(Some(&target), "wallet_address", None).unwrap();
+        let filter = direct_export_filter_for_target(
+            Some(&target),
+            "wallet_address",
+            None,
+            None,
+            Some("ethereum"),
+        )
+        .unwrap();
 
         assert!(filter.is_none());
     }

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1551,6 +1551,13 @@ fn protocol_target_addresses(
     Ok(addrs)
 }
 
+fn direct_export_network_scope<'a>(
+    target: Option<&'a IndexTarget>,
+    requested_network: Option<&'a str>,
+) -> Option<&'a str> {
+    requested_network.or_else(|| target.map(|t| t.network.as_str()))
+}
+
 fn direct_export_filter_for_target(
     target: Option<&IndexTarget>,
     default_col: &'static str,
@@ -4193,6 +4200,7 @@ impl Repository {
                             dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
                             dt.created_at";
                 let target = Self::direct_export_target(&mut tx, target_id).await?;
+                let export_network = direct_export_network_scope(target.as_ref(), network);
                 let spec = direct_export_filter_spec_for_dataset("balance_history").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4200,7 +4208,7 @@ impl Repository {
                     &[TargetKind::Wallet],
                     None,
                     None,
-                    network,
+                    export_network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4210,7 +4218,7 @@ impl Repository {
                         cols,
                         spec,
                         target_filter.as_ref(),
-                        network,
+                        export_network,
                         time_start,
                         time_end,
                         page_size,
@@ -4229,6 +4237,7 @@ impl Repository {
                             dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                             dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
                 let target = Self::direct_export_target(&mut tx, target_id).await?;
+                let export_network = direct_export_network_scope(target.as_ref(), network);
                 let spec = direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4236,7 +4245,7 @@ impl Repository {
                     &[TargetKind::Wallet],
                     None,
                     None,
-                    network,
+                    export_network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4246,7 +4255,7 @@ impl Repository {
                         cols,
                         spec,
                         target_filter.as_ref(),
-                        network,
+                        export_network,
                         time_start,
                         time_end,
                         page_size,
@@ -4265,6 +4274,7 @@ impl Repository {
                             dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
                             dt.created_at";
                 let target = Self::direct_export_target(&mut tx, target_id).await?;
+                let export_network = direct_export_network_scope(target.as_ref(), network);
                 let spec = direct_export_filter_spec_for_dataset("hl_trade_history").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4272,7 +4282,7 @@ impl Repository {
                     &[TargetKind::Wallet],
                     None,
                     None,
-                    network,
+                    export_network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4282,7 +4292,7 @@ impl Repository {
                         cols,
                         spec,
                         target_filter.as_ref(),
-                        network,
+                        export_network,
                         time_start,
                         time_end,
                         page_size,
@@ -4300,6 +4310,7 @@ impl Repository {
                             dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
                             dt.timestamp, dt.dataset_version_id, dt.created_at";
                 let target = Self::direct_export_target(&mut tx, target_id).await?;
+                let export_network = direct_export_network_scope(target.as_ref(), network);
                 let spec = direct_export_filter_spec_for_dataset("protocol_events").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4307,7 +4318,7 @@ impl Repository {
                     &[TargetKind::Protocol, TargetKind::Pool],
                     Some("pool_address"),
                     Some("protocol_address"),
-                    network,
+                    export_network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4317,7 +4328,7 @@ impl Repository {
                         cols,
                         spec,
                         target_filter.as_ref(),
-                        network,
+                        export_network,
                         time_start,
                         time_end,
                         page_size,
@@ -4337,6 +4348,7 @@ impl Repository {
                             dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                             dt.dataset_version_id, dt.created_at";
                 let target = Self::direct_export_target(&mut tx, target_id).await?;
+                let export_network = direct_export_network_scope(target.as_ref(), network);
                 let spec = direct_export_filter_spec_for_dataset("pool_snapshots").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4344,7 +4356,7 @@ impl Repository {
                     &[TargetKind::Protocol, TargetKind::Pool],
                     Some("pool_address"),
                     Some("protocol_address"),
-                    network,
+                    export_network,
                 )?;
                 if target_id.is_some() && target_filter.is_none() {
                     0
@@ -4354,7 +4366,7 @@ impl Repository {
                         cols,
                         spec,
                         target_filter.as_ref(),
-                        network,
+                        export_network,
                         time_start,
                         time_end,
                         page_size,
@@ -7452,6 +7464,22 @@ mod tests {
                 "{dataset} must not join raw_transactions"
             );
         }
+    }
+
+    #[test]
+    fn direct_export_network_scope_defaults_to_target_network() {
+        let mut target = make_index_target();
+        target.network = "ethereum-mainnet".to_string();
+
+        assert_eq!(
+            direct_export_network_scope(Some(&target), None),
+            Some("ethereum-mainnet")
+        );
+        assert_eq!(
+            direct_export_network_scope(Some(&target), Some("base-mainnet")),
+            Some("base-mainnet")
+        );
+        assert_eq!(direct_export_network_scope(None, None), None);
     }
 
     #[test]

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -1555,7 +1555,12 @@ fn direct_export_network_scope<'a>(
     target: Option<&'a IndexTarget>,
     requested_network: Option<&'a str>,
 ) -> Option<&'a str> {
-    requested_network.or_else(|| target.map(|t| t.network.as_str()))
+    match (target, requested_network) {
+        (Some(target), Some(network)) if network == target.network => Some(network),
+        (Some(_), Some(_)) => None,
+        (Some(target), None) => Some(target.network.as_str()),
+        (None, network) => network,
+    }
 }
 
 fn direct_export_filter_for_target(
@@ -4210,7 +4215,7 @@ impl Repository {
                     None,
                     export_network,
                 )?;
-                if target_id.is_some() && target_filter.is_none() {
+                if target_id.is_some() && (target_filter.is_none() || export_network.is_none()) {
                     0
                 } else {
                     stream_paged_direct_in_tx(
@@ -4247,7 +4252,7 @@ impl Repository {
                     None,
                     export_network,
                 )?;
-                if target_id.is_some() && target_filter.is_none() {
+                if target_id.is_some() && (target_filter.is_none() || export_network.is_none()) {
                     0
                 } else {
                     stream_paged_direct_in_tx(
@@ -4284,7 +4289,7 @@ impl Repository {
                     None,
                     export_network,
                 )?;
-                if target_id.is_some() && target_filter.is_none() {
+                if target_id.is_some() && (target_filter.is_none() || export_network.is_none()) {
                     0
                 } else {
                     stream_paged_direct_in_tx(
@@ -4320,7 +4325,7 @@ impl Repository {
                     Some("protocol_address"),
                     export_network,
                 )?;
-                if target_id.is_some() && target_filter.is_none() {
+                if target_id.is_some() && (target_filter.is_none() || export_network.is_none()) {
                     0
                 } else {
                     stream_paged_direct_in_tx(
@@ -4358,7 +4363,7 @@ impl Repository {
                     Some("protocol_address"),
                     export_network,
                 )?;
-                if target_id.is_some() && target_filter.is_none() {
+                if target_id.is_some() && (target_filter.is_none() || export_network.is_none()) {
                     0
                 } else {
                     stream_paged_direct_in_tx(
@@ -7467,7 +7472,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_export_network_scope_defaults_to_target_network() {
+    fn direct_export_network_scope_defaults_to_target_network_and_rejects_mismatch() {
         let mut target = make_index_target();
         target.network = "ethereum-mainnet".to_string();
 
@@ -7476,7 +7481,15 @@ mod tests {
             Some("ethereum-mainnet")
         );
         assert_eq!(
+            direct_export_network_scope(Some(&target), Some("ethereum-mainnet")),
+            Some("ethereum-mainnet")
+        );
+        assert_eq!(
             direct_export_network_scope(Some(&target), Some("base-mainnet")),
+            None
+        );
+        assert_eq!(
+            direct_export_network_scope(None, Some("base-mainnet")),
             Some("base-mainnet")
         );
         assert_eq!(direct_export_network_scope(None, None), None);

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -3994,13 +3994,21 @@ impl Repository {
     ///
     /// Returns the total number of records sent.
     async fn direct_export_target(
-        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         target_id: Option<Uuid>,
     ) -> anyhow::Result<Option<IndexTarget>> {
-        match target_id {
-            Some(tid) => self.get_index_target(tid).await,
-            None => Ok(None),
-        }
+        let Some(tid) = target_id else {
+            return Ok(None);
+        };
+        let row = sqlx::query(
+            "SELECT id, kind::text, network, chain_family::text, address, filter_spec, \
+             mode::text, label, owner_id, created_at, updated_at \
+             FROM index_targets WHERE id = $1",
+        )
+        .bind(tid)
+        .fetch_optional(&mut **tx)
+        .await?;
+        row.as_ref().map(row_to_index_target).transpose()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4184,7 +4192,7 @@ impl Repository {
                 let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, \
                             dt.timestamp, dt.balance, dt.tx_hash, dt.dataset_version_id, \
                             dt.created_at";
-                let target = self.direct_export_target(target_id).await?;
+                let target = Self::direct_export_target(&mut tx, target_id).await?;
                 let spec = direct_export_filter_spec_for_dataset("balance_history").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4220,7 +4228,7 @@ impl Repository {
                             dt.period_end, dt.total_closed_pnl, dt.total_funding, dt.total_fees, \
                             dt.net_pnl, dt.trade_count, dt.fill_count, dt.avg_trade_size, \
                             dt.win_count, dt.loss_count, dt.dataset_version_id, dt.created_at";
-                let target = self.direct_export_target(target_id).await?;
+                let target = Self::direct_export_target(&mut tx, target_id).await?;
                 let spec = direct_export_filter_spec_for_dataset("hl_pnl_summary").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4256,7 +4264,7 @@ impl Repository {
                             dt.entry_price, dt.exit_price, dt.size, dt.opened_at, dt.closed_at, \
                             dt.realized_pnl, dt.fees, dt.num_fills, dt.dataset_version_id, \
                             dt.created_at";
-                let target = self.direct_export_target(target_id).await?;
+                let target = Self::direct_export_target(&mut tx, target_id).await?;
                 let spec = direct_export_filter_spec_for_dataset("hl_trade_history").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4291,7 +4299,7 @@ impl Repository {
                 let cols = "dt.id, dt.network, dt.protocol_address, dt.protocol_name, \
                             dt.event_type, dt.event_details, dt.pool_address, dt.raw_event_id, \
                             dt.timestamp, dt.dataset_version_id, dt.created_at";
-                let target = self.direct_export_target(target_id).await?;
+                let target = Self::direct_export_target(&mut tx, target_id).await?;
                 let spec = direct_export_filter_spec_for_dataset("protocol_events").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),
@@ -4328,7 +4336,7 @@ impl Repository {
                             dt.token1_address, dt.token1_symbol, dt.reserve0, dt.reserve1, \
                             dt.tvl_usd, dt.snapshot_timestamp, dt.block_number, \
                             dt.dataset_version_id, dt.created_at";
-                let target = self.direct_export_target(target_id).await?;
+                let target = Self::direct_export_target(&mut tx, target_id).await?;
                 let spec = direct_export_filter_spec_for_dataset("pool_snapshots").unwrap();
                 let target_filter = direct_export_filter_for_target(
                     target.as_ref(),


### PR DESCRIPTION
## Summary
- route Gold dataset streaming exports that lack raw_transaction_id through direct address/time filters
- resolve target_id to target address before exporting direct-filtered Gold tables
- add regression coverage proving direct Gold export SQL does not join raw_transactions/target_matches

## Test Plan
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace