### PR TITLE
fix: record gold materialization completeness

### DIFF
--- a/adapters/src/dual_write.rs
+++ b/adapters/src/dual_write.rs
@@ -7,7 +7,7 @@
 //! V2 writes are best-effort: failures are logged but never abort the V1 path.
 
 use bigdecimal::BigDecimal;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use spectraplex_core::materializer::{
     BalanceSnapshot, DatasetName, DatasetRegistry, DecodedEvent, HlFillRecord, HlFundingPayment,
     NativeBalanceDelta, PoolSnapshot, TokenTransfer, WalletLedgerRecord,
@@ -75,6 +75,76 @@ pub struct GoldMaterializationResult {
     pub protocol_events_failed: usize,
     pub pool_snapshots_written: usize,
     pub pool_snapshots_failed: usize,
+    /// Gold record counts keyed by (dataset_name, network) for datasets that
+    /// were materialized or attempted during this run. Used as the signal for
+    /// which wallet-target completeness rows should be refreshed.
+    pub per_dataset_network_written: HashMap<(String, String), usize>,
+    /// Gold failure counts keyed by (dataset_name, network) so one network's
+    /// partial materialization does not mark other touched networks Partial.
+    pub per_dataset_network_failed: HashMap<(String, String), usize>,
+}
+
+fn increment_gold_dataset_network_count(
+    counts: &mut HashMap<(String, String), usize>,
+    dataset_name: &str,
+    network: &str,
+) {
+    *counts
+        .entry((dataset_name.to_string(), network.to_string()))
+        .or_insert(0) += 1;
+}
+
+fn increment_gold_dataset_network_failures(
+    counts: &mut HashMap<(String, String), usize>,
+    dataset_name: &str,
+    network: &str,
+    failed: usize,
+) {
+    if failed == 0 {
+        return;
+    }
+    *counts
+        .entry((dataset_name.to_string(), network.to_string()))
+        .or_insert(0) += failed;
+}
+
+fn supports_target_scoped_gold_completeness(dataset_name: &str) -> bool {
+    matches!(
+        dataset_name,
+        name if name == DatasetName::WalletLedger.as_sql_str()
+            || name == DatasetName::BalanceHistory.as_sql_str()
+    )
+}
+
+fn gold_dataset_record_counts(result: &GoldMaterializationResult) -> Vec<(&str, &str, usize)> {
+    let mut counts: Vec<(&str, &str, usize)> = result
+        .per_dataset_network_written
+        .iter()
+        .filter_map(|((dataset_name, network), records_count)| {
+            (*records_count > 0 && supports_target_scoped_gold_completeness(dataset_name))
+                .then_some((dataset_name.as_str(), network.as_str(), *records_count))
+        })
+        .collect();
+    counts.sort_unstable_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(b.1)));
+    counts
+}
+
+fn gold_wallet_dataset_status(
+    result: &GoldMaterializationResult,
+    dataset_name: &str,
+    network: &str,
+) -> CompletenessStatus {
+    let failed = result
+        .per_dataset_network_failed
+        .get(&(dataset_name.to_string(), network.to_string()))
+        .copied()
+        .unwrap_or(0);
+
+    if failed == 0 {
+        CompletenessStatus::Complete
+    } else {
+        CompletenessStatus::Partial
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1277,6 +1347,7 @@ impl Repository {
         &self,
         raw_txs: &[RawTransaction],
         wallet_address: Option<&str>,
+        wallet_target_id: Option<Uuid>,
     ) -> BronzeSilverResult {
         if raw_txs.is_empty() {
             return BronzeSilverResult::default();
@@ -1527,6 +1598,7 @@ impl Repository {
                         &all_decoded_events,
                         &all_hl_fills,
                         &all_hl_funding,
+                        wallet_target_id,
                     )
                     .await;
                 result.gold_wallet_ledger_written = gold_result.wallet_ledger_written;
@@ -1738,6 +1810,7 @@ impl Repository {
         decoded_events: &[DecodedEvent],
         hl_fills: &[HlFillRecord],
         hl_funding: &[HlFundingPayment],
+        wallet_target_id: Option<Uuid>,
     ) -> GoldMaterializationResult {
         let mut result = GoldMaterializationResult::default();
 
@@ -1987,10 +2060,30 @@ impl Repository {
             match self.save_wallet_ledger_records(&ledger_records).await {
                 Ok(()) => {
                     result.wallet_ledger_written = n;
+                    for record in &ledger_records {
+                        increment_gold_dataset_network_count(
+                            &mut result.per_dataset_network_written,
+                            DatasetName::WalletLedger.as_sql_str(),
+                            &record.network,
+                        );
+                    }
                     info!(count = n, "Gold: wallet_ledger records written");
                 }
                 Err(e) => {
                     result.wallet_ledger_failed = n;
+                    for record in &ledger_records {
+                        increment_gold_dataset_network_failures(
+                            &mut result.per_dataset_network_failed,
+                            DatasetName::WalletLedger.as_sql_str(),
+                            &record.network,
+                            1,
+                        );
+                        increment_gold_dataset_network_count(
+                            &mut result.per_dataset_network_written,
+                            DatasetName::WalletLedger.as_sql_str(),
+                            &record.network,
+                        );
+                    }
                     warn!(error = %e, count = n, "Gold: wallet_ledger write failed");
                 }
             }
@@ -1998,8 +2091,26 @@ impl Repository {
 
         // --- balance_history: seed from DB, then apply incrementally ---
         {
-            let mut balance_events: Vec<(String, String, i64, String, BigDecimal, Uuid)> =
-                Vec::new();
+            #[derive(Clone)]
+            struct BalanceEvent {
+                network: String,
+                asset: String,
+                timestamp: i64,
+                tx_hash: String,
+                delta: BigDecimal,
+                snapshot_id: Uuid,
+            }
+
+            let balance_snapshot_id =
+                |asset: &str, timestamp: i64, tx_hash: &str, source_id: Uuid| {
+                    let id_key = format!(
+                        "bh:{}:{}:{}:{}:{}",
+                        wallet_address, asset, timestamp, tx_hash, source_id
+                    );
+                    Uuid::new_v5(&Uuid::NAMESPACE_URL, id_key.as_bytes())
+                };
+
+            let mut balance_events: Vec<BalanceEvent> = Vec::new();
 
             for transfer in token_transfers {
                 let from_match =
@@ -2025,14 +2136,15 @@ impl Repository {
                 } else {
                     transfer.amount.clone()
                 };
-                balance_events.push((
-                    transfer.network.clone(),
+                let snapshot_id = balance_snapshot_id(&asset, timestamp, &tx_hash, transfer.id);
+                balance_events.push(BalanceEvent {
+                    network: transfer.network.clone(),
                     asset,
                     timestamp,
                     tx_hash,
                     delta,
-                    transfer.id,
-                ));
+                    snapshot_id,
+                });
             }
 
             for delta in native_deltas {
@@ -2043,96 +2155,239 @@ impl Repository {
                 let raw_tx = raw_tx_id.and_then(|id| raw_tx_map.get(&id));
                 let tx_hash = raw_tx.map(|r| r.tx_hash.clone()).unwrap_or_default();
                 let timestamp = raw_tx.map(|r| r.timestamp).unwrap_or(0);
-                balance_events.push((
-                    delta.network.clone(),
-                    delta.native_token.clone(),
+                let snapshot_id =
+                    balance_snapshot_id(&delta.native_token, timestamp, &tx_hash, delta.id);
+                balance_events.push(BalanceEvent {
+                    network: delta.network.clone(),
+                    asset: delta.native_token.clone(),
                     timestamp,
                     tx_hash,
-                    delta.delta.clone(),
-                    delta.id,
-                ));
+                    delta: delta.delta.clone(),
+                    snapshot_id,
+                });
             }
 
             if !balance_events.is_empty() {
-                // Collect unique networks to seed balances per network.
-                let mut networks: HashSet<String> = HashSet::new();
-                for (net, _, _, _, _, _) in &balance_events {
-                    networks.insert(net.clone());
+                #[derive(Clone)]
+                struct BalanceRecomputeEvent {
+                    id: Uuid,
+                    network: String,
+                    asset: String,
+                    timestamp: i64,
+                    tx_hash: String,
+                    delta: BigDecimal,
+                    created_at: DateTime<Utc>,
                 }
 
-                let mut running_balances: HashMap<(String, String), BigDecimal> = HashMap::new();
-                let mut latest_ts: HashMap<(String, String), i64> = HashMap::new();
-                for network in &networks {
-                    match self
-                        .get_latest_balance_snapshots(wallet_address, network)
+                // Sort by a total deterministic order. The deterministic snapshot_id
+                // is part of the replay order so split ingestion runs that share a
+                // timestamp still seed from, and apply after, already-materialized
+                // same-timestamp rows for the same asset.
+                balance_events.sort_by(|a, b| {
+                    a.network
+                        .cmp(&b.network)
+                        .then_with(|| a.asset.cmp(&b.asset))
+                        .then_with(|| a.timestamp.cmp(&b.timestamp))
+                        .then_with(|| a.snapshot_id.cmp(&b.snapshot_id))
+                });
+
+                let mut first_event_by_key: HashMap<(String, String), (i64, Uuid)> = HashMap::new();
+                let mut incoming_by_key: HashMap<(String, String), Vec<BalanceEvent>> =
+                    HashMap::new();
+                let mut incoming_ids: HashSet<Uuid> = HashSet::new();
+                for event in balance_events {
+                    incoming_ids.insert(event.snapshot_id);
+                    first_event_by_key
+                        .entry((event.network.clone(), event.asset.clone()))
+                        .or_insert((event.timestamp, event.snapshot_id));
+                    incoming_by_key
+                        .entry((event.network.clone(), event.asset.clone()))
+                        .or_default()
+                        .push(event);
+                }
+
+                let mut snapshots: Vec<BalanceSnapshot> = Vec::new();
+                for ((network, asset), incoming_events) in incoming_by_key {
+                    let Some((first_ts, first_id)) = first_event_by_key
+                        .get(&(network.clone(), asset.clone()))
+                        .copied()
+                    else {
+                        continue;
+                    };
+
+                    let seed = match self
+                        .get_latest_balance_snapshot_before_order(
+                            wallet_address,
+                            &network,
+                            &asset,
+                            first_ts,
+                            first_id,
+                        )
                         .await
                     {
-                        Ok(snapshots) => {
-                            for snap in snapshots {
-                                let key = (snap.network.clone(), snap.asset_symbol.clone());
-                                running_balances.insert(key.clone(), snap.balance);
-                                latest_ts.insert(key, snap.timestamp);
-                            }
-                        }
+                        Ok(seed) => seed,
                         Err(e) => {
+                            let skipped = incoming_events.len();
+                            result.balance_history_failed += skipped;
+                            increment_gold_dataset_network_failures(
+                                &mut result.per_dataset_network_failed,
+                                DatasetName::BalanceHistory.as_sql_str(),
+                                &network,
+                                skipped,
+                            );
+                            for _ in 0..skipped {
+                                increment_gold_dataset_network_count(
+                                    &mut result.per_dataset_network_written,
+                                    DatasetName::BalanceHistory.as_sql_str(),
+                                    &network,
+                                );
+                            }
                             warn!(
                                 error = %e,
                                 network = %network,
-                                "Failed to query latest balance snapshots — skipping balance_history for this network"
+                                asset = %asset,
+                                skipped = skipped,
+                                "Failed to query prior balance snapshot — marking balance_history partial for this asset/network"
                             );
-                            balance_events.retain(|(net, _, _, _, _, _)| net != network);
-                        }
-                    }
-                }
-
-                // Sort by (network, asset, timestamp) for deterministic application.
-                balance_events.sort_by(|a, b| {
-                    a.0.cmp(&b.0)
-                        .then_with(|| a.1.cmp(&b.1))
-                        .then_with(|| a.2.cmp(&b.2))
-                });
-
-                let mut snapshots: Vec<BalanceSnapshot> = Vec::new();
-                for (network, asset, timestamp, tx_hash, delta, source_id) in balance_events {
-                    // Skip events already represented in the DB to avoid double-counting.
-                    if let Some(&ts) = latest_ts.get(&(network.clone(), asset.clone())) {
-                        if timestamp <= ts {
                             continue;
                         }
+                    };
+
+                    let suffix = match self
+                        .get_balance_snapshots_at_or_after_order(
+                            wallet_address,
+                            &network,
+                            &asset,
+                            first_ts,
+                            first_id,
+                        )
+                        .await
+                    {
+                        Ok(suffix) => suffix,
+                        Err(e) => {
+                            let skipped = incoming_events.len();
+                            result.balance_history_failed += skipped;
+                            increment_gold_dataset_network_failures(
+                                &mut result.per_dataset_network_failed,
+                                DatasetName::BalanceHistory.as_sql_str(),
+                                &network,
+                                skipped,
+                            );
+                            for _ in 0..skipped {
+                                increment_gold_dataset_network_count(
+                                    &mut result.per_dataset_network_written,
+                                    DatasetName::BalanceHistory.as_sql_str(),
+                                    &network,
+                                );
+                            }
+                            warn!(
+                                error = %e,
+                                network = %network,
+                                asset = %asset,
+                                skipped = skipped,
+                                "Failed to query balance_history suffix — marking balance_history partial for this asset/network"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let has_existing_suffix =
+                        suffix.iter().any(|snap| !incoming_ids.contains(&snap.id));
+                    if has_existing_suffix {
+                        let skipped = incoming_events.len();
+                        result.balance_history_failed += skipped;
+                        increment_gold_dataset_network_failures(
+                            &mut result.per_dataset_network_failed,
+                            DatasetName::BalanceHistory.as_sql_str(),
+                            &network,
+                            skipped,
+                        );
+                        for _ in 0..skipped {
+                            increment_gold_dataset_network_count(
+                                &mut result.per_dataset_network_written,
+                                DatasetName::BalanceHistory.as_sql_str(),
+                                &network,
+                            );
+                        }
+                        warn!(
+                            network = %network,
+                            asset = %asset,
+                            skipped = skipped,
+                            "Skipping balance_history backfill because existing suffix rows lack stored deltas/source order for safe recomputation"
+                        );
+                        continue;
                     }
 
-                    let key = (network.clone(), asset.clone());
-                    let balance = running_balances
-                        .entry(key)
-                        .or_insert_with(|| BigDecimal::from(0));
-                    *balance += &delta;
+                    let mut recompute_events: Vec<BalanceRecomputeEvent> = incoming_events
+                        .into_iter()
+                        .map(|event| BalanceRecomputeEvent {
+                            id: event.snapshot_id,
+                            network: event.network,
+                            asset: event.asset,
+                            timestamp: event.timestamp,
+                            tx_hash: event.tx_hash,
+                            delta: event.delta,
+                            created_at: now,
+                        })
+                        .collect();
 
-                    let id_key = format!(
-                        "bh:{}:{}:{}:{}:{}",
-                        wallet_address, asset, timestamp, tx_hash, source_id
-                    );
-                    snapshots.push(BalanceSnapshot {
-                        id: Uuid::new_v5(&Uuid::NAMESPACE_URL, id_key.as_bytes()),
-                        wallet_address: wallet_address.to_string(),
-                        asset_symbol: asset,
-                        network,
-                        timestamp,
-                        balance: balance.clone(),
-                        tx_hash,
-                        dataset_version_id: bh_version_id,
-                        created_at: now,
+                    // Only incoming deterministic rows are safe to replay here. Any
+                    // existing suffix rows were fail-closed above because the current
+                    // schema does not store per-row deltas/source order for lossless
+                    // downstream recomputation.
+
+                    recompute_events.sort_by(|a, b| {
+                        a.timestamp.cmp(&b.timestamp).then_with(|| a.id.cmp(&b.id))
                     });
+
+                    let mut balance = seed
+                        .map(|snap| snap.balance)
+                        .unwrap_or_else(|| BigDecimal::from(0));
+                    for event in recompute_events {
+                        balance += &event.delta;
+                        snapshots.push(BalanceSnapshot {
+                            id: event.id,
+                            wallet_address: wallet_address.to_string(),
+                            asset_symbol: event.asset,
+                            network: event.network,
+                            timestamp: event.timestamp,
+                            balance: balance.clone(),
+                            tx_hash: event.tx_hash,
+                            dataset_version_id: bh_version_id,
+                            created_at: event.created_at,
+                        });
+                    }
                 }
 
                 if !snapshots.is_empty() {
                     let n = snapshots.len();
                     match self.save_balance_snapshots(&snapshots).await {
                         Ok(()) => {
-                            result.balance_history_written = n;
+                            result.balance_history_written += n;
+                            for snapshot in &snapshots {
+                                increment_gold_dataset_network_count(
+                                    &mut result.per_dataset_network_written,
+                                    DatasetName::BalanceHistory.as_sql_str(),
+                                    &snapshot.network,
+                                );
+                            }
                             info!(count = n, "Gold: balance_history records written");
                         }
                         Err(e) => {
-                            result.balance_history_failed = n;
+                            result.balance_history_failed += n;
+                            for snapshot in &snapshots {
+                                increment_gold_dataset_network_failures(
+                                    &mut result.per_dataset_network_failed,
+                                    DatasetName::BalanceHistory.as_sql_str(),
+                                    &snapshot.network,
+                                    1,
+                                );
+                                increment_gold_dataset_network_count(
+                                    &mut result.per_dataset_network_written,
+                                    DatasetName::BalanceHistory.as_sql_str(),
+                                    &snapshot.network,
+                                );
+                            }
                             warn!(error = %e, count = n, "Gold: balance_history write failed");
                         }
                     }
@@ -2165,10 +2420,30 @@ impl Repository {
                 match self.save_hl_pnl_summary(&summaries).await {
                     Ok(()) => {
                         result.hl_pnl_summary_written = n;
+                        for summary in &summaries {
+                            increment_gold_dataset_network_count(
+                                &mut result.per_dataset_network_written,
+                                DatasetName::HlPnlSummary.as_sql_str(),
+                                &summary.network,
+                            );
+                        }
                         info!(count = n, "Gold: hl_pnl_summary records written");
                     }
                     Err(e) => {
                         result.hl_pnl_summary_failed = n;
+                        for summary in &summaries {
+                            increment_gold_dataset_network_failures(
+                                &mut result.per_dataset_network_failed,
+                                DatasetName::HlPnlSummary.as_sql_str(),
+                                &summary.network,
+                                1,
+                            );
+                            increment_gold_dataset_network_count(
+                                &mut result.per_dataset_network_written,
+                                DatasetName::HlPnlSummary.as_sql_str(),
+                                &summary.network,
+                            );
+                        }
                         warn!(error = %e, count = n, "Gold: hl_pnl_summary write failed");
                     }
                 }
@@ -2191,10 +2466,30 @@ impl Repository {
                 match self.save_hl_trade_history(&trades).await {
                     Ok(()) => {
                         result.hl_trade_history_written = n;
+                        for trade in &trades {
+                            increment_gold_dataset_network_count(
+                                &mut result.per_dataset_network_written,
+                                DatasetName::HlTradeHistory.as_sql_str(),
+                                &trade.network,
+                            );
+                        }
                         info!(count = n, "Gold: hl_trade_history records written");
                     }
                     Err(e) => {
                         result.hl_trade_history_failed = n;
+                        for trade in &trades {
+                            increment_gold_dataset_network_failures(
+                                &mut result.per_dataset_network_failed,
+                                DatasetName::HlTradeHistory.as_sql_str(),
+                                &trade.network,
+                                1,
+                            );
+                            increment_gold_dataset_network_count(
+                                &mut result.per_dataset_network_written,
+                                DatasetName::HlTradeHistory.as_sql_str(),
+                                &trade.network,
+                            );
+                        }
                         warn!(error = %e, count = n, "Gold: hl_trade_history write failed");
                     }
                 }
@@ -2263,7 +2558,198 @@ impl Repository {
             }
         }
 
+        self.update_gold_completeness(
+            raw_txs,
+            wallet_address,
+            wallet_target_id,
+            &gold_versions,
+            &result,
+        )
+        .await;
+
         result
+    }
+
+    async fn count_gold_wallet_dataset_records(
+        &self,
+        dataset_name: &str,
+        target_id: Uuid,
+        wallet_address: &str,
+        network: &str,
+    ) -> anyhow::Result<i64> {
+        if dataset_name == DatasetName::WalletLedger.as_sql_str() {
+            return sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM wallet_ledger wl \
+                 JOIN target_matches tm ON tm.raw_transaction_id = wl.raw_transaction_id \
+                 WHERE wl.wallet_address = $1 AND wl.network = $2 AND tm.target_id = $3",
+            )
+            .bind(wallet_address)
+            .bind(network)
+            .bind(target_id)
+            .fetch_one(self.pool())
+            .await
+            .map_err(Into::into);
+        }
+
+        let query = if dataset_name == DatasetName::BalanceHistory.as_sql_str() {
+            "SELECT COUNT(*) FROM balance_history bh \
+             JOIN raw_transactions rt ON rt.network = bh.network AND rt.tx_hash = bh.tx_hash \
+             JOIN target_matches tm ON tm.raw_transaction_id = rt.id \
+             WHERE bh.wallet_address = $1 AND bh.network = $2 AND tm.target_id = $3"
+        } else {
+            anyhow::bail!("unsupported target-scoped Gold wallet dataset: {dataset_name}");
+        };
+
+        sqlx::query_scalar::<_, i64>(query)
+            .bind(wallet_address)
+            .bind(network)
+            .bind(target_id)
+            .fetch_one(self.pool())
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Update dataset completeness for Gold datasets materialized for a wallet.
+    async fn update_gold_completeness(
+        &self,
+        raw_txs: &[RawTransaction],
+        wallet_address: &str,
+        wallet_target_id: Option<Uuid>,
+        dataset_versions: &HashMap<String, Uuid>,
+        result: &GoldMaterializationResult,
+    ) {
+        let dataset_counts = gold_dataset_record_counts(result);
+        if dataset_counts.is_empty() {
+            return;
+        }
+
+        let mut net_groups: HashMap<&str, Vec<&RawTransaction>> = HashMap::new();
+        for raw in raw_txs {
+            net_groups
+                .entry(raw.network.as_str())
+                .or_default()
+                .push(raw);
+        }
+
+        for (dataset_name, network, _records_count) in &dataset_counts {
+            let Some(group_txs) = net_groups.get(network) else {
+                continue;
+            };
+
+            let target_id = if let Some(target_id) = wallet_target_id {
+                match self.get_index_target(target_id).await {
+                    Ok(Some(target))
+                        if wallet_target_matches_completeness(&target, wallet_address, network) =>
+                    {
+                        target.id
+                    }
+                    Ok(Some(target)) => {
+                        warn!(
+                            target_id = %target.id,
+                            target_kind = ?target.kind,
+                            target_network = %target.network,
+                            target_address = ?target.address,
+                            wallet = %wallet_address,
+                            network = %network,
+                            "Skipping Gold completeness update for mismatched wallet target"
+                        );
+                        continue;
+                    }
+                    Ok(None) => {
+                        warn!(
+                            target_id = %target_id,
+                            wallet = %wallet_address,
+                            network = %network,
+                            "Skipping Gold completeness update because provided wallet target was not found"
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            target_id = %target_id,
+                            wallet = %wallet_address,
+                            network = %network,
+                            "Failed to validate provided wallet target for Gold completeness update"
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                match self
+                    .get_index_target_by_address(TargetKind::Wallet, network, wallet_address, None)
+                    .await
+                {
+                    Ok(Some(target)) => target.id,
+                    Ok(None) => continue,
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            wallet = %wallet_address,
+                            network = %network,
+                            "Failed to look up target for Gold completeness update"
+                        );
+                        continue;
+                    }
+                }
+            };
+
+            let coverage_start = group_txs.iter().map(|raw| raw.timestamp).min();
+            let coverage_end = group_txs.iter().map(|raw| raw.timestamp).max();
+            let block_start = group_txs.iter().filter_map(|raw| raw.block_number).min();
+            let block_end = group_txs.iter().filter_map(|raw| raw.block_number).max();
+            let run_id = group_txs.iter().find_map(|raw| raw.ingestion_run_id);
+            let now = Utc::now();
+
+            let total_records_count = match self
+                .count_gold_wallet_dataset_records(dataset_name, target_id, wallet_address, network)
+                .await
+            {
+                Ok(count) => count,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        dataset = %dataset_name,
+                        wallet = %wallet_address,
+                        network = %network,
+                        "Failed to count Gold dataset records for completeness update"
+                    );
+                    continue;
+                }
+            };
+            let status = gold_wallet_dataset_status(result, dataset_name, network);
+            let dc = DatasetCompleteness {
+                id: Uuid::new_v5(
+                    &Uuid::NAMESPACE_URL,
+                    format!("{}:{}:{}", target_id, dataset_name, network).as_bytes(),
+                ),
+                target_id,
+                dataset_name: (*dataset_name).to_string(),
+                dataset_version_id: dataset_versions.get(*dataset_name).copied(),
+                network: (*network).to_string(),
+                status,
+                coverage_start,
+                coverage_end,
+                block_start,
+                block_end,
+                last_ingestion_run_id: run_id,
+                records_count: total_records_count,
+                gap_ranges: None,
+                notes: None,
+                created_at: now,
+                updated_at: now,
+            };
+
+            if let Err(e) = self.upsert_dataset_completeness(&dc).await {
+                warn!(
+                    error = %e,
+                    target_id = %target_id,
+                    dataset = %dataset_name,
+                    network = %network,
+                    "Failed to update Gold dataset completeness"
+                );
+            }
+        }
     }
 
     /// Update dataset completeness for each (target, dataset, network) touched
@@ -2385,6 +2871,23 @@ fn normalize_address_for_comparison(addr: &str) -> String {
     }
 }
 
+fn wallet_target_matches_completeness(
+    target: &IndexTarget,
+    wallet_address: &str,
+    network: &str,
+) -> bool {
+    if target.kind != TargetKind::Wallet || target.network != network {
+        return false;
+    }
+
+    let Some(target_address) = target.address.as_deref() else {
+        return false;
+    };
+
+    normalize_address_for_comparison(target_address)
+        == normalize_address_for_comparison(wallet_address)
+}
+
 // ---------------------------------------------------------------------------
 // Helpers for stamping dataset_version_id on Silver records
 // ---------------------------------------------------------------------------
@@ -2474,6 +2977,77 @@ mod tests {
         );
     }
 
+    fn test_index_target(kind: TargetKind, network: &str, address: Option<&str>) -> IndexTarget {
+        let now = Utc::now();
+        IndexTarget {
+            id: Uuid::new_v4(),
+            kind,
+            network: network.to_string(),
+            chain_family: ChainFamily::Evm,
+            address: address.map(str::to_string),
+            filter_spec: None,
+            mode: TargetMode::Backfill,
+            label: None,
+            owner_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn wallet_target_matches_completeness_validates_kind_network_and_address() {
+        let target = test_index_target(
+            TargetKind::Wallet,
+            "ethereum-mainnet",
+            Some("0xABCDEF0000000000000000000000000000000000"),
+        );
+        assert!(wallet_target_matches_completeness(
+            &target,
+            "0xabcdef0000000000000000000000000000000000",
+            "ethereum-mainnet"
+        ));
+
+        let wrong_kind = test_index_target(
+            TargetKind::Contract,
+            "ethereum-mainnet",
+            Some("0xabcdef0000000000000000000000000000000000"),
+        );
+        assert!(!wallet_target_matches_completeness(
+            &wrong_kind,
+            "0xabcdef0000000000000000000000000000000000",
+            "ethereum-mainnet"
+        ));
+
+        let wrong_network = test_index_target(
+            TargetKind::Wallet,
+            "base-mainnet",
+            Some("0xabcdef0000000000000000000000000000000000"),
+        );
+        assert!(!wallet_target_matches_completeness(
+            &wrong_network,
+            "0xabcdef0000000000000000000000000000000000",
+            "ethereum-mainnet"
+        ));
+
+        let wrong_address = test_index_target(
+            TargetKind::Wallet,
+            "ethereum-mainnet",
+            Some("0x1111110000000000000000000000000000000000"),
+        );
+        assert!(!wallet_target_matches_completeness(
+            &wrong_address,
+            "0xabcdef0000000000000000000000000000000000",
+            "ethereum-mainnet"
+        ));
+
+        let missing_address = test_index_target(TargetKind::Wallet, "ethereum-mainnet", None);
+        assert!(!wallet_target_matches_completeness(
+            &missing_address,
+            "0xabcdef0000000000000000000000000000000000",
+            "ethereum-mainnet"
+        ));
+    }
+
     // -- chain_to_default_source (Rollout Plan Section 2.4) --
 
     #[test]
@@ -2489,6 +3063,184 @@ mod tests {
     #[test]
     fn chain_to_source_hyperliquid() {
         assert_eq!(chain_to_default_source(&Chain::Hyperliquid), "rest");
+    }
+
+    // -- Gold completeness provenance helpers --
+
+    #[test]
+    fn gold_dataset_record_counts_includes_only_written_gold_datasets() {
+        let mut result = GoldMaterializationResult {
+            wallet_ledger_written: 2,
+            wallet_ledger_failed: 1,
+            balance_history_written: 1,
+            balance_history_failed: 0,
+            hl_pnl_summary_written: 0,
+            hl_pnl_summary_failed: 3,
+            hl_trade_history_written: 4,
+            hl_trade_history_failed: 0,
+            protocol_events_written: 0,
+            protocol_events_failed: 0,
+            pool_snapshots_written: 0,
+            pool_snapshots_failed: 1,
+            per_dataset_network_written: HashMap::new(),
+            per_dataset_network_failed: HashMap::new(),
+        };
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::WalletLedger.as_sql_str(),
+            "solana-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::WalletLedger.as_sql_str(),
+            "solana-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::BalanceHistory.as_sql_str(),
+            "ethereum-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::HlTradeHistory.as_sql_str(),
+            "hypercore-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::HlTradeHistory.as_sql_str(),
+            "hypercore-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::HlTradeHistory.as_sql_str(),
+            "hypercore-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::HlTradeHistory.as_sql_str(),
+            "hypercore-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::ProtocolEvents.as_sql_str(),
+            "ethereum-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::PoolSnapshots.as_sql_str(),
+            "ethereum-mainnet",
+        );
+
+        let counts = gold_dataset_record_counts(&result);
+
+        assert_eq!(
+            counts,
+            vec![
+                (
+                    DatasetName::BalanceHistory.as_sql_str(),
+                    "ethereum-mainnet",
+                    1,
+                ),
+                (DatasetName::WalletLedger.as_sql_str(), "solana-mainnet", 2,),
+            ]
+        );
+    }
+
+    #[test]
+    fn gold_wallet_dataset_status_is_scoped_to_dataset_and_network_failures() {
+        let mut result = GoldMaterializationResult::default();
+        increment_gold_dataset_network_failures(
+            &mut result.per_dataset_network_failed,
+            DatasetName::WalletLedger.as_sql_str(),
+            "solana-mainnet",
+            1,
+        );
+        increment_gold_dataset_network_failures(
+            &mut result.per_dataset_network_failed,
+            DatasetName::HlPnlSummary.as_sql_str(),
+            "hypercore-mainnet",
+            2,
+        );
+
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::WalletLedger.as_sql_str(),
+                "solana-mainnet"
+            ),
+            CompletenessStatus::Partial
+        );
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::WalletLedger.as_sql_str(),
+                "ethereum-mainnet"
+            ),
+            CompletenessStatus::Complete
+        );
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::BalanceHistory.as_sql_str(),
+                "ethereum-mainnet"
+            ),
+            CompletenessStatus::Complete
+        );
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::HlPnlSummary.as_sql_str(),
+                "hypercore-mainnet"
+            ),
+            CompletenessStatus::Partial
+        );
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::HlTradeHistory.as_sql_str(),
+                "hypercore-mainnet"
+            ),
+            CompletenessStatus::Complete
+        );
+    }
+
+    #[test]
+    fn gold_wallet_dataset_status_does_not_cross_mark_balance_history_networks_partial() {
+        let mut result = GoldMaterializationResult::default();
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::BalanceHistory.as_sql_str(),
+            "ethereum-mainnet",
+        );
+        increment_gold_dataset_network_count(
+            &mut result.per_dataset_network_written,
+            DatasetName::BalanceHistory.as_sql_str(),
+            "base-mainnet",
+        );
+        increment_gold_dataset_network_failures(
+            &mut result.per_dataset_network_failed,
+            DatasetName::BalanceHistory.as_sql_str(),
+            "ethereum-mainnet",
+            1,
+        );
+        result.balance_history_failed = 1;
+
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::BalanceHistory.as_sql_str(),
+                "ethereum-mainnet"
+            ),
+            CompletenessStatus::Partial
+        );
+        assert_eq!(
+            gold_wallet_dataset_status(
+                &result,
+                DatasetName::BalanceHistory.as_sql_str(),
+                "base-mainnet"
+            ),
+            CompletenessStatus::Complete
+        );
     }
 
     // -- V1 → V2 Transaction conversion --

--- a/adapters/src/v2_repo.rs
+++ b/adapters/src/v2_repo.rs
@@ -35,6 +35,30 @@ use crate::repo::Repository;
 /// Maximum allowed LIMIT for V2 repository queries to prevent unbounded result sets.
 const MAX_QUERY_LIMIT: i64 = 10_000;
 
+const HL_PNL_SUMMARY_CONFLICT_SQL: &str = " ON CONFLICT (id) DO UPDATE SET \
+     total_closed_pnl = EXCLUDED.total_closed_pnl, \
+     total_funding = EXCLUDED.total_funding, \
+     total_fees = EXCLUDED.total_fees, \
+     net_pnl = EXCLUDED.net_pnl, \
+     trade_count = EXCLUDED.trade_count, \
+     fill_count = EXCLUDED.fill_count, \
+     avg_trade_size = EXCLUDED.avg_trade_size, \
+     win_count = EXCLUDED.win_count, \
+     loss_count = EXCLUDED.loss_count, \
+     dataset_version_id = EXCLUDED.dataset_version_id";
+
+const HL_TRADE_HISTORY_CONFLICT_SQL: &str = " ON CONFLICT (id) DO UPDATE SET \
+     side = EXCLUDED.side, \
+     entry_price = EXCLUDED.entry_price, \
+     exit_price = EXCLUDED.exit_price, \
+     size = EXCLUDED.size, \
+     opened_at = EXCLUDED.opened_at, \
+     closed_at = EXCLUDED.closed_at, \
+     realized_pnl = EXCLUDED.realized_pnl, \
+     fees = EXCLUDED.fees, \
+     num_fills = EXCLUDED.num_fills, \
+     dataset_version_id = EXCLUDED.dataset_version_id";
+
 // ---------------------------------------------------------------------------
 // Enum ↔ SQL string helpers
 // ---------------------------------------------------------------------------
@@ -347,7 +371,7 @@ pub fn build_raw_transaction_upsert_returning(
         args.add(tx.ingested_at)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
     }
-    query.push_str(" ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW() RETURNING id");
+    query.push_str(" ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW(), ingestion_run_id = COALESCE(EXCLUDED.ingestion_run_id, raw_transactions.ingestion_run_id) RETURNING id");
     Ok((query, args))
 }
 
@@ -1119,11 +1143,45 @@ pub fn build_dataset_completeness_upsert(
          ON CONFLICT (target_id, dataset_name, network) \
          DO UPDATE SET \
              dataset_version_id = EXCLUDED.dataset_version_id, \
-             status = EXCLUDED.status, \
-             coverage_start = EXCLUDED.coverage_start, \
-             coverage_end = EXCLUDED.coverage_end, \
-             block_start = EXCLUDED.block_start, \
-             block_end = EXCLUDED.block_end, \
+             status = CASE \
+                 WHEN dataset_completeness.dataset_version_id IS NOT DISTINCT FROM EXCLUDED.dataset_version_id \
+                      AND dataset_completeness.status <> 'complete' AND EXCLUDED.status = 'complete' \
+                      AND ( \
+                          (dataset_completeness.coverage_start IS NOT NULL \
+                           AND (EXCLUDED.coverage_start IS NULL OR EXCLUDED.coverage_start > dataset_completeness.coverage_start)) \
+                          OR (dataset_completeness.coverage_end IS NOT NULL \
+                              AND (EXCLUDED.coverage_end IS NULL OR EXCLUDED.coverage_end < dataset_completeness.coverage_end)) \
+                          OR (dataset_completeness.block_start IS NOT NULL \
+                              AND (EXCLUDED.block_start IS NULL OR EXCLUDED.block_start > dataset_completeness.block_start)) \
+                          OR (dataset_completeness.block_end IS NOT NULL \
+                              AND (EXCLUDED.block_end IS NULL OR EXCLUDED.block_end < dataset_completeness.block_end)) \
+                      ) \
+                 THEN dataset_completeness.status \
+                 ELSE EXCLUDED.status END, \
+             coverage_start = CASE \
+                 WHEN dataset_completeness.dataset_version_id IS DISTINCT FROM EXCLUDED.dataset_version_id THEN EXCLUDED.coverage_start \
+                 WHEN EXCLUDED.coverage_start IS NULL THEN dataset_completeness.coverage_start \
+                 WHEN dataset_completeness.coverage_start IS NULL THEN EXCLUDED.coverage_start \
+                 WHEN EXCLUDED.coverage_start < dataset_completeness.coverage_start THEN EXCLUDED.coverage_start \
+                 ELSE dataset_completeness.coverage_start END, \
+             coverage_end = CASE \
+                 WHEN dataset_completeness.dataset_version_id IS DISTINCT FROM EXCLUDED.dataset_version_id THEN EXCLUDED.coverage_end \
+                 WHEN EXCLUDED.coverage_end IS NULL THEN dataset_completeness.coverage_end \
+                 WHEN dataset_completeness.coverage_end IS NULL THEN EXCLUDED.coverage_end \
+                 WHEN EXCLUDED.coverage_end > dataset_completeness.coverage_end THEN EXCLUDED.coverage_end \
+                 ELSE dataset_completeness.coverage_end END, \
+             block_start = CASE \
+                 WHEN dataset_completeness.dataset_version_id IS DISTINCT FROM EXCLUDED.dataset_version_id THEN EXCLUDED.block_start \
+                 WHEN EXCLUDED.block_start IS NULL THEN dataset_completeness.block_start \
+                 WHEN dataset_completeness.block_start IS NULL THEN EXCLUDED.block_start \
+                 WHEN EXCLUDED.block_start < dataset_completeness.block_start THEN EXCLUDED.block_start \
+                 ELSE dataset_completeness.block_start END, \
+             block_end = CASE \
+                 WHEN dataset_completeness.dataset_version_id IS DISTINCT FROM EXCLUDED.dataset_version_id THEN EXCLUDED.block_end \
+                 WHEN EXCLUDED.block_end IS NULL THEN dataset_completeness.block_end \
+                 WHEN dataset_completeness.block_end IS NULL THEN EXCLUDED.block_end \
+                 WHEN EXCLUDED.block_end > dataset_completeness.block_end THEN EXCLUDED.block_end \
+                 ELSE dataset_completeness.block_end END, \
              last_ingestion_run_id = EXCLUDED.last_ingestion_run_id, \
              records_count = EXCLUDED.records_count, \
              gap_ranges = EXCLUDED.gap_ranges, \
@@ -1728,6 +1786,70 @@ pub fn build_dataset_filter_query_direct(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
+fn build_balance_history_target_filter_query(
+    select_cols: &str,
+    target_id: Uuid,
+    target_address: &str,
+    network: Option<&str>,
+    time_start: Option<i64>,
+    time_end: Option<i64>,
+    limit: i64,
+    offset: i64,
+) -> anyhow::Result<(String, sqlx::postgres::PgArguments)> {
+    let limit = limit.min(MAX_QUERY_LIMIT);
+    let mut sql = format!(
+        "SELECT {select_cols} FROM balance_history dt \
+         JOIN raw_transactions rt ON rt.network = dt.network AND rt.tx_hash = dt.tx_hash \
+         JOIN target_matches tm ON tm.raw_transaction_id = rt.id"
+    );
+    let mut args = sqlx::postgres::PgArguments::default();
+    let mut n: usize = 0;
+    let mut wheres: Vec<String> = Vec::new();
+
+    n += 1;
+    wheres.push(format!("tm.target_id = ${n}"));
+    use sqlx::Arguments;
+    args.add(target_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    n += 1;
+    wheres.push(format!("dt.wallet_address = ${n}"));
+    args.add(target_address.to_string())
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if let Some(net) = network {
+        n += 1;
+        wheres.push(format!("dt.network = ${n}"));
+        args.add(net.to_string())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    if let Some(start) = time_start {
+        n += 1;
+        wheres.push(format!("dt.timestamp >= ${n}"));
+        args.add(start).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    if let Some(end) = time_end {
+        n += 1;
+        wheres.push(format!("dt.timestamp <= ${n}"));
+        args.add(end).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+
+    sql.push_str(" WHERE ");
+    sql.push_str(&wheres.join(" AND "));
+
+    n += 1;
+    let lim_n = n;
+    n += 1;
+    let off_n = n;
+    sql.push_str(&format!(
+        " ORDER BY dt.timestamp DESC, dt.id DESC LIMIT ${lim_n} OFFSET ${off_n}"
+    ));
+    args.add(limit).map_err(|e| anyhow::anyhow!("{e}"))?;
+    args.add(offset).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    Ok((sql, args))
+}
+
 /// Build a batch INSERT for `raw_evm_traces` with ON CONFLICT DO NOTHING.
 pub fn build_raw_evm_trace_insert(
     traces: &[RawEvmTrace],
@@ -2174,7 +2296,8 @@ impl Repository {
 
     /// Insert raw transactions and return the canonical database IDs.
     ///
-    /// Uses `ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW()`
+    /// Uses `ON CONFLICT (network, tx_hash) DO UPDATE` to refresh `updated_at`
+    /// and associate duplicate canonical rows with the current ingestion run,
     /// so that the RETURNING clause always yields the canonical row ID, even
     /// when the raw transaction already exists from a different target's
     /// ingestion. This is critical for multi-target deduplication: the same
@@ -3475,6 +3598,30 @@ impl Repository {
         Ok(())
     }
 
+    /// Refresh dataset_version_id for deterministic balance_history rows already
+    /// represented in storage during an idempotent Gold replay.
+    pub async fn update_balance_snapshot_dataset_versions(
+        &self,
+        ids: &[Uuid],
+        dataset_version_id: Option<Uuid>,
+    ) -> anyhow::Result<u64> {
+        let mut updated = 0u64;
+        for chunk in ids.chunks(500) {
+            let chunk_ids: Vec<Uuid> = chunk.to_vec();
+            let result = sqlx::query(
+                "UPDATE balance_history \
+                 SET dataset_version_id = $1 \
+                 WHERE id = ANY($2)",
+            )
+            .bind(dataset_version_id)
+            .bind(&chunk_ids)
+            .execute(self.pool())
+            .await?;
+            updated += result.rows_affected();
+        }
+        Ok(updated)
+    }
+
     /// Query wallet_ledger records with optional wallet, network, and time-window filters.
     #[allow(clippy::too_many_arguments)]
     pub async fn query_wallet_ledger_records(
@@ -3534,32 +3681,42 @@ impl Repository {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<Vec<BalanceSnapshot>> {
-        let target_address = if let Some(tid) = target_id {
-            match self.get_index_target(tid).await? {
-                Some(t) => match t.address {
-                    Some(addr) if !addr.is_empty() => Some(addr),
-                    _ => return Ok(Vec::new()),
-                },
-                None => return Ok(Vec::new()),
-            }
-        } else {
-            None
-        };
         let cols = "dt.id, dt.wallet_address, dt.asset_symbol, dt.network, dt.timestamp, \
                     dt.balance, dt.tx_hash, dt.dataset_version_id, dt.created_at";
-        let (sql, args) = build_dataset_filter_query_direct(
-            cols,
-            DatasetName::BalanceHistory.physical_table(),
-            "dt.timestamp",
-            target_address.as_deref(),
-            "wallet_address",
-            network,
-            time_start,
-            time_end,
-            "timestamp",
-            limit,
-            offset,
-        )?;
+        let (sql, args) = if let Some(tid) = target_id {
+            let target = match self.get_index_target(tid).await? {
+                Some(t) => t,
+                None => return Ok(Vec::new()),
+            };
+            let target_address = match target.address {
+                Some(addr) if !addr.is_empty() => addr,
+                _ => return Ok(Vec::new()),
+            };
+            build_balance_history_target_filter_query(
+                cols,
+                tid,
+                &target_address,
+                network,
+                time_start,
+                time_end,
+                limit,
+                offset,
+            )?
+        } else {
+            build_dataset_filter_query_direct(
+                cols,
+                DatasetName::BalanceHistory.physical_table(),
+                "dt.timestamp",
+                None,
+                "wallet_address",
+                network,
+                time_start,
+                time_end,
+                "timestamp",
+                limit,
+                offset,
+            )?
+        };
         let rows = sqlx::query_with(&sql, args).fetch_all(self.pool()).await?;
         rows.iter().map(row_to_balance_snapshot).collect()
     }
@@ -3858,7 +4015,7 @@ impl Repository {
                     .push_bind(r.dataset_version_id)
                     .push_bind(r.created_at);
             });
-            query_builder.push(" ON CONFLICT (id) DO NOTHING");
+            query_builder.push(HL_PNL_SUMMARY_CONFLICT_SQL);
             query_builder.build().execute(self.pool()).await?;
         }
         Ok(())
@@ -3889,7 +4046,7 @@ impl Repository {
                     .push_bind(r.dataset_version_id)
                     .push_bind(r.created_at);
             });
-            query_builder.push(" ON CONFLICT (id) DO NOTHING");
+            query_builder.push(HL_TRADE_HISTORY_CONFLICT_SQL);
             query_builder.build().execute(self.pool()).await?;
         }
         Ok(())
@@ -3972,6 +4129,63 @@ impl Repository {
         )
         .bind(wallet_address)
         .bind(network)
+        .fetch_all(self.pool())
+        .await?;
+        rows.iter().map(row_to_balance_snapshot).collect()
+    }
+
+    pub async fn get_latest_balance_snapshot_before_order(
+        &self,
+        wallet_address: &str,
+        network: &str,
+        asset_symbol: &str,
+        before_timestamp: i64,
+        before_id: Uuid,
+    ) -> anyhow::Result<Option<BalanceSnapshot>> {
+        let row = sqlx::query(
+            "SELECT id, wallet_address, asset_symbol, network, timestamp, balance, tx_hash, \
+             dataset_version_id, created_at \
+             FROM balance_history \
+             WHERE wallet_address = $1 \
+               AND network = $2 \
+               AND asset_symbol = $3 \
+               AND (timestamp < $4 OR (timestamp = $4 AND id < $5)) \
+             ORDER BY timestamp DESC, id DESC, created_at DESC \
+             LIMIT 1",
+        )
+        .bind(wallet_address)
+        .bind(network)
+        .bind(asset_symbol)
+        .bind(before_timestamp)
+        .bind(before_id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.as_ref().map(row_to_balance_snapshot).transpose()
+    }
+
+    pub async fn get_balance_snapshots_at_or_after_order(
+        &self,
+        wallet_address: &str,
+        network: &str,
+        asset_symbol: &str,
+        at_or_after_timestamp: i64,
+        at_or_after_id: Uuid,
+    ) -> anyhow::Result<Vec<BalanceSnapshot>> {
+        let rows = sqlx::query(
+            "SELECT id, wallet_address, asset_symbol, network, timestamp, balance, tx_hash, \
+             dataset_version_id, created_at \
+             FROM balance_history \
+             WHERE wallet_address = $1 \
+               AND network = $2 \
+               AND asset_symbol = $3 \
+               AND (timestamp > $4 OR (timestamp = $4 AND id >= $5)) \
+             ORDER BY timestamp ASC, id ASC, created_at ASC",
+        )
+        .bind(wallet_address)
+        .bind(network)
+        .bind(asset_symbol)
+        .bind(at_or_after_timestamp)
+        .bind(at_or_after_id)
         .fetch_all(self.pool())
         .await?;
         rows.iter().map(row_to_balance_snapshot).collect()
@@ -6172,7 +6386,7 @@ mod tests {
         assert!(query.starts_with("INSERT INTO raw_transactions"));
         assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9)"));
         assert!(query.ends_with(
-            "ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW() RETURNING id"
+            "ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW(), ingestion_run_id = COALESCE(EXCLUDED.ingestion_run_id, raw_transactions.ingestion_run_id) RETURNING id"
         ));
     }
 
@@ -6184,7 +6398,7 @@ mod tests {
         assert!(query.contains("($1, $2, $3, $4, $5, $6, $7, $8, $9)"));
         assert!(query.contains("($10, $11, $12, $13, $14, $15, $16, $17, $18)"));
         assert!(query.ends_with(
-            "ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW() RETURNING id"
+            "ON CONFLICT (network, tx_hash) DO UPDATE SET updated_at = NOW(), ingestion_run_id = COALESCE(EXCLUDED.ingestion_run_id, raw_transactions.ingestion_run_id) RETURNING id"
         ));
     }
 
@@ -6843,11 +7057,45 @@ mod tests {
         assert!(query.starts_with("INSERT INTO dataset_completeness"));
         assert!(query.contains("ON CONFLICT (target_id, dataset_name, network)"));
         assert!(query.contains("DO UPDATE SET"));
-        assert!(query.contains("status = EXCLUDED.status"));
-        assert!(query.contains("coverage_start = EXCLUDED.coverage_start"));
-        assert!(query.contains("coverage_end = EXCLUDED.coverage_end"));
+        assert!(query.contains("status = CASE"));
+        assert!(query.contains(
+            "dataset_completeness.dataset_version_id IS NOT DISTINCT FROM EXCLUDED.dataset_version_id"
+        ));
+        assert!(query.contains(
+            "AND dataset_completeness.status <> 'complete' AND EXCLUDED.status = 'complete'"
+        ));
+        assert!(query.contains("EXCLUDED.coverage_start > dataset_completeness.coverage_start"));
+        assert!(query.contains("EXCLUDED.coverage_end < dataset_completeness.coverage_end"));
+        assert!(query.contains("EXCLUDED.block_start > dataset_completeness.block_start"));
+        assert!(query.contains("EXCLUDED.block_end < dataset_completeness.block_end"));
+        assert!(query.contains(
+            "dataset_completeness.dataset_version_id IS DISTINCT FROM EXCLUDED.dataset_version_id THEN EXCLUDED.coverage_start"
+        ));
+        assert!(query.contains("THEN dataset_completeness.status"));
+        assert!(query.contains("coverage_start = CASE"));
+        assert!(query.contains("WHEN dataset_completeness.coverage_start IS NULL"));
+        assert!(
+            query.contains("WHEN EXCLUDED.coverage_start < dataset_completeness.coverage_start")
+        );
+        assert!(query.contains("coverage_end = CASE"));
+        assert!(query.contains("WHEN EXCLUDED.coverage_end > dataset_completeness.coverage_end"));
         assert!(query.contains("records_count = EXCLUDED.records_count"));
         assert!(query.contains("updated_at = EXCLUDED.updated_at"));
+    }
+
+    #[test]
+    fn hl_gold_conflict_clauses_refresh_dataset_version() {
+        assert!(HL_PNL_SUMMARY_CONFLICT_SQL.contains("ON CONFLICT (id) DO UPDATE SET"));
+        assert!(HL_PNL_SUMMARY_CONFLICT_SQL.contains("net_pnl = EXCLUDED.net_pnl"));
+        assert!(HL_PNL_SUMMARY_CONFLICT_SQL
+            .contains("dataset_version_id = EXCLUDED.dataset_version_id"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL.contains("ON CONFLICT (id) DO UPDATE SET"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL.contains("side = EXCLUDED.side"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL.contains("opened_at = EXCLUDED.opened_at"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL.contains("closed_at = EXCLUDED.closed_at"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL.contains("realized_pnl = EXCLUDED.realized_pnl"));
+        assert!(HL_TRADE_HISTORY_CONFLICT_SQL
+            .contains("dataset_version_id = EXCLUDED.dataset_version_id"));
     }
 
     #[test]
@@ -7202,6 +7450,32 @@ mod tests {
         )
         .unwrap();
         assert!(sql.contains("dt.network"));
+    }
+
+    #[test]
+    fn balance_history_target_query_uses_target_matches() {
+        let tid = Uuid::new_v4();
+        let (sql, _) = build_balance_history_target_filter_query(
+            "dt.*",
+            tid,
+            "0xabc",
+            Some("ethereum-mainnet"),
+            Some(100),
+            Some(200),
+            50,
+            0,
+        )
+        .unwrap();
+        assert!(sql.contains(
+            "JOIN raw_transactions rt ON rt.network = dt.network AND rt.tx_hash = dt.tx_hash"
+        ));
+        assert!(sql.contains("JOIN target_matches tm ON tm.raw_transaction_id = rt.id"));
+        assert!(sql.contains("tm.target_id = $1"));
+        assert!(sql.contains("dt.wallet_address = $2"));
+        assert!(sql.contains("dt.network = $3"));
+        assert!(sql.contains("dt.timestamp >= $4"));
+        assert!(sql.contains("dt.timestamp <= $5"));
+        assert!(sql.ends_with("ORDER BY dt.timestamp DESC, dt.id DESC LIMIT $6 OFFSET $7"));
     }
 
     #[test]

--- a/api/src/materialize_worker.rs
+++ b/api/src/materialize_worker.rs
@@ -11,7 +11,7 @@ use crate::fire_callback;
 use spectraplex_adapters::dual_write::BronzeSilverResult;
 use spectraplex_adapters::repo::Repository;
 use spectraplex_core::config::AppConfig;
-use spectraplex_core::v2::{CompletenessStatus, DatasetCompleteness};
+use spectraplex_core::v2::{CompletenessStatus, DatasetCompleteness, TargetKind};
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -389,6 +389,23 @@ pub(crate) async fn execute_normalize(
                 run_id
             )
         })?;
+        if target.kind != TargetKind::Wallet {
+            anyhow::bail!(
+                "ingestion_run {} belongs to non-wallet target {} ({:?})",
+                run_id,
+                tid,
+                target.kind
+            );
+        }
+        if target.network != irun.network {
+            anyhow::bail!(
+                "ingestion_run {} network {} does not match target {} network {}",
+                run_id,
+                irun.network,
+                tid,
+                target.network
+            );
+        }
         let target_addr = target.address.ok_or_else(|| {
             anyhow::anyhow!(
                 "index_target {} for ingestion_run {} has no address",
@@ -438,7 +455,7 @@ pub(crate) async fn execute_normalize(
         // Bronze-native Silver materialization: extract Silver records directly
         // from RawTransaction without reconstructing V1 Transaction values.
         let silver_result = repo
-            .materialize_silver_from_bronze(&raw_txs, Some(&effective_wallet))
+            .materialize_silver_from_bronze(&raw_txs, Some(&effective_wallet), Some(tid))
             .await;
 
         if !silver_result.all_succeeded() {


### PR DESCRIPTION
## Summary
- record dataset completeness rows after Gold materialization writes rows
- attach active Gold dataset version provenance to those completeness rows
- add coverage for mapping Gold materialization counts to non-empty datasets

## Test Plan
- cargo test -p spectraplex-adapters --lib dual_write::tests -- --nocapture
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace