### PR TITLE
[codex] Remove more guarded production unwraps

### DIFF
--- a/adapters/src/evm.rs
+++ b/adapters/src/evm.rs
@@ -173,18 +173,18 @@ impl EvmAdapter {
             match self.provider.get_logs(filter).await {
                 Ok(logs) => return Ok(logs),
                 Err(e) => {
-                    last_err = Some(e);
                     if attempt + 1 < RPC_MAX_RETRIES {
                         let delay = Duration::from_millis(RPC_RETRY_BASE_MS * 2u64.pow(attempt));
                         warn!(
                             attempt = attempt + 1,
                             max_retries = RPC_MAX_RETRIES,
                             delay_ms = delay.as_millis() as u64,
-                            error = %last_err.as_ref().unwrap(),
+                            error = %e,
                             "RPC get_logs failed, retrying"
                         );
                         tokio::time::sleep(delay).await;
                     }
+                    last_err = Some(e);
                 }
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -619,8 +619,7 @@ async fn main() -> anyhow::Result<()> {
             network,
         } => {
             let input_str = input.to_string_lossy();
-            let transactions = if input_str.starts_with("db:") {
-                let wallet = input_str.strip_prefix("db:").unwrap();
+            let transactions = if let Some(wallet) = input_str.strip_prefix("db:") {
                 let p = pool
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("--db-url is required for db: input"))?;


### PR DESCRIPTION
## Summary
- replace the CLI `db:` input guarded unwrap with direct `strip_prefix` matching
- log EVM retry errors directly instead of unwrapping the stored last error

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`