### PR TITLE
[codex] Report smoke test curl transport failures

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -95,7 +95,10 @@ curl_json() {
   fi
 
   local resp
-  resp=$("${cmd[@]}")
+  if ! resp=$("${cmd[@]}"); then
+    echo "ERROR: curl request failed: $method $url" >&2
+    return 1
+  fi
   local http_code
   http_code=$(echo "$resp" | tail -n1)
   local body_lines


### PR DESCRIPTION
## Summary

- handle transport-level `curl` failures inside the smoke test HTTP helper
- print the request method and URL before returning failure
- keep existing non-2xx response handling unchanged

## Why

With `set -e`, a connection failure inside command substitution could exit before the helper reported which request failed. The smoke output is clearer when local API startup or connectivity breaks.

## Validation

- `bash -n scripts/smoke-test.sh`
- intentional `curl` failure against `http://127.0.0.1:9` prints the new request context and exits non-zero
- `git diff --check`