### PR TITLE
[codex] Validate smoke test arguments

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -47,11 +47,32 @@ API_PID=""
 TARGET_WALLET="So11111111111111111111111111111111111111112"
 TARGET_NETWORK="solana-mainnet"
 
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/smoke-test.sh [--skip-ingest]
+
+Options:
+  --skip-ingest  Skip provider-dependent ingestion and job polling.
+  -h, --help     Show this help message.
+USAGE
+}
+
 SKIP_INGEST=false
 for arg in "$@"; do
-  if [[ "$arg" == "--skip-ingest" ]]; then
-    SKIP_INGEST=true
-  fi
+  case "$arg" in
+    --skip-ingest)
+      SKIP_INGEST=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown option: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
 done
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `--help` output for the smoke test script
- keep `--skip-ingest` as the supported option
- fail immediately on unknown options before starting Docker or the API

## Why

The smoke script previously ignored unknown arguments. A misspelled option could accidentally run the full provider-dependent smoke path instead of the intended mode.

## Validation

- `bash -n scripts/smoke-test.sh`
- `./scripts/smoke-test.sh --help`
- `./scripts/smoke-test.sh --unknown-option` exits non-zero before side effects
- `git diff --check`