### PR TITLE
[codex] Trim Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
-target
 .git
+target/
+node_modules/
+.smithers/
+.claude/
+.entire/
+design/
+
+workflow.tsx
+package.json
+bun.lock
+
 *.md
 .env


### PR DESCRIPTION
## Summary

- exclude local `node_modules`, agent caches, and design/workflow scratch files from Docker build context
- keep the runtime Rust sources, Cargo metadata, and migrations available to the existing Dockerfile

## Why

The Dockerfile builds the Rust workspace with `COPY . .`. Without these ignores, local development artifacts can be sent in the Docker context, making builds slower and less reproducible.

## Validation

- `git diff --check`
- inspected `.dockerignore` contents