### PR TITLE
[codex] Remove guarded production unwraps

### DIFF
--- a/api/src/export_worker.rs
+++ b/api/src/export_worker.rs
@@ -259,8 +259,6 @@ async fn execute_export_job(
                 return;
             }
 
-            let has_sink = job.sink_config.is_some();
-
             let prov_dv_id = _export_meta.dataset_version_id;
             let prov_dv = _export_meta.dataset_version;
             let prov_cs = _export_meta.completeness_status.as_deref();
@@ -269,7 +267,7 @@ async fn execute_export_job(
 
             let result_location = format!("exports/{}.{}", job_id, ext);
 
-            if has_sink {
+            if let Some(sink_value) = job.sink_config.as_ref() {
                 // Transition to 'delivering'. update_or_abort only
                 // writes the row if we still own the lease (Ok(true)).
                 // If Ok(false) ("someone else took over"), we clean up
@@ -395,7 +393,6 @@ async fn execute_export_job(
                 // into memory (fixes PR #238 [P2] sink-OOM concern):
                 // LocalFileSink does a streaming `io::copy`; WebhookSink
                 // uses `ReaderStream` for a streaming request body.
-                let sink_value = job.sink_config.as_ref().unwrap();
                 let delivery_result = match serde_json::from_value::<SinkConfig>(sink_value.clone())
                 {
                     Ok(sink_config) => match build_sink(&sink_config, export_dir) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,11 +208,11 @@ async fn main() -> anyhow::Result<()> {
             // MUST resolve it. Silently falling back to --rpc / --grpc-url
             // would connect to the wrong network (e.g. --network base-mainnet
             // but --rpc points to Ethereum mainnet).
-            if network.is_some() && net_ctx.is_none() {
+            if let (Some(network), None) = (network.as_deref(), net_ctx.as_ref()) {
                 anyhow::bail!(
                     "network '{}' is not configured in the provider registry. \
                      Check spectraplex.toml or SPECTRAPLEX_* environment variables.",
-                    network.as_deref().unwrap()
+                    network
                 );
             }
 


### PR DESCRIPTION
## Summary

- replace a CLI network error-path `unwrap()` with pattern matching
- thread export sink config through the sink-delivery branch with `if let Some(...)` instead of re-checking and unwrapping

## Why

Both unwraps were logically guarded, but the control-flow version makes the invariant explicit and avoids panic-shaped code in production paths.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace` outside the sandbox
- `cargo clippy --workspace --all-targets -- -D warnings`

The first sandboxed `cargo test --workspace` attempt failed before escalation on macOS system-configuration/socket permission errors; the same command passed outside the sandbox.