### PR TITLE
[codex] Harden Solana slot conversions

### DIFF
--- a/adapters/src/solana.rs
+++ b/adapters/src/solana.rs
@@ -15,6 +15,10 @@ use spectraplex_core::v2::{
 use tracing::{info, warn};
 use uuid::Uuid;
 
+fn u64_to_i64_or_max(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
 pub struct SolanaAdapter {
     client: Arc<RpcClient>,
     network: String,
@@ -224,7 +228,7 @@ impl Connector for SolanaAdapter {
                             network: network.clone(),
                             tx_hash: sig_info.signature.clone(),
                             timestamp: tx.block_time.unwrap_or(0),
-                            block_number: Some(slot as i64),
+                            block_number: Some(u64_to_i64_or_max(slot)),
                             raw_metadata,
                             source: "solana-rpc-wallet-backfill".to_string(),
                             ingestion_run_id: None,
@@ -370,6 +374,13 @@ mod tests {
         // Invalid base58 signature should return None gracefully
         let sig = cursor_to_until_sig(Some(&cursor));
         assert!(sig.is_none());
+    }
+
+    #[test]
+    fn test_u64_to_i64_or_max_saturates() {
+        assert_eq!(u64_to_i64_or_max(42), 42);
+        assert_eq!(u64_to_i64_or_max(i64::MAX as u64), i64::MAX);
+        assert_eq!(u64_to_i64_or_max(u64::MAX), i64::MAX);
     }
 
     #[test]

--- a/adapters/src/solana_grpc.rs
+++ b/adapters/src/solana_grpc.rs
@@ -52,6 +52,10 @@ impl Default for GrpcStreamConfig {
     }
 }
 
+fn u64_to_i64_or_max(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
 /// Tracks the last processed slot for checkpoint-based reconnection.
 #[derive(Clone)]
 pub struct SlotCheckpoint {
@@ -442,7 +446,7 @@ pub fn convert_grpc_to_raw_transaction(
         network: network.to_string(),
         tx_hash,
         timestamp,
-        block_number: Some(slot as i64),
+        block_number: Some(u64_to_i64_or_max(slot)),
         raw_metadata,
         source: source.to_string(),
         ingestion_run_id: None,
@@ -1367,6 +1371,20 @@ mod tests {
         let raw_tx = result.unwrap();
         assert_eq!(raw_tx.source, "solana-grpc-account-stream");
         assert_eq!(raw_tx.block_number, Some(700));
+    }
+
+    #[test]
+    fn test_convert_grpc_to_raw_transaction_saturates_slot_block_number() {
+        let tx_info = make_test_tx_info(vec![1000], vec![900], vec![vec![1u8; 32]]);
+        let raw_tx = convert_grpc_to_raw_transaction(
+            &tx_info,
+            u64::MAX,
+            "solana-mainnet",
+            "solana-grpc-wallet-backfill",
+        )
+        .unwrap();
+
+        assert_eq!(raw_tx.block_number, Some(i64::MAX));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -138,6 +138,10 @@ enum Commands {
     ListNetworks,
 }
 
+fn checkpoint_slot_to_u64(slot: i64) -> Option<u64> {
+    u64::try_from(slot).ok()
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
@@ -326,8 +330,8 @@ async fn main() -> anyhow::Result<()> {
                         if let Some(ref endpoint) = grpc_url {
                             let adapter = SolanaGrpcAdapter::new(endpoint, x_token.clone());
                             if let Some(ref cp) = checkpoint {
-                                if let Some(slot) = cp.last_slot {
-                                    adapter.checkpoint().update(slot as u64);
+                                if let Some(slot) = cp.last_slot.and_then(checkpoint_slot_to_u64) {
+                                    adapter.checkpoint().update(slot);
                                 }
                             }
                             adapter
@@ -765,6 +769,12 @@ mod tests {
         assert_eq!(cp.last_timestamp, Some(400));
         assert_eq!(cp.last_slot, Some(6000 - 32)); // finality buffer applied
         assert_eq!(cp.last_block, None);
+    }
+
+    #[test]
+    fn test_checkpoint_slot_to_u64_rejects_negative_slot() {
+        assert_eq!(checkpoint_slot_to_u64(-1), None);
+        assert_eq!(checkpoint_slot_to_u64(42), Some(42));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Persist Solana RPC and gRPC `u64` slots as saturating `i64` block numbers instead of unchecked casts.
- Prevent negative legacy Solana checkpoints from wrapping into huge gRPC resume slots.
- Add boundary coverage for slot saturation and negative checkpoint slots.

## Validation
- `cargo test -p spectraplex-adapters solana`
- `cargo test -p spectraplex-cli test_checkpoint_slot_to_u64_rejects_negative_slot`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`