### PR TITLE
[codex] Simplify EVM decimal divisor construction

### DIFF
--- a/adapters/src/evm_parser.rs
+++ b/adapters/src/evm_parser.rs
@@ -376,12 +376,9 @@ fn token_symbol(contract_address: &str) -> String {
     }
 }
 
-/// Normalize a raw token amount by dividing by 10^decimals.
 /// Normalize a BigDecimal raw amount by dividing by 10^decimals.
 fn normalize_bigdecimal(raw: BigDecimal, decimals: u32) -> BigDecimal {
-    use std::str::FromStr;
-    let divisor = BigDecimal::from_str(&format!("1{}", "0".repeat(decimals as usize)))
-        .unwrap_or_else(|_| BigDecimal::from(1));
+    let divisor = BigDecimal::new(1.into(), -i64::from(decimals));
     raw / divisor
 }
 


### PR DESCRIPTION
## Summary
- construct the EVM token amount divisor directly as a scaled `BigDecimal`
- remove string formatting/parsing and the unreachable parse fallback from `normalize_bigdecimal`
- clean up a duplicated helper doc line

## Validation
- `cargo test -p spectraplex-adapters evm_parser`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`