### PR TITLE
[codex] Check shell script syntax in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ env:
   SQLX_OFFLINE: true
 
 jobs:
+  shell:
+    name: Shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          for script in scripts/*.sh; do
+            bash -n "$script"
+          done
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a CI job that runs `bash -n` over every `scripts/*.sh` file
- keep the existing Rust formatting, clippy, test, and release build jobs unchanged

## Why

The repo now has operational shell helpers that are part of the local development and smoke-test path. CI should catch syntax regressions in those scripts instead of relying only on ad hoc local checks.

## Validation

- `for script in scripts/*.sh; do bash -n "$script"; done`
- `git diff --check`