### PR TITLE
[codex] Require executable shell scripts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: |
           for script in scripts/*.sh; do
             bash -n "$script"
+            test -x "$script"
           done
 
   fmt:


### PR DESCRIPTION
## Summary

- extend the CI shell script check to verify each `scripts/*.sh` file is executable
- keep the existing `bash -n` syntax check in the same loop

## Why

The helper scripts are invoked directly in docs and local workflows. CI should catch accidental mode changes that make those commands fail even when the script contents are valid.

## Validation

- `for script in scripts/*.sh; do bash -n "$script"; test -x "$script"; done`
- `git diff --check`